### PR TITLE
Revert "add quote for train_cmd (#44)"

### DIFF
--- a/metaseq/launcher/slurm.py
+++ b/metaseq/launcher/slurm.py
@@ -217,7 +217,7 @@ def gen_train_command(args, env, config, oss_destination, save_dir, save_dir_key
     train_cmd.extend(["--cluster-env", cluster_env.value])
 
     for hp in config.values():
-        train_cmd.extend(map(shlex.quote, map(str, hp.get_cli_args())))
+        train_cmd.extend(map(str, hp.get_cli_args()))
     return train_cmd
 
 


### PR DESCRIPTION
opt-baseline training broke with this PR. Reverting.

The dry-run fix should be a fix in the dry-run codepath, not one that universally applies addition quotes to all args for slurm launch.