### PR TITLE
Make Checkpoint Loading Strict

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -413,9 +413,7 @@ def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False) ->
             state = torch_load_cpu(local_path)
     except Exception as error:
         logger.error(
-            f"Got Exception While Trying To Load {path} with Paths to Load {paths_to_load}"
-        )
-        logger.error(
+            f"Got Exception While Trying To Load {path} with Paths to Load {paths_to_load}."
             "If you are not meaning to --restore-file, remove the command explictly."
         )
         raise error

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -411,13 +411,15 @@ def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False) ->
             state = _merge_flat_fsdp_shards([torch_load_cpu(f) for f in paths_to_load])
         else:
             state = torch_load_cpu(local_path)
-    except Exception:
-        print(
-            "got exception while trying to load",
-            path,
-            "with paths to load",
-            paths_to_load,
+    except Exception as error:
+        logger.error(
+            f"Got Exception While Trying To Load {path} with Paths to Load {paths_to_load}"
         )
+        logger.error(
+            "If you are not meaning to --restore-file, remove the command explictly."
+        )
+        raise error
+
     logger.info("Done reading from disk")
 
     if "cfg" in state and state["cfg"] is not None:


### PR DESCRIPTION
**Patch Description**
Currently if --restore-file is set, but there's failure in loading the file, we'll (somewhat) silently continue training with a randomly initialized model. This PR makes the failure explicit.

Specifically addresses #142 