### PR TITLE
Allow downloading to a target directory

### DIFF
--- a/metaseq/scripts/download_opt175b.sh
+++ b/metaseq/scripts/download_opt175b.sh
@@ -8,7 +8,7 @@
 # filename format: checkpoint_last-model_part-[0-7]-shard[0-123].pt
 
 # To download all the of the parameters for the 175B model, run:
-# bash ./download_opt175b.sh "<presigned_url_given_in_email>"
+# bash ./download_opt175b.sh "<presigned_url_given_in_email>" "<target directory>"
 
 presigned_url=$1
 str_to_replace='stubbed.pt'

--- a/projects/OPT/download_opt175b.md
+++ b/projects/OPT/download_opt175b.md
@@ -16,6 +16,12 @@ bash metaseq/scripts/download_opt175b.sh "<presigned_url_given_in_email>"
 
 Make sure to wrap the url in quotes here.  You will get a 403 error otherwise.
 
+By default this will download the files into the directory that the command is run in. You can also optionally include a target directory by running:
+
+```
+bash metaseq/scripts/download_opt175b.sh "<presigned_url_given_in_email>" "<target directory>"
+```
+
 ## Reshard the shards
 To consolidate the 992 shards into 8 files model-parallel evaluation, run (assuming you have SLURM set up already):
 ```


### PR DESCRIPTION
**Patch Description**
Minor modification to the 175B download script to allow the user to download the files into a directory other than the one that the command is being run from.

**Testing steps**
I ran it.