### PR TITLE
Fix errors when build docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p /build
 WORKDIR /build
 
-# Fix for https://github.com/NVIDIA/nvidia-docker/issues/1631
-RUN rm /etc/apt/sources.list.d/cuda.list
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-key del 7fa2af80 && \
     apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends curl && \
@@ -32,7 +29,7 @@ RUN pip3 install -v --no-cache-dir --global-option="--cpp_ext" --global-option="
 # Install Megatron-LM branch
 WORKDIR /build
 
-RUN git clone --branch fairseq_v2 https://github.git adcom/ngoyal2707/Megatron-LM.git
+RUN git clone --branch fairseq_v2 https://github.com/ngoyal2707/Megatron-LM.git
 WORKDIR /build/Megatron-LM
 RUN pip3 install six regex
 RUN pip3 install -e .
@@ -40,14 +37,13 @@ RUN pip3 install -e .
 # Install Fairscale
 WORKDIR /build
 
-RUN git clone https://github.com/facebookresearch/fairscale.git
+RUN git clone --branch prefetch_fsdp_params_simple https://github.com/facebookresearch/fairscale.git
 WORKDIR /build/fairscale
-RUN git checkout prefetch_fsdp_params_simple
 RUN pip3 install -e .
 
 # Install metaseq
 WORKDIR /build
-RUN git clone https://github.com/facebookresearch/metaseq.git
+RUN git clone --branch dockerfilefix https://github.com/QIU-Shuo/metaseq.git
 WORKDIR /build/metaseq
 RUN pip3 install -e .
 RUN python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN pip3 install -e .
 
 # Install metaseq
 WORKDIR /build
-RUN git clone --branch dockerfilefix https://github.com/QIU-Shuo/metaseq.git
+RUN git clone https://github.com/facebookresearch/metaseq.git
 WORKDIR /build/metaseq
 RUN pip3 install -e .
 RUN python3 setup.py install

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ def do_setup(package_data):
             "mypy",
             "ninja",
             'numpy; python_version>="3.7"',
-            "omegaconf==2.1.1",
+            "omegaconf<=2.1.1",
             "pre-commit",
             "pytest",
             "regex",

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ def do_setup(package_data):
             "editdistance",
             "fire",
             "flask==2.1.1",  # for api
-            "hydra-core>=1.1.0",
+            "hydra-core>=1.1.0,<1.2",
             "iopath",
             "ipdb",
             "ipython",


### PR DESCRIPTION
**Patch Description**
Hi, the current Dockerfile cannot build successfully, I made a few fix for it. 

1.  Limit the max version for hydra-core, since hydra-core 1.2 will require omegaconf~=2.2 and raise a conflict.
2. Fix error in line 35.
3. I didn't encounter issue https://github.com/NVIDIA/nvidia-docker/issues/1631, and the workaround in line 8-9 raises an file not found error for me. They have probably fixed the docker, but I am not sure about this.

**Testing steps**
docker build -f Dockerfile .

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
