### PR TITLE
included two OSs in bug_report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Minimal means having the shortest code but still preserving the bug. -->
 
  - fairseq Version (e.g., 1.0 or master):
  - PyTorch Version (e.g., 1.0)
- - OS (e.g., Linux):
+ - OS (e.g., Linux, Windows, MacOS):
  - How you installed fairseq (`pip`, source):
  - Build command you used (if compiling from source):
  - Python version:


### PR DESCRIPTION
**Patch Description**
Closing #42 

**Testing steps**
I have added two OSs in the OS section in `bug_report.md`.

<!--

Considerations before submitting:

- [x] Was this discussed/approved via a Github issue?
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
