### PR TITLE
Update convert_to_singleton.py

### DIFF
--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -93,10 +93,6 @@ def worker_main(cfg: MetaseqConfig):
 
     if dist_utils.get_global_rank() == 0:
         glued = glue_megatron_parts(model_parts)
-
-        with open("temp.pt", "wb") as f:
-            torch.save(glued, f)
-
         glued["decoder.version"] = torch.tensor([3])
 
         if "decoder.output_projection.weight" in glued:


### PR DESCRIPTION
Modified the consolidate part of the code to support the conversion of OPT66B.
@patrickvonplaten and I spent a bit of time debugging the script to get the restored.pt file for opt-66b. 
Thanks a lot @patrickvonplaten for your help. Here is what worked for us. 

Previous code would just overload the RAM (669 GB available were not enough) 
**Patch Description**
Changed `metaseq/scripts/convert_to_s`

**Testing steps**
Converted OPT-66B on 8 A100

Will try to test it one more time just to be sure 