### PR TITLE
Support document level attention while training model parallel models

### DIFF
--- a/metaseq/dataclass/constants.py
+++ b/metaseq/dataclass/constants.py
@@ -45,3 +45,6 @@ DDP_BACKEND_CHOICES = ChoiceEnum(
 DATASET_IMPL_CHOICES = ChoiceEnum(["raw", "lazy", "cached", "mmap", "fasta"])
 ZERO_SHARDING_CHOICES = ChoiceEnum(["none", "os"])
 CLIP_GRAD_NORM_TYPE_CHOICES = ChoiceEnum(["l2", "inf"])
+
+# Default document attention separator
+UNSPECIFIED_DOC_SEP = -1

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -22,7 +22,7 @@ try:
         RowParallelLinear,
         split_tensor_along_last_dim,
     )
-    from megatron.model.fused_softmax import ScaledUpperTriangMaskedSoftmax
+    from megatron.model.fused_softmax import ScaledUpperTriangMaskedSoftmax, ScaledMaskedSoftmax
     from megatron.model import utils as megatron_utils
 
     has_megatron_submodule = True
@@ -373,10 +373,21 @@ class ModelParallelMultiheadAttention(nn.Module):
             if attn_mask is not None:
                 matmul_result = torch.nan_to_num(matmul_result)
 
-            # attention_scores = matmul_result.view(*output_size)
-            attn_probs = ScaledUpperTriangMaskedSoftmax.apply(matmul_result, 1.0)
-            # attn_probs = self.scale_mask_softmax(attention_scores,
-            #                                         attn_mask)
+            if len(attn_mask.size()) == 3:
+                # Going back to original scaled_masked_softmax to accomodate
+                # non-causal attention masking (use the given input attention)
+                attention_scores = matmul_result.view(*output_size)
+                attn_mask = attn_mask < -0.5
+                attn_mask = attn_mask.unsqueeze(1)
+                attn_probs = ScaledMaskedSoftmax.apply(attention_scores, attn_mask, 1.0)
+                attn_probs = attn_probs.view(output_size[0]*output_size[1],
+                    output_size[2],
+                    output_size[3])
+            else:
+                # attention_scores = matmul_result.view(*output_size)
+                attn_probs = ScaledUpperTriangMaskedSoftmax.apply(matmul_result, 1.0)
+                # attn_probs = self.scale_mask_softmax(attention_scores,
+                #                                         attn_mask)
             with get_cuda_rng_tracker().fork():
                 attn_probs = self.dropout_module(attn_probs)
 

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -22,7 +22,10 @@ try:
         RowParallelLinear,
         split_tensor_along_last_dim,
     )
-    from megatron.model.fused_softmax import ScaledUpperTriangMaskedSoftmax, ScaledMaskedSoftmax
+    from megatron.model.fused_softmax import (
+        ScaledUpperTriangMaskedSoftmax,
+        ScaledMaskedSoftmax,
+    )
     from megatron.model import utils as megatron_utils
 
     has_megatron_submodule = True
@@ -373,6 +376,11 @@ class ModelParallelMultiheadAttention(nn.Module):
             if attn_mask is not None:
                 matmul_result = torch.nan_to_num(matmul_result)
 
+            # The attn_mask shape can be either seq_length x seq_length, or batch_size x seq_length x seq_length
+            # depending on whether we are broadcasting the same attention mask across the batch, or
+            # masking dynamically based on the data (e.g. for document attention).
+            # If we have a per sequence mask, the condition len(attn_mask.size()) == 3
+            # is true.
             if len(attn_mask.size()) == 3:
                 # Going back to original scaled_masked_softmax to accomodate
                 # non-causal attention masking (use the given input attention)
@@ -380,9 +388,9 @@ class ModelParallelMultiheadAttention(nn.Module):
                 attn_mask = attn_mask < -0.5
                 attn_mask = attn_mask.unsqueeze(1)
                 attn_probs = ScaledMaskedSoftmax.apply(attention_scores, attn_mask, 1.0)
-                attn_probs = attn_probs.view(output_size[0]*output_size[1],
-                    output_size[2],
-                    output_size[3])
+                attn_probs = attn_probs.view(
+                    output_size[0] * output_size[1], output_size[2], output_size[3]
+                )
             else:
                 # attention_scores = matmul_result.view(*output_size)
                 attn_probs = ScaledUpperTriangMaskedSoftmax.apply(matmul_result, 1.0)
@@ -470,8 +478,24 @@ class ModelParallelMultiheadAttention(nn.Module):
             ]
 
             if attn_mask is not None:
-                attn_mask = attn_mask.unsqueeze(0)
-                attn_weights += attn_mask
+                # The attn_mask shape can be either seq_length x seq_length, or batch_size x seq_length x seq_length
+                # depending on whether we are broadcasting the same attention mask across the batch, or
+                # masking dynamically based on the data (e.g. for document attention).
+                # If we have a per sequence mask, the condition len(attn_mask.size()) == 3
+                # is true.
+                if len(attn_mask.size()) == 3:
+                    attn_mask = attn_mask.unsqueeze(1)
+                    attn_mask = attn_mask.repeat(1, self.num_heads_partition, 1, 1)
+                    attn_mask = attn_mask.view(
+                        bsz * self.num_heads_partition, tgt_len, src_len
+                    )
+                    attn_weights = attn_weights.masked_fill(
+                        attn_mask < -0.5,
+                        float("-inf"),
+                    )
+                else:
+                    attn_mask = attn_mask.unsqueeze(0)
+                    attn_weights += attn_mask
 
             if key_padding_mask is not None:
                 # don't attend to padding symbols

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -392,10 +392,7 @@ class ModelParallelMultiheadAttention(nn.Module):
                     output_size[0] * output_size[1], output_size[2], output_size[3]
                 )
             else:
-                # attention_scores = matmul_result.view(*output_size)
                 attn_probs = ScaledUpperTriangMaskedSoftmax.apply(matmul_result, 1.0)
-                # attn_probs = self.scale_mask_softmax(attention_scores,
-                #                                         attn_mask)
             with get_cuda_rng_tracker().fork():
                 attn_probs = self.dropout_module(attn_probs)
 

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -381,7 +381,7 @@ class ModelParallelMultiheadAttention(nn.Module):
             # masking dynamically based on the data (e.g. for document attention).
             # If we have a per sequence mask, the condition len(attn_mask.size()) == 3
             # is true.
-            if len(attn_mask.size()) == 3:
+            if (attn_mask is not None) and (len(attn_mask.size()) == 3):
                 # Going back to original scaled_masked_softmax to accomodate
                 # non-causal attention masking (use the given input attention)
                 attention_scores = matmul_result.view(*output_size)

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -615,7 +615,9 @@ class TransformerDecoder(IncrementalDecoder):
             positions = (
                 torch.cumsum(mask_with_reset, dim=1).type_as(mask) * mask
             ).long() + self.padding_idx
-            # HACK set padding_idx to None to work
+
+            # If the positions are pre-computed, padding_idx should not be set.
+            # Ref metaseq/metaseq/modules/learned_positional_embedding.py
             if self.embed_positions is not None:
                 self.embed_positions.padding_idx = None
         else:

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -380,6 +380,7 @@ class TransformerDecoder(IncrementalDecoder):
             else None
         )
         self.use_alibi: bool = getattr(args, "alibi", False)
+        self.self_attn_doc_sep: int = getattr(args, 'self_attn_doc_sep', -1)
         initialize_params_on_gpu = getattr(
             args, "tensor_parallel_init_model_on_gpu", False
         )
@@ -573,10 +574,30 @@ class TransformerDecoder(IncrementalDecoder):
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
     ):
         # embed tokens and positions
-        positions = None
+        if self.self_attn_doc_sep != -1:
+            # create own positions when self_attn_doc_sep is set
+            mask = tokens.ne(self.padding_idx).int()
+            mask_with_reset = tokens.ne(self.padding_idx).int()
+            doc_id_indices = (tokens == self.self_attn_doc_sep).nonzero().tolist()
+            for batch_idx in range(tokens.size(0)):
+                batch_doc_indices = [index[1]  for index in doc_id_indices if index[0]==batch_idx]
+                batch_doc_indices.sort()
+                for k, doc_sep_idx in enumerate(batch_doc_indices):
+                    if k==0:
+                        mask_with_reset[batch_idx, doc_sep_idx] = -doc_sep_idx + 1
+                    else:
+                        mask_with_reset[batch_idx, doc_sep_idx] = batch_doc_indices[k-1] - doc_sep_idx + 1
+            positions = (torch.cumsum(mask_with_reset, dim=1).type_as(mask) * mask).long() + self.padding_idx
+            # HACK set padding_idx to None to work
+            if self.embed_positions is not None:
+                self.embed_positions.padding_idx = None
+        else:
+            positions = None
         if self.embed_positions is not None:
             positions = self.embed_positions(
-                tokens, incremental_state=incremental_state
+                tokens,
+                incremental_state=incremental_state,
+                positions=positions
             )
 
         # see IncrementalDecoder for important information about
@@ -718,7 +739,7 @@ class TransformerDecoder(IncrementalDecoder):
         # see IncrementalDecoder for important information about
         # incremental state. Note that it may be an empty dictionary.
         if not incremental_state and not full_context_alignment:
-            self_attn_mask = self.buffered_future_mask(x)
+            self_attn_mask = self.buffered_future_mask(x, prev_output_tokens)
         else:
             self_attn_mask = None
 
@@ -787,7 +808,7 @@ class TransformerDecoder(IncrementalDecoder):
             return self.max_target_positions
         return min(self.max_target_positions, self.embed_positions.max_positions)
 
-    def buffered_future_mask(self, tensor):
+    def buffered_future_mask(self, tensor, input_tokens=None):
         batch_size, cur_seq_len = tensor.size(0), tensor.size(1)
         max_seq_len = self.max_positions()
         need_to_make_new_mask = (
@@ -809,6 +830,14 @@ class TransformerDecoder(IncrementalDecoder):
             if self.use_alibi:
                 alibi = self.alibi.repeat(batch_size, 1, 1)  # batch_size, 1, 1
                 self._future_mask = self._future_mask.unsqueeze(0) + alibi
+            elif self.self_attn_doc_sep != -1:
+                # Code to accomodate dynamic attention when document seperator is used
+                assert input_tokens is not None
+                self._future_mask = self._future_mask[:cur_seq_len, :cur_seq_len]
+                self._future_mask = self._future_mask.unsqueeze(0).repeat(batch_size, 1, 1)
+                doc_id_indices = (input_tokens == self.self_attn_doc_sep).nonzero().tolist()
+                for indices in doc_id_indices:
+                    self._future_mask[indices[0], indices[1]:, :indices[1]] = float("-inf")
         self._future_mask = self._future_mask.to(tensor)
         if self.use_alibi:
             return self._future_mask[
@@ -816,6 +845,8 @@ class TransformerDecoder(IncrementalDecoder):
                 :cur_seq_len,
                 :cur_seq_len,
             ]
+        elif self.self_attn_doc_sep != -1:
+            return self._future_mask
         else:
             return self._future_mask[:cur_seq_len, :cur_seq_len]
 

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -123,6 +123,13 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
             "help": "use the ALiBi position method instead of regular position embeddings"
         },
     )
+    # Dynamic Attention
+    self_attn_doc_sep: int = field(
+        default=-1, 
+        metadata={
+            "help": "use dynamic self attention masking when document separator ID is specified"
+        }
+    )
     fsdp_checkpoint_wrap_layer_frequency: int = field(
         default=1,
         metadata={

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -11,6 +11,8 @@ from typing import Optional
 
 from omegaconf import II
 
+from metaseq.dataclass.constants import UNSPECIFIED_DOC_SEP
+
 from metaseq import utils
 from metaseq.dataclass import ChoiceEnum, MetaseqDataclass
 from metaseq.models import (
@@ -125,7 +127,7 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
     )
     # Dynamic Attention
     self_attn_doc_sep: int = field(
-        default=-1,
+        default=UNSPECIFIED_DOC_SEP,
         metadata={
             "help": "use dynamic self attention masking when document separator ID is specified"
         },

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -125,10 +125,10 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
     )
     # Dynamic Attention
     self_attn_doc_sep: int = field(
-        default=-1, 
+        default=-1,
         metadata={
             "help": "use dynamic self attention masking when document separator ID is specified"
-        }
+        },
     )
     fsdp_checkpoint_wrap_layer_frequency: int = field(
         default=1,


### PR DESCRIPTION
**Patch Description**
We are trying to optimize model training by having document level attention. What this entails is that we modify the attention mask to just attend to tokens in the current document, as opposed to having a constant triangular (causal) attention mask. The goal here is to ensure that tokens don't attend across documents.

To accomplish this, we
1. Change the constant upper triangular mask to depend on the data separator tokens, specified by the `self_attn_doc_sep` field
2. Reset the positional encoding at the end of each document.

**Testing steps**
Consider a list of 20 documents. We consider the following two cases - 
1. Passing the documents, one per sequence, in a batch of 20 sequences. No special attention mask is used, we still use the upper triangular mask.
2. Passing the documents packed in a single sequence, separated by a special document separator token. Document attention is used here.

By intuition, we can see that the gradients in these two scenarios should match. We find that it is indeed the case.

Documents packed, with document level attention
```
> /fsx-mudslide/punitkoura/src/metaseq/metaseq/trainer.py(781)train_step()
-> grad_norm = self.clip_grad_norm(
(Pdb) self.model.decoder.embed_positions.weight.grad[2:10]
tensor([[-6.5479e-03,  9.6962e-03,  2.6375e-03,  ..., -5.1121e-03,
         -1.9985e-02,  2.4901e-03],
        [ 2.5498e-02, -7.1761e-03,  2.2065e-02,  ...,  6.4638e-03,
         -1.0154e-02,  5.8792e-03],
        [ 7.9259e-05, -4.0577e-03,  3.9698e-03,  ...,  2.3798e-04,
          3.1224e-03,  1.0833e-02],
        ...,
        [-7.4849e-06,  1.7103e-03, -1.5433e-03,  ...,  2.2430e-03,
         -9.3732e-03,  1.5123e-03],
        [-1.4408e-03, -1.8149e-03,  6.9925e-06,  ...,  1.1794e-03,
         -1.4160e-03,  2.6913e-03],
        [-1.4234e-03, -6.3481e-03,  7.6257e-03,  ...,  7.9472e-03,
         -1.1467e-03,  3.3719e-03]], device='cuda:0')
(Pdb) 
```

Documents sent one by one
```
> /fsx-mudslide/punitkoura/src/metaseq/metaseq/trainer.py(781)train_step()
-> grad_norm = self.clip_grad_norm(
(Pdb) self.model.decoder.embed_positions.weight.grad[2:10]
tensor([[-6.5555e-03,  9.6926e-03,  2.6306e-03,  ..., -5.1131e-03,
         -1.9988e-02,  2.4959e-03],
        [ 2.5496e-02, -7.1761e-03,  2.2073e-02,  ...,  6.4701e-03,
         -1.0157e-02,  5.8840e-03],
        [ 7.5817e-05, -4.0496e-03,  3.9688e-03,  ...,  2.3734e-04,
          3.1189e-03,  1.0830e-02],
        ...,
        [-1.3878e-05,  1.7050e-03, -1.5432e-03,  ...,  2.2473e-03,
         -9.3719e-03,  1.5083e-03],
        [-1.4369e-03, -1.8114e-03,  5.8990e-06,  ...,  1.1820e-03,
         -1.4172e-03,  2.6962e-03],
        [-1.4229e-03, -6.3467e-03,  7.6208e-03,  ...,  7.9439e-03,
         -1.1527e-03,  3.3779e-03]], device='cuda:0')
(Pdb) 
```

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
