### PR TITLE
changed metaseq_internal to metaseq

### DIFF
--- a/metaseq/scripts/reshard_mp_launch.sh
+++ b/metaseq/scripts/reshard_mp_launch.sh
@@ -21,7 +21,7 @@ do
   srun --job-name=$jname \
     --gpus-per-node=8 --nodes=1 --ntasks-per-node=1 --cpus-per-task=64 \
    --output "$save_dir"/"$jname".log \
-    python -m metaseq_internal.scripts.reshard_mp $prefix $save_dir --part $i --target-ddp-size $tgt_size &
+    python -m metaseq.scripts.reshard_mp $prefix $save_dir --part $i --target-ddp-size $tgt_size &
 done
 echo "Waiting on slurm..."
 wait $(jobs -p)


### PR DESCRIPTION
**Patch Description**
In the shard script, it incorrectly pointed to `metaseq_internal` instead of `metaseq` as the location of the `reshard_mp` file.

**Testing steps**
I tested my change by sharding the 175b file with the modified script.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue? No
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)? Yes
- [ ] Did you make sure to update the docs? No need, same commands
- [ ] Did you write any new necessary tests? No need
-->
