### PR TITLE
Dynamic loss scaler changes for 66b

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -142,7 +142,7 @@ class CommonConfig(MetaseqDataclass):
         },
     )
     min_loss_scale: float = field(
-        default=0.03125,
+        default=2 ** -5,
         metadata={"help": "minimum FP16 loss scale, after which training is stopped"},
     )
     threshold_loss_scale: Optional[float] = field(

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -129,10 +129,10 @@ class CommonConfig(MetaseqDataclass):
         default=False, metadata={"help": "don't flatten FP16 grads tensor"}
     )
     fp16_init_scale: int = field(
-        default=2**7, metadata={"help": "default FP16 loss scale"}
+        default=4, metadata={"help": "default FP16 loss scale"}
     )
     fp16_scale_window: Optional[int] = field(
-        default=None,
+        default=256,
         metadata={"help": "number of updates before increasing loss scale"},
     )
     fp16_scale_tolerance: float = field(
@@ -142,7 +142,7 @@ class CommonConfig(MetaseqDataclass):
         },
     )
     min_loss_scale: float = field(
-        default=1e-4,
+        default=0.03125,
         metadata={"help": "minimum FP16 loss scale, after which training is stopped"},
     )
     threshold_loss_scale: Optional[float] = field(

--- a/metaseq/optim/dynamic_loss_scaler.py
+++ b/metaseq/optim/dynamic_loss_scaler.py
@@ -16,7 +16,7 @@ class DynamicLossScaler(object):
         scale_window=256,
         tolerance=0.0,
         threshold=None,
-        min_loss_scale=0.03125,
+        min_loss_scale=2 ** -5,
     ):
         self.loss_scale = init_scale
         self.scale_factor = scale_factor

--- a/metaseq/optim/dynamic_loss_scaler.py
+++ b/metaseq/optim/dynamic_loss_scaler.py
@@ -67,17 +67,9 @@ class DynamicLossScaler(object):
                 self._last_rescale_iter = self._iter
                 self._overflows_since_rescale = 0
 
-            if self.loss_scale <= self.min_loss_scale:
-                # Use FloatingPointError as an uncommon error that parent
-                # functions can safely catch to stop training.
+            if self.loss_scale < self.min_loss_scale:
+                # Don't scale down past min_loss_scale, just continue to skip grad after overflow error is raised.
                 self.loss_scale = prev_scale
-                raise FloatingPointError(
-                    (
-                        "Minimum loss scale reached ({}). Your loss is probably exploding. "
-                        "Try lowering the learning rate, using gradient clipping or "
-                        "increasing the batch size."
-                    ).format(self.min_loss_scale)
-                )
 
             self._iter += 1
             raise OverflowError("setting loss scale to: " + str(self.loss_scale))

--- a/metaseq/optim/dynamic_loss_scaler.py
+++ b/metaseq/optim/dynamic_loss_scaler.py
@@ -47,6 +47,8 @@ class DynamicLossScaler(object):
 
     def _decrease_loss_scale(self):
         self.loss_scale /= self.scale_factor
+        # also decrease the scale_window (lower loss scale, smaller window)
+        self.scale_window = max(int(self.scale_window / self.scale_factor), 1)
         if self.threshold is not None:
             self.loss_scale = max(self.loss_scale, self.threshold)
 

--- a/metaseq/optim/fp16_optimizer.py
+++ b/metaseq/optim/fp16_optimizer.py
@@ -254,25 +254,9 @@ class FP16Optimizer(_FP16OptimizerMixin, optim.BaseOptimizer):
         self.fp32_optimizer = fp32_optimizer
         self.fp32_params = fp32_params
 
-        if getattr(cfg.common, "fp16_scale_window", None) is None:
-            if len(cfg.optimization.update_freq) > 1:
-                raise ValueError(
-                    "--fp16-scale-window must be given explicitly when using a "
-                    "custom --update-freq schedule"
-                )
-            data_parallel_size = int(
-                cfg.distributed_training.distributed_world_size
-                / cfg.common.model_parallel_size
-            )
-            scale_window = int(
-                2**14 / data_parallel_size / cfg.optimization.update_freq[0]
-            )
-        else:
-            scale_window = cfg.common.fp16_scale_window
-
         self.scaler = DynamicLossScaler(
             init_scale=cfg.common.fp16_init_scale,
-            scale_window=scale_window,
+            scale_window=cfg.common.fp16_scale_window,
             tolerance=cfg.common.fp16_scale_tolerance,
             threshold=cfg.common.threshold_loss_scale,
             min_loss_scale=cfg.common.min_loss_scale,

--- a/metaseq/optim/fp16_optimizer.py
+++ b/metaseq/optim/fp16_optimizer.py
@@ -481,25 +481,9 @@ class MemoryEfficientFP16Optimizer(
         super().__init__(cfg.optimizer)
         self.wrapped_optimizer = optimizer
 
-        if getattr(cfg.common, "fp16_scale_window", None) is None:
-            if len(cfg.optimization.update_freq) > 1:
-                raise ValueError(
-                    "--fp16-scale-window must be given explicitly when using a "
-                    "custom --update-freq schedule"
-                )
-            data_parallel_size = int(
-                cfg.distributed_training.distributed_world_size
-                / cfg.common.model_parallel_size
-            )
-            scale_window = int(
-                2**14 / data_parallel_size / cfg.optimization.update_freq[0]
-            )
-        else:
-            scale_window = cfg.common.fp16_scale_window
-
         self.scaler = DynamicLossScaler(
             init_scale=cfg.common.fp16_init_scale,
-            scale_window=scale_window,
+            scale_window=cfg.common.fp16_scale_window,
             tolerance=cfg.common.fp16_scale_tolerance,
             threshold=cfg.common.threshold_loss_scale,
             min_loss_scale=cfg.common.min_loss_scale,

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -852,6 +852,13 @@ class Trainer(object):
                 round=4,
                 weight=0,
             )
+            metrics.log_scalar(
+                "scale_window",
+                self.optimizer.scaler.scale_window,
+                priority=700,
+                round=4,
+                weight=0,
+            )
 
         metrics.log_stop_time("train_wall")
         return logging_output


### PR DESCRIPTION
* Set hard defaults for loss scaler logic (no longer a function of data parallelism)
* Scale scale window with loss scale
* Remove raising FloatingPointError when min loss scale is reached - just continue skipping gradients (using external monitoring to restart)
