### PR TITLE
No slurm

### DIFF
--- a/metaseq/scripts/reshard_mp_launch.sh
+++ b/metaseq/scripts/reshard_mp_launch.sh
@@ -21,7 +21,7 @@ do
   srun --job-name=$jname \
     --gpus-per-node=8 --nodes=1 --ntasks-per-node=1 --cpus-per-task=64 \
    --output "$save_dir"/"$jname".log \
-    python -m metaseq_internal.scripts.reshard_mp $prefix $save_dir --part $i --target-ddp-size $tgt_size &
+    python -m metaseq.scripts.reshard_mp $prefix $save_dir --part $i --target-ddp-size $tgt_size &
 done
 echo "Waiting on slurm..."
 wait $(jobs -p)

--- a/metaseq/scripts/reshard_mp_launch_no_slurm.sh
+++ b/metaseq/scripts/reshard_mp_launch_no_slurm.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+prefix=$1
+save_dir=$2
+mparts=$3
+tgt_size=$4
+shift 4
+mkdir -p $save_dir
+let "last_part=$mparts -1"
+echo "$@"
+for i in $(seq 0 $last_part)
+do
+
+  echo "python -m metaseq.scripts.reshard_mp $prefix $save_dir --part $i --target-ddp-size $tgt_size"
+  jname=reshard_mp"$i"_ddp"$tgt_size"
+  echo $jname
+  python3 -m metaseq.scripts.reshard_mp $prefix $save_dir --part $i --target-ddp-size $tgt_size &
+done
+echo "Waiting on jobs..."
+wait $(jobs -p)
+echo "Done"
+

--- a/projects/OPT/download_opt175b.md
+++ b/projects/OPT/download_opt175b.md
@@ -17,7 +17,11 @@ bash metaseq/scripts/download_opt175b.sh "<presigned_url_given_in_email>"
 ## Reshard the shards
 To consolidate the 992 shards into 8 files model-parallel evaluation, run (assuming you have SLURM set up already):
 ```
-bash metaseq/scripts/reshard_sbatch.sh <directory_where_all_the_shards_are>/checkpoint_last <output_dir>/ 8 1
+bash metaseq/scripts/reshard_mp_launch.sh <directory_where_all_the_shards_are>/checkpoint_last <output_dir>/ 8 1
+```
+If you don't have slurm on your machine, run:
+```
+bash metaseq/scripts/reshard_mp_launch_no_slurm.sh <directory_where_all_the_shards_are>/checkpoint_last <output_dir>/ 8 1
 ```
 
 Note that most of our models expect to run with Model (Tensor) Parallelism. For smaller models, some


### PR DESCRIPTION
**Patch Description**
- Fixed `reshard_mp_launch.sh` pointing to correct script.
- Added script to support sharding with no slurm.
- Updated documentation to point to correct `reshard_mp_launch.sh` file.

**Testing steps**
I tested the changes by successfully resharding OPT-175b.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue? No
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)? Yes
- [ ] Did you make sure to update the docs? Yes
- [ ] Did you write any new necessary tests? No test necessary
-->
