### PR TITLE
[api] Make robust to crashes.

### DIFF
--- a/metaseq/launcher/slurm.py
+++ b/metaseq/launcher/slurm.py
@@ -551,3 +551,17 @@ def azure_support():
         fi
         """
     )
+
+def requeue():
+    """
+    Requeues the current running job.
+
+    Throws a RuntimeException if not in a SLURM environment.
+    """
+    jobid = os.environ.get('SLURM_JOB_ID')
+    if not jobid:
+        raise RuntimeError(
+            "Could not find $SLURM_JOB_ID. Perhaps this isn't running in SLURM?"
+        )
+    train_proc = subprocess.Popen(['scontrol', 'requeue', jobid])
+    train_proc.wait()


### PR DESCRIPTION
**Patch Description**
While we host our API on SLURM, we need to be able to recover from crashes. @pwmeta proposed this solution of leveraging SLURM to turn-it-off-and-on-again. This implements that change.

**Testing steps**
Ongoing.