### PR TITLE
CLI interactive

### DIFF
--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -238,7 +238,7 @@ def _spawn_helper(main, cfg, kwargs):
         for p in spawncontext.processes:
             if p.is_alive():
                 os.kill(p.pid, signal.SIGTERM)
-            raise
+        raise
 
 
 def call_main(cfg: MetaseqConfig, main, **kwargs):

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -232,7 +232,8 @@ def _spawn_helper(main, cfg, kwargs):
         retval = distributed_main(-1, main, cfg, kwargs)
         spawncontext.join()
         return retval
-    except Exception:
+    except (KeyboardInterrupt, Exception):
+        # weirdly KeyboardInterrupt is not an Exception
         logger.info("Killing subworkers.")
         # propagate exceptions on the main node by killing workers
         for p in spawncontext.processes:

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pickle
 import random
+import signal
 import socket
 import struct
 import subprocess
@@ -179,6 +180,9 @@ def distributed_init(cfg: MetaseqConfig):
 
 
 def distributed_main(i, main, cfg: MetaseqConfig, kwargs):
+    if not cfg.distributed_training.distributed_no_spawn:
+        # local spawner is actually rank + 1
+        i = i + 1
     cfg.distributed_training.device_id = i
     if torch.cuda.is_available() and not cfg.common.cpu:
         torch.cuda.set_device(cfg.distributed_training.device_id)
@@ -186,7 +190,8 @@ def distributed_main(i, main, cfg: MetaseqConfig, kwargs):
         # the env. To make it work in cleaner way, we might need to change their interfaces to be
         # able to pass local rank.
         os.environ["LOCAL_RANK"] = str(cfg.distributed_training.device_id)
-    if cfg.distributed_training.distributed_rank is None:  # torch.multiprocessing.spawn
+    if cfg.distributed_training.distributed_rank is None:
+        # _span_helper
         cfg.distributed_training.distributed_rank = kwargs.pop("start_rank", 0) + i
 
     cfg.distributed_training.distributed_rank = distributed_init(cfg)
@@ -200,6 +205,42 @@ def distributed_main(i, main, cfg: MetaseqConfig, kwargs):
         torch.distributed.barrier(get_global_group())
 
 
+def _spawn_helper(main, cfg, kwargs):
+    """
+    Perform a fork() to many processes.
+
+    Intentionally runs the rank0 in the main process so that signals
+    can be more easily caught and we can cleanup processes.
+    """
+    # Launch multiple subprocesses
+    spawncontext = torch.multiprocessing.start_processes(
+        distributed_main,
+        # need to give rank offset as 1 to cover the fact that the main
+        # process is rank 0, but that spawn() doesn't let you control rank
+        (main, cfg, kwargs),
+        nprocs=min(
+            torch.cuda.device_count(),
+            cfg.distributed_training.distributed_world_size,
+        ),
+        join=False,
+        start_method='spawn',
+    )
+
+    try:
+        # -1 because we offset by +1 inside distributed_main when using
+        # spawn_helper
+        retval = distributed_main(-1, main, cfg, kwargs)
+        spawncontext.join()
+        return retval
+    except Exception:
+        logger.info("Killing subworkers.")
+        # propagate exceptions on the main node by killing workers
+        for p in spawncontext.processes:
+            if p.is_alive():
+                os.kill(p.pid, signal.SIGTERM)
+            raise
+
+
 def call_main(cfg: MetaseqConfig, main, **kwargs):
     if cfg.distributed_training.distributed_init_method is None:
         infer_init_method(cfg.distributed_training)
@@ -210,20 +251,12 @@ def call_main(cfg: MetaseqConfig, main, **kwargs):
             start_rank = cfg.distributed_training.distributed_rank
             cfg.distributed_training.distributed_rank = None  # assign automatically
             kwargs["start_rank"] = start_rank
-            torch.multiprocessing.spawn(
-                fn=distributed_main,
-                args=(main, cfg, kwargs),
-                nprocs=min(
-                    torch.cuda.device_count(),
-                    cfg.distributed_training.distributed_world_size,
-                ),
-                join=True,
-            )
+            return _spawn_helper(main, cfg, kwargs)
         else:
-            distributed_main(cfg.distributed_training.device_id, main, cfg, kwargs)
+            return distributed_main(cfg.distributed_training.device_id, main, cfg, kwargs)
     else:
         # single GPU main
-        main(cfg, **kwargs)
+        return main(cfg, **kwargs)
 
 
 def new_groups(grouped_ranks: List[List[int]]):

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -225,7 +225,7 @@ def _spawn_helper(main, cfg, kwargs):
             cfg.distributed_training.distributed_world_size,
         ),
         join=False,
-        start_method='spawn',
+        start_method="spawn",
     )
 
     try:
@@ -255,7 +255,9 @@ def call_main(cfg: MetaseqConfig, main, **kwargs):
             kwargs["start_rank"] = start_rank
             return _spawn_helper(main, cfg, kwargs)
         else:
-            return distributed_main(cfg.distributed_training.device_id, main, cfg, kwargs)
+            return distributed_main(
+                cfg.distributed_training.device_id, main, cfg, kwargs
+            )
     else:
         # single GPU main
         return main(cfg, **kwargs)

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -8,7 +8,6 @@ import ast
 import copy
 import logging
 import os
-import signal
 import time
 from argparse import Namespace
 from typing import Any, Dict, Iterator, List, Optional

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -8,6 +8,7 @@ import ast
 import copy
 import logging
 import os
+import signal
 import time
 from argparse import Namespace
 from typing import Any, Dict, Iterator, List, Optional

--- a/metaseq_cli/interactive_cli.py
+++ b/metaseq_cli/interactive_cli.py
@@ -41,9 +41,9 @@ def input_loop():
         try:
             # green display, bold user prompt
             display = (
-                '\033[32mPrompt (ctrl-D to end input, ctrl-C to quit):\n\033[0;1m'
+                "\033[32mPrompt (ctrl-D to end input, ctrl-C to quit):\n\033[0;1m"
                 if not inp
-                else ''
+                else ""
             )
             data = input(display)
             inp.append(data)
@@ -80,14 +80,14 @@ def worker_main(cfg: MetaseqConfig, namespace_args=None):
             prompt = input_loop()
             tokens = encode_fn(generator, prompt)
             request_object = {
-                'inputs': [tokens],
-                'max_tokens': [128],
+                "inputs": [tokens],
+                "max_tokens": [128],
             }
             dist_utils.broadcast_object(
                 request_object, src_rank=0, group=dist_utils.get_global_group()
             )
             generations = generator.generate(**request_object)
-            print(generations[0][0]['text'])
+            print(generations[0][0]["text"])
     else:
         # useful in FSDP setting
         while True:

--- a/metaseq_cli/interactive_cli.py
+++ b/metaseq_cli/interactive_cli.py
@@ -59,12 +59,11 @@ def input_loop():
     return "\n".join(inp)
 
 
-def worker_main(cfg1: MetaseqConfig, namespace_args=None):
+def worker_main(cfg: MetaseqConfig, namespace_args=None):
     global generator
     # make sure generations are stochastic since we have many workers
     torch.manual_seed(random.randint(1, 20000))
     torch.cuda.manual_seed(random.randint(1, 20000))
-    cfg = cfg1
 
     generator = GeneratorInterface(cfg)
     models = generator.load_model()  # noqa: F841
@@ -102,9 +101,7 @@ def cli_main():
     """
     Command line interactive.
     """
-    global cfg
     parser = options.get_generation_parser()
-
     # dumb defaults overriding
     parser.set_defaults(lr_scheduler=None, criterion=None)
     flat_launch_args = []

--- a/metaseq_cli/interactive_cli.py
+++ b/metaseq_cli/interactive_cli.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3 -u
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Host the demo.
+
+Launch with `python -m metaseq_cli.interactive_hosted` to run locally.
+
+See docs/api.md for more information.
+"""
+
+import os
+import random
+import sys
+
+import torch
+
+from metaseq import options
+from metaseq.dataclass.configs import MetaseqConfig
+from metaseq.dataclass.utils import convert_namespace_to_omegaconf
+from metaseq.distributed import utils as dist_utils
+from metaseq.hub_utils import GeneratorInterface
+from metaseq.service.constants import (
+    MAX_SEQ_LEN,
+    TOTAL_WORLD_SIZE,
+    CHECKPOINT_LOCAL,
+    CHECKPOINT_FOLDER,
+    LAUNCH_ARGS,
+)
+from metaseq.service.utils import encode_fn, build_logger
+
+logger = build_logger()
+
+
+def input_loop():
+    inp = []
+    while True:
+        try:
+            # green display, bold user prompt
+            display = (
+                '\033[32mPrompt (ctrl-D to end input, ctrl-C to quit):\n\033[0;1m'
+                if not inp
+                else ''
+            )
+            data = input(display)
+            inp.append(data)
+        except KeyboardInterrupt:
+            # reset the formatting
+            sys.stdout.write("\033[0m")
+            raise RuntimeError("time to die")
+        except EOFError:
+            break
+        # reset the formatting
+        sys.stdout.write("\033[0m")
+    logger.debug(f"Input: {inp}")
+    return "\n".join(inp)
+
+
+def worker_main(cfg1: MetaseqConfig, namespace_args=None):
+    global generator
+    # make sure generations are stochastic since we have many workers
+    torch.manual_seed(random.randint(1, 20000))
+    torch.cuda.manual_seed(random.randint(1, 20000))
+    cfg = cfg1
+
+    generator = GeneratorInterface(cfg)
+    models = generator.load_model()  # noqa: F841
+
+    # quiet some of the stuff for visual aspects
+    logging.getLogger("metaseq.hub_utils").setLevel(logging.WARNING)
+
+    logger.info(f"loaded model {cfg.distributed_training.distributed_rank}")
+    request_object = dist_utils.broadcast_object(
+        None, src_rank=0, group=dist_utils.get_global_group()
+    )
+    if torch.distributed.get_rank() == 0:
+        while True:
+            prompt = input_loop()
+            tokens = encode_fn(generator, prompt)
+            request_object = {
+                'inputs': [tokens],
+                'max_tokens': [128],
+            }
+            dist_utils.broadcast_object(
+                request_object, src_rank=0, group=dist_utils.get_global_group()
+            )
+            generations = generator.generate(**request_object)
+            print(generations[0][0]['text'])
+    else:
+        # useful in FSDP setting
+        while True:
+            request_object = dist_utils.broadcast_object(
+                None, src_rank=0, group=dist_utils.get_global_group()
+            )
+            _ = generator.generate(**request_object)
+
+
+def cli_main():
+    """
+    Command line interactive.
+    """
+    global cfg
+    parser = options.get_generation_parser()
+
+    # dumb defaults overriding
+    parser.set_defaults(lr_scheduler=None, criterion=None)
+    flat_launch_args = []
+    for s in LAUNCH_ARGS:
+        flat_launch_args += s.split()
+    args = options.parse_args_and_arch(parser, input_args=flat_launch_args)
+    args.data = os.path.dirname(args.path)  # hardcode the data arg
+    cfg = convert_namespace_to_omegaconf(args)
+    cfg.distributed_training.distributed_world_size = TOTAL_WORLD_SIZE
+    dist_utils.call_main(cfg, worker_main, namespace_args=args)
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/metaseq_cli/interactive_cli.py
+++ b/metaseq_cli/interactive_cli.py
@@ -24,10 +24,7 @@ from metaseq.dataclass.utils import convert_namespace_to_omegaconf
 from metaseq.distributed import utils as dist_utils
 from metaseq.hub_utils import GeneratorInterface
 from metaseq.service.constants import (
-    MAX_SEQ_LEN,
     TOTAL_WORLD_SIZE,
-    CHECKPOINT_LOCAL,
-    CHECKPOINT_FOLDER,
     LAUNCH_ARGS,
 )
 from metaseq.service.utils import encode_fn, build_logger

--- a/metaseq_cli/interactive_cli.py
+++ b/metaseq_cli/interactive_cli.py
@@ -14,6 +14,7 @@ See docs/api.md for more information.
 import os
 import random
 import sys
+import logging
 
 import torch
 
@@ -49,7 +50,7 @@ def input_loop():
         except KeyboardInterrupt:
             # reset the formatting
             sys.stdout.write("\033[0m")
-            raise RuntimeError("time to die")
+            raise
         except EOFError:
             break
         # reset the formatting


### PR DESCRIPTION
**Patch Description**
Adds support for CLI interactive.

This involves a major change to distributed initialization, which I copied from ParlAI: Instead of having the main process spawn N subprocesses all running the distributed code, and then idle until they wrap up, we have it spawn N-1 processes and then we also run the distributed code on the main process.

This means that exceptions or signals like KeyboardInterrupts in the main thread can be caught and propagated to the spawns to be terminated. It also means we don't need to do any hacks to reroute stdin/stdout in the rank0 process.

**Testing steps**
![Screen Shot 2022-05-05 at 16 11 46](https://user-images.githubusercontent.com/31896/167018123-14e91cd3-df29-435e-9d44-c8c150042cc3.png)

Also tested that I can cleanly ctrl-c now, and also several exceptions due to standard iterations were correctly propagated.