### PR TITLE
Add eos mode for src tgt dataset

### DIFF
--- a/metaseq/data/streaming_src_tgt_dataset.py
+++ b/metaseq/data/streaming_src_tgt_dataset.py
@@ -51,7 +51,7 @@ class StreamingSrcTgtDataset(torch.utils.data.IterableDataset):
         self.seed = seed
         if break_mode == "none" or break_mode == "complete":
             self.block_iterator = yield_src_tgt_blocks
-        elif break_mode == "eos_pad_8": # Single example per sequence
+        elif break_mode == "eos_pad_8":  # Single example per sequence
             self.block_iterator = yield_src_tgt_single_sentences_pad_8
         else:
             raise NotImplementedError(f"Unknown break mode: {break_mode}")
@@ -165,6 +165,7 @@ def yield_src_tgt_blocks(iterable, block_size, drop_last, padding_idx):
             "src_block": src_block,
             "tgt_block": tgt_block,
         }
+
 
 def yield_src_tgt_single_sentences_pad_8(iterable, block_size, drop_last, padding_idx):
     """Mimics sample-break-mode eos i.e. 1 example per sequence without any packing.

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -427,7 +427,6 @@ class StreamingLanguageModelingTask(LegacyTask):
         # thus increasing randomness. This assumes that no single document spans
         # 10 full batches, which is reasonable when batch sizes are in the
         # millions and documents are on average much smaller.
-        assert isinstance(dataset, StreamingTokenBlockDataset)
         shuffle_buffer_size = 10 * max_sentences * num_shards
         logger.info(f"setting shuffle buffer size to {shuffle_buffer_size}")
         dataset.set_shuffle_buffer_size(shuffle_buffer_size)

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -23,6 +23,7 @@ from metaseq.data import (
     ResamplingDataset,
     StreamingShuffleDataset,
     StreamingTokenBlockDataset,
+    StreamingSrcTgtDataset,
     data_utils,
     iterators,
 )
@@ -427,6 +428,7 @@ class StreamingLanguageModelingTask(LegacyTask):
         # thus increasing randomness. This assumes that no single document spans
         # 10 full batches, which is reasonable when batch sizes are in the
         # millions and documents are on average much smaller.
+        assert isinstance(dataset, StreamingTokenBlockDataset) or isinstance(dataset, StreamingSrcTgtDataset)
         shuffle_buffer_size = 10 * max_sentences * num_shards
         logger.info(f"setting shuffle buffer size to {shuffle_buffer_size}")
         dataset.set_shuffle_buffer_size(shuffle_buffer_size)

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -428,7 +428,9 @@ class StreamingLanguageModelingTask(LegacyTask):
         # thus increasing randomness. This assumes that no single document spans
         # 10 full batches, which is reasonable when batch sizes are in the
         # millions and documents are on average much smaller.
-        assert isinstance(dataset, StreamingTokenBlockDataset) or isinstance(dataset, StreamingSrcTgtDataset)
+        assert isinstance(dataset, StreamingTokenBlockDataset) or isinstance(
+            dataset, StreamingSrcTgtDataset
+        )
         shuffle_buffer_size = 10 * max_sentences * num_shards
         logger.info(f"setting shuffle buffer size to {shuffle_buffer_size}")
         dataset.set_shuffle_buffer_size(shuffle_buffer_size)


### PR DESCRIPTION
Description:
Currently, multiple examples are packed into a single sequence during training/fine-tuning and attention can happen across sequences. This diff adds eos mode, which uses a single example per sequence. This can be useful for fine-tuning/debugging. 

Test Plan:
Code path is executed via --break-mode eos_pad_8 and code has been tested earlier in a private branch.