### PR TITLE
Recursively unwrap fully sharded model in `convert_to_singleton.py`

### DIFF
--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -67,19 +67,20 @@ def worker_main(cfg: MetaseqConfig):
     # consolidate everything on rank0
     mp_size = dist_utils.get_model_parallel_world_size()
     model_parts = [{} for _ in range(mp_size)]
-    sd = model.module.state_dict()
-    for key in sorted(sd.keys()):
-        tensor = sd[key]
-        gathered = [tensor for _ in range(mp_size)]
-        torch.distributed.all_gather(
-            gathered, tensor, group=dist_utils.get_global_group()
-        )
-        for r, t in enumerate(gathered):
-            model_parts[r][key] = t.cpu()
+
+    with model.summon_full_params():
+        for name, p in model.named_parameters():
+            gathered = [torch.zeros_like(p) for _ in range(mp_size)]
+            torch.distributed.all_gather(
+                gathered, p, group=dist_utils.get_global_group()
+            )
+            for r, t in enumerate(gathered):
+                model_parts[r][name] = t.cpu()
 
     glued = glue_megatron_parts(model_parts)
     # glued['decoder.output_projection.weight'] = glued['decoder.embed_tokens.weight']
-    del glued["decoder.output_projection.weight"]
+    if "decoder.output_projection.weight":
+        del glued["decoder.output_projection.weight"]
 
     if dist_utils.get_global_rank() == 0:
         with open(cfg.task.data + "/restored.pt", "wb") as f:

--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -79,7 +79,7 @@ def worker_main(cfg: MetaseqConfig):
 
     glued = glue_megatron_parts(model_parts)
     # glued['decoder.output_projection.weight'] = glued['decoder.embed_tokens.weight']
-    if "decoder.output_projection.weight":
+    if "decoder.output_projection.weight" in glued:
         del glued["decoder.output_projection.weight"]
 
     if dist_utils.get_global_rank() == 0:


### PR DESCRIPTION
**Patch Description**
Describe your changes

- Related to: #60 

`convert_to_singleton.py` doesn't seem to recusively unwrap fully sharded modules, leaving with the following parameters in `restored.pt` (notice the `flat_param` substring):
```python
{'decoder.embed_positions.weight': torch.Size([2050, 2048]), 'decoder.embed_tokens.weight': torch.Size([50272, 2048]), 'decoder.layer_norm.bias': torch.Size([2048]), 'decoder.layer_norm.weight': torch.Size([2048]), 'decoder.layers.0.flat_param_0': torch.Size([25185280]), 'decoder.layers.1.flat_param_0': torch.Size([25185280]), 'decoder.layers.10.flat_param_0': torch.Size([25185280]), 'decoder.layers.11.flat_param_0': torch.Size([25185280]), 'decoder.layers.12.flat_param_0': torch.Size([25185280]), 'decoder.layers.13.flat_param_0': torch.Size([25185280]), 'decoder.layers.14.flat_param_0': torch.Size([25185280]), 'decoder.layers.15.flat_param_0': torch.Size([25185280]), 'decoder.layers.16.flat_param_0': torch.Size([25185280]), 'decoder.layers.17.flat_param_0': torch.Size([25185280]), 'decoder.layers.18.flat_param_0': torch.Size([25185280]), 'decoder.layers.19.flat_param_0': torch.Size([25185280]), 'decoder.layers.2.flat_param_0': torch.Size([25185280]), 'decoder.layers.20.flat_param_0': torch.Size([25185280]), 'decoder.layers.21.flat_param_0': torch.Size([25185280]), 'decoder.layers.22.flat_param_0': torch.Size([25185280]), 'decoder.layers.23.flat_param_0': torch.Size([25185280]), 'decoder.layers.3.flat_param_0': torch.Size([25185280]), 'decoder.layers.4.flat_param_0': torch.Size([25185280]), 'decoder.layers.5.flat_param_0': torch.Size([25185280]), 'decoder.layers.6.flat_param_0': torch.Size([25185280]), 'decoder.layers.7.flat_param_0': torch.Size([25185280]), 'decoder.layers.8.flat_param_0': torch.Size([25185280]), 'decoder.layers.9.flat_param_0': torch.Size([25185280]), 'decoder.version': torch.Size([1])}
```

**Testing steps**
Describe how you tested your changes

Tested on `1B3` checkpoint, and the keys to `restored.pt` correspond to their unwrapped version. Haven't tested logits/generation as model should already be loaded from checkpoint before hand.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->

cc @stephenroller
