### PR TITLE
Fix progress bar exception when both tensorboard and wandb are turned on

### DIFF
--- a/metaseq/logging/progress_bar/__init__.py
+++ b/metaseq/logging/progress_bar/__init__.py
@@ -34,15 +34,9 @@ def get_progress_bar(
     else:
         raise ValueError("Unknown log format: {}".format(log_format))
 
-    if tensorboard_logdir:
-        bar = TensorboardProgressBarWrapper(bar, tensorboard_logdir)
-
     if wandb_project:
-        if tensorboard_logdir:
-            bar = WandBProgressBarWrapper(
-                bar.wrapped_bar, wandb_project, run_name=wandb_run_name
-            )
-        else:
-            bar = WandBProgressBarWrapper(bar, wandb_project, run_name=wandb_run_name)
+        bar = WandBProgressBarWrapper(bar, wandb_project, run_name=wandb_run_name)
+    elif tensorboard_logdir:
+        bar = TensorboardProgressBarWrapper(bar, tensorboard_logdir)
 
     return bar

--- a/metaseq/logging/progress_bar/__init__.py
+++ b/metaseq/logging/progress_bar/__init__.py
@@ -38,6 +38,11 @@ def get_progress_bar(
         bar = TensorboardProgressBarWrapper(bar, tensorboard_logdir)
 
     if wandb_project:
-        bar = WandBProgressBarWrapper(bar, wandb_project, run_name=wandb_run_name)
+        if tensorboard_logdir:
+            bar = WandBProgressBarWrapper(
+                bar.wrapped_bar, wandb_project, run_name=wandb_run_name
+            )
+        else:
+            bar = WandBProgressBarWrapper(bar, wandb_project, run_name=wandb_run_name)
 
     return bar


### PR DESCRIPTION
Change the progress bar creation logic so that only one of `WandBProgressBarWrapper` and `TensorboardProgressBarWrapper` is called. Calling these two wrappers sequentially will result in an exception.