### PR TITLE
Pin omegaconf to 2.1.1, tensorboard to 2.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def do_setup(package_data):
             "regex",
             "sklearn",  # for evals
             "sacrebleu",  # for evals
-            "tensorboard",
+            "tensorboard==2.8.0",
             "timeout-decorator",
             "tokenizers",
             "torch",

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ def do_setup(package_data):
             "mypy",
             "ninja",
             'numpy; python_version>="3.7"',
-            "omegaconf",
+            "omegaconf==2.1.1",
             "pre-commit",
             "pytest",
             "regex",

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,9 @@ def do_setup(package_data):
             "setuptools>=18.0",
         ],
         install_requires=[
+            # protobuf version pinned due to tensorboard not pinning a version.
+            #  https://github.com/protocolbuffers/protobuf/issues/10076
+            "protobuf==3.20.1",
             "azure-storage-blob",
             "boto3",
             "black==22.1.0",


### PR DESCRIPTION
* Resolves https://github.com/facebookresearch/metaseq/issues/55#issuecomment-1135353598
* Avoids https://github.com/facebookresearch/metaseq/pull/124