### PR TITLE
Add missing Namespace import

### DIFF
--- a/metaseq/file_io.py
+++ b/metaseq/file_io.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from argparse import Namespace
+from argparse import Namespace  # noqa: F401
 import json
 import logging
 import os

--- a/metaseq/file_io.py
+++ b/metaseq/file_io.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from argparse import Namespace
 import json
 import logging
 import os


### PR DESCRIPTION
Without this `gpt3_eval` hits the following exception:

```
NameError: name 'Namespace' is not defined
```