### PR TITLE
change omegaconf function name

### DIFF
--- a/metaseq/dataclass/utils.py
+++ b/metaseq/dataclass/utils.py
@@ -372,8 +372,8 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
     # omegaconf version that supports object flags, or when we migrate all existing models
     from omegaconf import _utils
 
-    old_primitive = _utils.is_primitive_type
-    _utils.is_primitive_type = lambda _: True
+    old_primitive = _utils.is_primitive_type_annotation
+    _utils.is_primitive_type_annotation = lambda _: True
 
     if cfg.task is None and getattr(args, "task", None):
         cfg.task = Namespace(**vars(args))


### PR DESCRIPTION
**Patch Description**
In omegaconf==2.2.1,  `_utils.is_primitive_type` changes to `_utils.is_primative_type_annotation` 

