### PR TITLE
Singleton checkpoint needs to include decoder.version for single-ton checkpoint to run correctly

### DIFF
--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -91,14 +91,15 @@ def worker_main(cfg: MetaseqConfig):
 
     glued = glue_megatron_parts(model_parts)
     # glued['decoder.output_projection.weight'] = glued['decoder.embed_tokens.weight']
-    
+
     glued["decoder.version"] = model["model"]["decoder.version"].cpu()
-    
+
     if "decoder.output_projection.weight" in glued:
         del glued["decoder.output_projection.weight"]
 
     output_sd = checkpoint_utils.load_checkpoint_to_cpu(
         cfg.common_eval.path.replace("reshard.pt", "reshard-model_part-0.pt")
+    )
     output_sd["model"] = utils.move_to_cpu(glued)
     output_sd["cfg"]["model"].arch = "transformer_lm"
 


### PR DESCRIPTION
If we don't transfer the `"decoder.version"` to the singleton checkpoint, a very sneaky bug happens which was found by @thomasw21 as part of this PR: https://github.com/huggingface/transformers/pull/17785

If the `decoder.version` param is not present in the state_dict it follows that upon loading the single-ton checkpoint the loaded layer_norm is set to `None` here: https://github.com/facebookresearch/metaseq/blob/e0c4f6b0e4c523906ad8d561f727e3f2ac3a8e73/metaseq/models/transformer.py#L932

So it's absolutely crucial that we include this variable.

I will update all of the converted HF checkpoints here later today and then I think we can be sure that OPT works correctly :partying_face: 
https://huggingface.co/models?other=opt_metasq

**Patch Description**
Describe your changes

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
