### PR TITLE
Finetune only on target labels

### DIFF
--- a/metaseq/data/__init__.py
+++ b/metaseq/data/__init__.py
@@ -30,6 +30,7 @@ from .resampling_dataset import ResamplingDataset
 from .sort_dataset import SortDataset
 from .streaming_shuffle_dataset import StreamingShuffleDataset
 from .streaming_token_block_dataset import StreamingTokenBlockDataset
+from .streaming_src_tgt_dataset import StreamingSrcTgtDataset
 from .strip_token_dataset import StripTokenDataset
 from .token_block_dataset import TokenBlockDataset
 from .pad_dataset import MultiplePadDataset
@@ -73,6 +74,7 @@ __all__ = [
     "SortDataset",
     "StreamingShuffleDataset",
     "StreamingTokenBlockDataset",
+    "StreamingSrcTgtDataset",
     "StripTokenDataset",
     "TokenBlockDataset",
     "TruncateDataset",

--- a/metaseq/data/streaming_src_tgt_dataset.py
+++ b/metaseq/data/streaming_src_tgt_dataset.py
@@ -1,0 +1,166 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+class StreamingSrcTgtDataset(torch.utils.data.IterableDataset):
+    """View an IterableDataset of tokens as a 1D tensor and chunk into blocks.
+
+    This dataset can only be iterated over once.
+
+    Args:
+        dataset (~torch.utils.data.IterableDataset): dataset to chunk
+        block_size (int): maximum block size
+        break_mode (str, optional): Mode used for breaking tokens. Values can
+            be one of:
+            - 'none': break tokens into equally sized blocks (up to block_size)
+        drop_last (bool, optional): drop the last item (default: False)
+        padding_idx (int, optional): index to use for padding symbols
+            (required if *drop_last* is ``False``)
+        shuffle_buffer_size (int, optional): buffer this many items and shuffle
+            using the provided *seed*; default value is 1, so no shuffling is
+            performed. This can be adjusted dynamically after initialization,
+            but only before iteration has begun.
+        seed (int, optional): seed for shuffling
+    """
+
+    def __init__(
+        self,
+        dataset: torch.utils.data.IterableDataset,
+        block_size: int,
+        break_mode: str = "none",
+        drop_last: Optional[bool] = False,
+        padding_idx: Optional[int] = None,
+        shuffle_buffer_size: int = 1,
+        seed: Optional[int] = None,
+    ):
+        super().__init__()
+        self.dataset = dataset
+        self.block_size = block_size
+        self.break_mode = break_mode
+        self.drop_last = drop_last
+        self.padding_idx = padding_idx
+        self.shuffle_buffer_size = shuffle_buffer_size
+        self.seed = seed
+        if break_mode == "none" or break_mode == "complete":
+            self.block_iterator = yield_src_tgt_blocks
+        elif break_mode == "eos":
+            raise NotImplementedError(f"EOS break mode is currently not implemented!")
+        else:
+            raise NotImplementedError(f"Unknown break mode: {break_mode}")
+
+        if not drop_last and padding_idx is None:
+            raise ValueError("padding_idx is required when drop_last is False")
+
+        assert shuffle_buffer_size >= 1
+        if shuffle_buffer_size > 1 and seed is None:
+            raise ValueError("seed is required when shuffle_buffer_size > 1")
+
+        self._started_iteration = False
+
+    def set_epoch(self, epoch):
+        if hasattr(self.dataset, "set_epoch"):
+            self.dataset.set_epoch(epoch)
+
+    def set_shuffle_buffer_size(self, new_shuffle_buffer_size):
+        assert not self._started_iteration
+        self.shuffle_buffer_size = new_shuffle_buffer_size
+
+    def __iter__(self):
+        assert not self._started_iteration
+        self.started_iteration = True
+
+        block_itr = self.block_iterator(
+            self.dataset,
+            self.block_size,
+            self.drop_last,
+            self.padding_idx,
+        )
+
+        if self.seed is not None:
+            # add a random offset (2273) to the given seed to decouple this RNG
+            # from any other RNG instances elsewhere
+            rng = np.random.default_rng(2273 + self.seed)
+        else:
+            rng = None
+
+        buffer = []
+
+        def get_next_item_and_replace_in_buffer(replacement_item):
+            # return a random item from the buffer and replace with a new item
+            nonlocal rng
+            idx = rng.integers(len(buffer)) if rng is not None else 0
+            item = buffer[idx]
+            if replacement_item is not None:
+                buffer[idx] = replacement_item
+            else:
+                buffer.pop(idx)
+            return item
+
+        for block in block_itr:
+            if len(buffer) < self.shuffle_buffer_size:
+                # initially fill the buffer to the requested size
+                buffer.append(block)
+            else:
+                # return random block from the buffer and replace with new block
+                yield get_next_item_and_replace_in_buffer(block)
+
+        # clear buffer of any remaining items
+        while buffer:
+            yield get_next_item_and_replace_in_buffer(None)
+
+
+def yield_src_tgt_blocks(iterable, block_size, drop_last, padding_idx):
+    """Packs multiple examples together in a block"""
+    cur_src_block = []
+    cur_src_block_ids = []
+    cur_tgt_block = []
+    cur_block_remain = block_size
+    for idx, (src, tgt) in enumerate(iterable):
+        if src.numel() > block_size:
+            # truncate right side
+            src = src[:block_size]
+            tgt = tgt[:block_size]
+
+        if src.numel() > cur_block_remain:
+            padding = cur_src_block[-1].new_full((cur_block_remain,), padding_idx)
+            cur_src_block.append(padding)
+            cur_tgt_block.append(padding)
+            src_block = torch.cat(cur_src_block)
+            tgt_block = torch.cat(cur_tgt_block)
+            yield {
+                "ids": torch.LongTensor(cur_src_block_ids),
+                "src_block": src_block,
+                "tgt_block": tgt_block,
+            }
+
+            cur_src_block = []
+            cur_src_block_ids = []
+            cur_tgt_block = []
+            cur_block_remain = block_size
+
+        cur_src_block.append(src)
+        cur_src_block_ids.append(idx)
+        cur_tgt_block.append(tgt)
+        cur_block_remain -= src.numel()
+        assert cur_block_remain >= 0
+
+    if not drop_last and len(cur_src_block) > 0:
+        if cur_block_remain > 0:
+            padding = cur_src_block[-1].new_full((cur_block_remain,), padding_idx)
+            cur_src_block.append(padding)
+            cur_tgt_block.append(padding)
+        src_block = torch.cat(cur_src_block)
+        tgt_block = torch.cat(cur_tgt_block)
+        assert src_block.numel() == block_size
+        yield {
+            "ids": torch.LongTensor(cur_src_block_ids),
+            "src_block": src_block,
+            "tgt_block": tgt_block,
+        }

--- a/metaseq/data/streaming_src_tgt_dataset.py
+++ b/metaseq/data/streaming_src_tgt_dataset.py
@@ -86,16 +86,15 @@ class StreamingSrcTgtDataset(torch.utils.data.IterableDataset):
         if self.seed is not None:
             # add a random offset (2273) to the given seed to decouple this RNG
             # from any other RNG instances elsewhere
-            rng = np.random.default_rng(2273 + self.seed)
+            self.rng = np.random.default_rng(2273 + self.seed)
         else:
-            rng = None
+            self.rng = None
 
         buffer = []
 
         def get_next_item_and_replace_in_buffer(replacement_item):
             # return a random item from the buffer and replace with a new item
-            nonlocal rng
-            idx = rng.integers(len(buffer)) if rng is not None else 0
+            idx = self.rng.integers(len(buffer)) if self.rng is not None else 0
             item = buffer[idx]
             if replacement_item is not None:
                 buffer[idx] = replacement_item
@@ -125,6 +124,7 @@ def yield_src_tgt_blocks(iterable, block_size, drop_last, padding_idx):
     for idx, (src, tgt) in enumerate(iterable):
         if src.numel() > block_size:
             # truncate right side
+            # TODO: Switch this to left truncate so that the target isnt ever truncated
             src = src[:block_size]
             tgt = tgt[:block_size]
 

--- a/metaseq/model_parallel/criterions/vocab_parallel_cross_entropy.py
+++ b/metaseq/model_parallel/criterions/vocab_parallel_cross_entropy.py
@@ -46,6 +46,8 @@ class VocabParallelCrossEntropyCriterion(BaseCriterion):
         if has_pad:
             loss = loss * (target != self.padding_idx)
         loss = loss.sum()
+        # When using target loss only, use num tokens in target only as the sample_size
+        # See StreamingSrcTgtDataset
         sample_size = (
             sample["ntokens_target"]
             if "ntokens_target" in sample

--- a/metaseq/tasks/streaming_finetune_language_modeling.py
+++ b/metaseq/tasks/streaming_finetune_language_modeling.py
@@ -9,8 +9,7 @@ on-the-fly tokenization.
 
 import logging
 import os
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import torch
 

--- a/metaseq/tasks/streaming_finetune_language_modeling.py
+++ b/metaseq/tasks/streaming_finetune_language_modeling.py
@@ -60,6 +60,9 @@ class StreamingFinetuneLanguageModelingTask(StreamingLanguageModelingTask):
         cycle back over the same data. We also have two different data sources
         in each shard (foo and bar), which will be combined and shuffled.
 
+        Each jsonl entry is a dict with "src" and "tgt" keys. Loss is computed
+        only on the tgt tokens.
+
         Args:
             split (str): name of the split (e.g., train, valid, valid1, test)
         """

--- a/metaseq/tasks/streaming_finetune_language_modeling.py
+++ b/metaseq/tasks/streaming_finetune_language_modeling.py
@@ -1,0 +1,148 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Streaming Language Modeling task that loads corpora in src-tgt format and performs
+on-the-fly tokenization.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from metaseq.data import (
+    JsonlDataset,
+    StreamingShuffleDataset,
+    StreamingSrcTgtDataset,
+    data_utils,
+)
+from metaseq.tasks.streaming_language_modeling import (
+    StreamingLanguageModelingTask,
+    StreamingLanguageModelingConfig,
+)
+from metaseq.tasks import register_task
+
+logger = logging.getLogger(__name__)
+
+
+@register_task(
+    "streaming_finetune_language_modeling", dataclass=StreamingLanguageModelingConfig
+)
+class StreamingFinetuneLanguageModelingTask(StreamingLanguageModelingTask):
+    def _tokenize_src_tgt_json(self, json):
+        src = json["src"].rstrip(" ")
+        tgt = json["tgt"].rstrip()
+        full_tokens = torch.LongTensor(
+            self.tokenizer.encode(" ".join([src, tgt])).ids + [self.eod]
+        )
+        src_tokens_len = len(self.tokenizer.encode(src).ids)
+        tgt_tokens = torch.clone(full_tokens)
+        tgt_tokens[:src_tokens_len] = self.dictionary.pad_index
+        return (full_tokens, tgt_tokens)
+
+    def load_dataset(self, split: str, epoch=1, combine=False, **kwargs):
+        """Load a given dataset split.
+
+        The folder structure is assumed to look like:
+
+            /path/to/data/train/00/foo.jsonl
+            /path/to/data/train/00/bar.jsonl
+            /path/to/data/train/01/foo.jsonl
+            /path/to/data/train/01/bar.jsonl
+            /path/to/data/valid/00/foo.jsonl
+            /path/to/data/valid/00/bar.jsonl
+
+        In this example, we have two "shards" of training data, which will be
+        iterated over in epochs 1 and 2, respectively. Subsequent epochs will
+        cycle back over the same data. We also have two different data sources
+        in each shard (foo and bar), which will be combined and shuffled.
+
+        Args:
+            split (str): name of the split (e.g., train, valid, valid1, test)
+        """
+        # This function reads a bunch of jsonl files, concats them together,
+        # shuffles them, then chunks them into blocks of tokens (e.g., 2048).
+
+        # determine number of shards for this split shards = {}
+        cur_shard_str = self.get_shard_str(epoch, split)
+
+        # concatenate any jsonl files that are part of the shard
+        datasets, corpora = [], []
+        for file in sorted(
+            os.listdir(os.path.join(self.args.data, split, cur_shard_str))
+        ):
+            if not file.endswith(".jsonl"):
+                continue
+            datasets.append(
+                JsonlDataset(
+                    path=os.path.join(self.args.data, split, cur_shard_str, file),
+                    tokenizer=self._tokenize_src_tgt_json,
+                )
+            )
+            corpora.append(os.path.splitext(file)[0])
+        assert len(datasets) > 0
+
+        if self.args.multicorpus_sampling_alpha != 1:
+            raise NotImplementedError
+
+        dataset = torch.utils.data.ConcatDataset(datasets)
+
+        # shuffle order across epochs
+        dataset = StreamingShuffleDataset(dataset, seed=self.args.seed)
+
+        self.datasets[split] = StreamingSrcTgtDataset(
+            dataset,
+            # We generate blocks with one extra token, so that we have a target
+            # for the final input token. This results in slight data loss.
+            block_size=self.args.tokens_per_sample + 1,
+            break_mode=self.args.sample_break_mode,
+            # we drop the remainder block during training
+            drop_last=(split == "train"),
+            padding_idx=self.source_dictionary.pad(),
+            # 1284 is a randomly-generated offset to decouple the seed used here
+            # from the seed used above in StreamingShuffleDataset
+            seed=1284 + self.args.seed,
+        )
+
+    def _collate_fn(self, items: List[Dict[str, Any]]):
+        # StreamingTokenBlockDataset returns None as filler
+        if len([x for x in items if x is not None]) == 0:
+            return {}
+
+        src_tokens = data_utils.collate_tokens(
+            [x["src_block"] for x in items if x is not None],
+            pad_idx=self.source_dictionary.pad(),
+            pad_to_bsz=self.args.batch_size,
+        )
+        tgt_tokens = data_utils.collate_tokens(
+            [x["tgt_block"] for x in items if x is not None],
+            pad_idx=self.source_dictionary.pad(),
+            pad_to_bsz=self.args.batch_size,
+        )
+
+        # generate inputs and targets
+        input = src_tokens[:, :-1].contiguous()
+        target = tgt_tokens[:, 1:].contiguous()
+
+        ids = torch.cat([x["ids"] for x in items if x is not None])
+        if ids.numel() != torch.unique(ids).numel():
+            n_duplicate = ids.numel() - torch.unique(ids).numel()
+            logger.error(
+                f"found {n_duplicate}/{ids.numel()} duplicate document IDs in the same batch!"
+            )
+
+        # metaseq expects batches to have the following structure
+        return {
+            "id": ids,
+            "net_input": {
+                "src_tokens": input,
+            },
+            "target": target,
+            "nsentences": input.size(0),
+            "ntokens": input.ne(self.dictionary.pad()).sum(),
+            "ntokens_target": target.ne(self.dictionary.pad()).sum(),
+        }

--- a/metaseq/tasks/streaming_finetune_language_modeling.py
+++ b/metaseq/tasks/streaming_finetune_language_modeling.py
@@ -104,6 +104,7 @@ class StreamingFinetuneLanguageModelingTask(StreamingLanguageModelingTask):
             padding_idx=self.source_dictionary.pad(),
             # 1284 is a randomly-generated offset to decouple the seed used here
             # from the seed used above in StreamingShuffleDataset
+            # TODO: Track this seed to avoid collisions. See issue #65
             seed=1284 + self.args.seed,
         )
 

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -257,6 +257,20 @@ class StreamingLanguageModelingTask(LegacyTask):
         )
         return resampled_datasets
 
+    def get_shard_str(self, epoch, split):
+        shards = {}
+        for shard_id in os.listdir(os.path.join(self.args.data, split)):
+            assert (
+                int(shard_id) not in shards
+            ), f"shard id: {shard_id} not in shards: {shards}"
+            shards[int(shard_id)] = shard_id
+        assert min(shards.keys()) == 0
+        assert max(shards.keys()) == len(shards) - 1
+
+        cur_shard_str = shards[(epoch - 1) % len(shards)]
+        return cur_shard_str
+
+
     def load_dataset(self, split: str, epoch=1, combine=False, **kwargs):
         """Load a given dataset split.
 
@@ -281,16 +295,7 @@ class StreamingLanguageModelingTask(LegacyTask):
         # shuffles them, then chunks them into blocks of tokens (e.g., 2048).
 
         # determine number of shards for this split
-        shards = {}
-        for shard_id in os.listdir(os.path.join(self.args.data, split)):
-            assert (
-                int(shard_id) not in shards
-            ), f"shard id: {shard_id} not in shards: {shards}"
-            shards[int(shard_id)] = shard_id
-        assert min(shards.keys()) == 0
-        assert max(shards.keys()) == len(shards) - 1
-
-        cur_shard_str = shards[(epoch - 1) % len(shards)]
+        cur_shard_str = get_shard_str(epoch, split)
 
         # concatenate any jsonl files that are part of the shard
         datasets, corpora = [], []

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -280,7 +280,7 @@ class StreamingLanguageModelingTask(LegacyTask):
         # shuffles them, then chunks them into blocks of tokens (e.g., 2048).
 
         # determine number of shards for this split
-        cur_shard_str = get_shard_str(epoch, split)
+        cur_shard_str = self.get_shard_str(epoch, split)
 
         # concatenate any jsonl files that are part of the shard
         datasets, corpora = [], []

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -23,7 +23,6 @@ from metaseq.data import (
     ResamplingDataset,
     StreamingShuffleDataset,
     StreamingTokenBlockDataset,
-    StreamingSrcTgtDataset,
     data_utils,
     iterators,
 )
@@ -45,9 +44,6 @@ logger = logging.getLogger(__name__)
 class StreamingLanguageModelingConfig(MetaseqDataclass):
     data: Optional[str] = field(
         default=None, metadata={"help": "path to data directory with JSONL files"}
-    )
-    src_tgt_format: Optional[bool] = field(
-        default=False, metadata={"help": "data is in src-tgt format"}
     )
     vocab_filename: Optional[str] = field(
         default="", metadata={"help": "path to bpe-vocab.json"}
@@ -165,17 +161,6 @@ class StreamingLanguageModelingTask(LegacyTask):
     @classmethod
     def setup_task(cls, args, **kwargs):
         return cls(args)
-
-    def _tokenize_src_tgt_json(self, json):
-        src = json["src"].rstrip(" ")
-        tgt = json["tgt"].rstrip()
-        full_tokens = torch.LongTensor(
-            self.tokenizer.encode(" ".join([src, tgt])).ids + [self.eod]
-        )
-        src_tokens_len = len(self.tokenizer.encode(src).ids)
-        tgt_tokens = torch.clone(full_tokens)
-        tgt_tokens[:src_tokens_len] = self.dictionary.pad_index
-        return (full_tokens, tgt_tokens)
 
     def _tokenize_one_json(self, json):
         text = json["text"]
@@ -307,9 +292,7 @@ class StreamingLanguageModelingTask(LegacyTask):
             datasets.append(
                 JsonlDataset(
                     path=os.path.join(self.args.data, split, cur_shard_str, file),
-                    tokenizer=self._tokenize_src_tgt_json
-                    if self.args.src_tgt_format
-                    else self._tokenize_one_json,
+                    tokenizer=self._tokenize_one_json,
                 )
             )
             corpora.append(os.path.splitext(file)[0])
@@ -324,12 +307,7 @@ class StreamingLanguageModelingTask(LegacyTask):
         dataset = StreamingShuffleDataset(dataset, seed=self.args.seed)
 
         # chunk into blocks of tokens
-        StreamingDataset = (
-            StreamingSrcTgtDataset
-            if self.args.src_tgt_format
-            else StreamingTokenBlockDataset
-        )
-        self.datasets[split] = StreamingDataset(
+        self.datasets[split] = StreamingTokenBlockDataset(
             dataset,
             # We generate blocks with one extra token, so that we have a target
             # for the final input token. This results in slight data loss.
@@ -348,30 +326,14 @@ class StreamingLanguageModelingTask(LegacyTask):
         if len([x for x in items if x is not None]) == 0:
             return {}
 
-        if self.args.src_tgt_format:
-            src_tokens = data_utils.collate_tokens(
-                [x["src_block"] for x in items if x is not None],
-                pad_idx=self.source_dictionary.pad(),
-                pad_to_bsz=self.args.batch_size,
-            )
-            tgt_tokens = data_utils.collate_tokens(
-                [x["tgt_block"] for x in items if x is not None],
-                pad_idx=self.source_dictionary.pad(),
-                pad_to_bsz=self.args.batch_size,
-            )
-
-            # generate inputs and targets
-            input = src_tokens[:, :-1].contiguous()
-            target = tgt_tokens[:, 1:].contiguous()
-        else:
-            tokens = data_utils.collate_tokens(
-                [x["block"] for x in items if x is not None],
-                pad_idx=self.source_dictionary.pad(),
-                pad_to_bsz=self.args.batch_size,
-            )
-            # generate inputs and targets
-            input = tokens[:, :-1].contiguous()
-            target = tokens[:, 1:].contiguous()
+        tokens = data_utils.collate_tokens(
+            [x["block"] for x in items if x is not None],
+            pad_idx=self.source_dictionary.pad(),
+            pad_to_bsz=self.args.batch_size,
+        )
+        # generate inputs and targets
+        input = tokens[:, :-1].contiguous()
+        target = tokens[:, 1:].contiguous()
 
         ids = torch.cat([x["ids"] for x in items if x is not None])
         if ids.numel() != torch.unique(ids).numel():
@@ -381,7 +343,7 @@ class StreamingLanguageModelingTask(LegacyTask):
             )
 
         # metaseq expects batches to have the following structure
-        batch = {
+        return {
             "id": ids,
             "net_input": {
                 "src_tokens": input,
@@ -390,9 +352,6 @@ class StreamingLanguageModelingTask(LegacyTask):
             "nsentences": input.size(0),
             "ntokens": input.ne(self.dictionary.pad()).sum(),
         }
-        if self.args.src_tgt_format:
-            batch["ntokens_target"] = target.ne(self.dictionary.pad()).sum()
-        return batch
 
     def dataset(self, split):
         return self.datasets[split]

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -255,7 +255,6 @@ class StreamingLanguageModelingTask(LegacyTask):
         cur_shard_str = shards[(epoch - 1) % len(shards)]
         return cur_shard_str
 
-
     def load_dataset(self, split: str, epoch=1, combine=False, **kwargs):
         """Load a given dataset split.
 


### PR DESCRIPTION
**Description:**
This diff allows us to backpropagate losses only on designated target tokens rather than all the input tokens. It introduces a new jsonl data format for this, where "src" and "tgt" keys are specified. To use this, use the streaming_finetune_language_modeling task. The task concatenates the src and the tgt, and is trained to produce this autoregressively, but only takes losses on the tgt tokens into account. This is particularly useful during fine-tuning.

**Test plan**
1. Does not change existing pre-training i.e. tested existing pre-training on 125M model and ppl for the first 5 updates were exactly the same i.e. unchanged.

2. Works successfully on src-tgt-format without crashing and performs competitively on copa from superglue.