### PR TITLE
[Bug Fixed] Add quote for `train_cmd` in `metaseq/launcher/slurm.py`

### DIFF
--- a/metaseq/launcher/slurm.py
+++ b/metaseq/launcher/slurm.py
@@ -217,7 +217,7 @@ def gen_train_command(args, env, config, oss_destination, save_dir, save_dir_key
     train_cmd.extend(["--cluster-env", cluster_env.value])
 
     for hp in config.values():
-        train_cmd.extend(map(str, hp.get_cli_args()))
+        train_cmd.extend(map(shlex.quote, map(str, hp.get_cli_args())))
     return train_cmd
 
 


### PR DESCRIPTION
Hi there, thanks for your great work!
I found that there is no quote for `train_cmd` in `metaseq/launcher/slurm.py`.
It leads to an issue that `dry-run` prints a command without quote, namely `--adam-betas (0.9, 0.95)`, which could not run directly. The correct command should be `--adam-betas '(0.9, 0.95)'`.

**Patch Description**
Add quote for `train_cmd` in the function `gen_train_command` of `metaseq/launcher/slurm.py`.
The command `--adam-betas (0.9, 0.95)` will be fixed to `--adam-betas '(0.9, 0.95)'` in this PR : )

**Testing steps**
Run the following command to print the `dry-run` message.
```bash
opt-baselines \
  -n 1 -g 2 \
  -p test_v0 \
  --model-size 125m \
  --azure \
  --data ./dataset \
  --checkpoints-dir "./outputs" \
  --local \
  --dry-run
```
