### PR TITLE
[Cleanup]: remove upgrade_state_dict logic, normformer, unused alignment/encoder args

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -645,9 +645,7 @@ def _merge_flat_fsdp_shards(shards_to_load: List[Dict], unpad=False) -> Dict:
         merged_state[key] = shards_to_load[0][key]
 
     pad_info = _get_pad_info(shards_to_load[-1])
-    dtype = torch.float16
     for k in shards_to_load[0]["model"]:
-        dtype = shards_to_load[0]["model"][k].dtype
         if "flat_param" in k:
             pad_info_k = pad_info[k]
             catted = torch.cat([x["model"][k] for x in shards_to_load])

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -505,7 +505,7 @@ def load_model_ensemble_and_task(
                 # build model for ensemble
                 model = task.build_model(cfg.model)
 
-            model.load_state_dict(state["model"], strict=strict, model_cfg=cfg.model)
+            model.load_state_dict(state["model"], strict=strict)
             logger.info("Done loading state dict")
             # reset state so it gets loaded for the next model in ensemble
             state = None

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -660,8 +660,6 @@ def _merge_flat_fsdp_shards(shards_to_load: List[Dict], unpad=False) -> Dict:
 
             merged_state["model"][k] = catted
 
-    if "decoder.version" not in merged_state["model"]:
-        merged_state["model"]["decoder.version"] = torch.tensor([3.0], dtype=dtype)
     if OPT_KEY in merged_state:
         merged_state[OPT_KEY] = _merge_flat_fsdp_opt_state(shards_to_load)
     return merged_state

--- a/metaseq/criterions/cross_entropy.py
+++ b/metaseq/criterions/cross_entropy.py
@@ -88,7 +88,7 @@ class CrossEntropyCriterion(BaseCriterion):
     def compute_loss(self, model, net_output, sample, reduce=True):
         lprobs = model.get_normalized_probs(net_output, log_probs=True)
         lprobs = lprobs.view(-1, lprobs.size(-1))
-        target = model.get_targets(sample, net_output).view(-1)
+        target = model.get_targets(sample).view(-1)
         loss = nll_loss(
             lprobs,
             target,

--- a/metaseq/distributed/fully_sharded_data_parallel.py
+++ b/metaseq/distributed/fully_sharded_data_parallel.py
@@ -71,7 +71,7 @@ class FullyShardedDataParallel(FSDP):
                 super().state_dict()
                 return destination or {}
 
-    def load_state_dict(self, state_dict, strict=True, model_cfg=None):
+    def load_state_dict(self, state_dict, strict=True):
         if self.use_sharded_state:
             return super().load_local_state_dict(state_dict, strict=strict)
         else:

--- a/metaseq/distributed/stitch_fsdp_ckpt.py
+++ b/metaseq/distributed/stitch_fsdp_ckpt.py
@@ -221,28 +221,6 @@ def _handle_one(parts, is_weight):
     return ret_val
 
 
-def handle_legacy_ln_(glued_model, n_parts):
-    """Consolidate ffn_layernorm.lns.weight.{part_id} -> ffn_layernorm.weight"""
-    if "decoder.layers.0.ffn_layernorm.lns.0.weight" not in glued_model:
-        return
-    n_layers = get_n_layers(glued_model)
-    for i in range(n_layers):
-        layer_weights = [
-            glued_model.pop(f"decoder.layers.{i}.ffn_layernorm.lns.{p}.weight")
-            for p in range(n_parts)
-        ]
-        layer_biases = [
-            glued_model.pop(f"decoder.layers.{i}.ffn_layernorm.lns.{p}.bias")
-            for p in range(n_parts)
-        ]
-        glued_model[f"decoder.layers.{i}.ffn_layernorm.weight"] = _handle_one(
-            layer_weights, True
-        )
-        glued_model[f"decoder.layers.{i}.ffn_layernorm.bias"] = _handle_one(
-            layer_biases, False
-        )
-
-
 def get_n_layers(glued_model):
     n_layers = 0
     while True:
@@ -309,9 +287,6 @@ def reshard_megatron_parts(model_parts, new_model_part_count=1):
                 new_model_parts[i][key] = torch.cat(
                     (resharded_ks[i], resharded_vs[i], resharded_qs[i]), dim=0
                 )
-
-        elif "ffn_layernorm" in key:
-            _conslidate_and_redshard(key, dim=0)
         elif "layer_norm" in key:
             assert_all_close(key)
             _copy_key_to_all_parts(key)
@@ -352,9 +327,6 @@ def reshard_megatron_parts(model_parts, new_model_part_count=1):
 
     for new_model_part in new_model_parts:
         assert len(new_model_part.keys()) >= len(model_parts[0].keys())
-        assert "decoder.layers.0.ffn_layernorm.lns.0.weight" not in new_model_part
-    # Consolidate ffn_layernorm.lns.weight.{part_id} -> ffn_layernorm.weight
-    # handle_legacy_ln_(glued_model, len(model_parts))
     return new_model_parts
 
 

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -7,7 +7,6 @@ import argparse
 import ast
 import copy
 import logging
-import os
 import time
 from argparse import Namespace
 from typing import Any, Dict, Iterator, List, Optional
@@ -29,78 +28,6 @@ from metaseq.distributed.utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def from_pretrained(
-    model_name_or_path,
-    checkpoint_file="model.pt",
-    data_name_or_path=".",
-    archive_map=None,
-    **kwargs,
-):
-    post_build_model_hook = kwargs.get("post_build_model_hook", None)
-
-    from metaseq import checkpoint_utils, file_utils
-
-    if archive_map is not None:
-        if model_name_or_path in archive_map:
-            model_name_or_path = archive_map[model_name_or_path]
-        if data_name_or_path is not None and data_name_or_path in archive_map:
-            data_name_or_path = archive_map[data_name_or_path]
-
-        # allow archive_map to set default arg_overrides (e.g., tokenizer, bpe)
-        # for each model
-        if isinstance(model_name_or_path, dict):
-            for k, v in model_name_or_path.items():
-                if k == "checkpoint_file":
-                    checkpoint_file = v
-                elif (
-                    k != "path"
-                    # only set kwargs that don't already have overrides
-                    and k not in kwargs
-                ):
-                    kwargs[k] = v
-            model_name_or_path = model_name_or_path["path"]
-
-    model_path = file_utils.load_archive_file(model_name_or_path)
-
-    # convenience hack for loading data and BPE codes from model archive
-    if data_name_or_path.startswith("."):
-        kwargs["data"] = os.path.abspath(os.path.join(model_path, data_name_or_path))
-    else:
-        kwargs["data"] = file_utils.load_archive_file(data_name_or_path)
-    for file, arg in {
-        "code": "bpe_codes",
-        "bpecodes": "bpe_codes",
-        "sentencepiece.bpe.model": "sentencepiece_model",
-        "merges.txt": "bpe_merges",
-        "vocab.json": "bpe_vocab",
-    }.items():
-        path = os.path.join(model_path, file)
-        if os.path.exists(path):
-            kwargs[arg] = path
-
-    if "user_dir" in kwargs:
-        utils.import_user_module(argparse.Namespace(user_dir=kwargs["user_dir"]))
-
-    def _build_fn(train_cfg, task):
-        if post_build_model_hook:
-            return post_build_model_hook(task.build_model(train_cfg.model), task)
-        else:
-            return task.build_model(train_cfg.model)
-
-    models, args, task = checkpoint_utils.load_model_ensemble_and_task(
-        [os.path.join(model_path, cpt) for cpt in checkpoint_file.split(os.pathsep)],
-        arg_overrides=kwargs,
-        suffix=kwargs.get("suffix", ""),
-        build_model_hook=lambda cfg, task: _build_fn(cfg, task),
-    )
-
-    return {
-        "args": args,
-        "task": task,
-        "models": models,
-    }
 
 
 class GeneratorHubInterface(nn.Module):

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -145,7 +145,6 @@ class GeneratorHubInterface(nn.Module):
         cfg,
         task,
         models,
-        moe_disable_padding=True,
         skip_prepare_for_inference=False,
     ):
         super().__init__()

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -179,24 +179,17 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias_dropout_add_func = bias_dropout_add_fused_train
         else:
             bias_dropout_add_func = bias_dropout_add_fused_inference
+
         if self.c_attn is not None:
             # NormFormer Head Scaling Logic
             tgt_len, bsz = attn_output.size(0), attn_output.size(1)
             attn_output = attn_output.view(tgt_len, bsz, self.nh, self.head_dim)
             attn_output = torch.einsum("tbhd,h->tbhd", attn_output, self.c_attn)
             attn_output = attn_output.reshape(tgt_len, bsz, self.embed_dim)
-        if self.attn_ln is None:
-            x = bias_dropout_add_func(
-                attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
-            )
-        else:
-            x = torch.nn.functional.dropout(
-                attn_output + attn_bias.view(1, 1, -1),
-                p=self.args.dropout,
-                training=self.training,
-            )
-            x = self.attn_ln(x)
-            x = residual + x
+
+        x = bias_dropout_add_func(
+            attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
+        )
         return x, attn_weights
 
 

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -179,14 +179,6 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias_dropout_add_func = bias_dropout_add_fused_train
         else:
             bias_dropout_add_func = bias_dropout_add_fused_inference
-
-        if self.c_attn is not None:
-            # NormFormer Head Scaling Logic
-            tgt_len, bsz = attn_output.size(0), attn_output.size(1)
-            attn_output = attn_output.view(tgt_len, bsz, self.nh, self.head_dim)
-            attn_output = torch.einsum("tbhd,h->tbhd", attn_output, self.c_attn)
-            attn_output = attn_output.reshape(tgt_len, bsz, self.embed_dim)
-
         x = bias_dropout_add_func(
             attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
         )

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -59,11 +59,10 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(net_output, log_probs, sample)
+        return self.get_normalized_probs_scriptable(net_output, log_probs)
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
     # can't access the base class model in Torchscript.
@@ -72,8 +71,7 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         logits = net_output[0]

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -86,9 +86,5 @@ class BaseDecoder(nn.Module):
         """Maximum input length supported by the decoder."""
         return 1e6  # an arbitrary large number
 
-    def upgrade_state_dict_named(self, state_dict, name):
-        """Upgrade old state dicts to work with newer code."""
-        return state_dict
-
     def prepare_for_onnx_export_(self):
         self.onnx_trace = True

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -59,7 +59,7 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         return self.get_normalized_probs_scriptable(net_output, log_probs)
@@ -71,7 +71,7 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         logits = net_output[0]

--- a/metaseq/models/base_encoder.py
+++ b/metaseq/models/base_encoder.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional
 
 import torch
 import torch.nn as nn

--- a/metaseq/models/base_encoder.py
+++ b/metaseq/models/base_encoder.py
@@ -60,19 +60,6 @@ class BaseEncoder(nn.Module):
         }
         return self.forward(**encoder_input)
 
-    def reorder_encoder_out(self, encoder_out, new_order):
-        """
-        Reorder encoder output according to `new_order`.
-
-        Args:
-            encoder_out: output from the ``forward()`` method
-            new_order (LongTensor): desired order
-
-        Returns:
-            `encoder_out` rearranged according to `new_order`
-        """
-        raise NotImplementedError
-
     def max_positions(self):
         """Maximum input length supported by the encoder."""
         return 1e6  # an arbitrary large number

--- a/metaseq/models/base_encoder.py
+++ b/metaseq/models/base_encoder.py
@@ -77,10 +77,6 @@ class BaseEncoder(nn.Module):
         """Maximum input length supported by the encoder."""
         return 1e6  # an arbitrary large number
 
-    def upgrade_state_dict_named(self, state_dict, name):
-        """Upgrade old state dicts to work with newer code."""
-        return state_dict
-
     def set_num_updates(self, num_updates):
         """State from trainer to pass along to model at every update."""
 

--- a/metaseq/models/base_encoder.py
+++ b/metaseq/models/base_encoder.py
@@ -15,7 +15,6 @@ EncoderOut = NamedTuple(
         ("encoder_out", Tensor),  # T x B x C
         ("encoder_padding_mask", Optional[Tensor]),  # B x T
         ("encoder_embedding", Optional[Tensor]),  # B x T x C
-        ("encoder_states", Optional[List[Tensor]]),  # List[T x B x C]
         ("src_tokens", Optional[Tensor]),  # B x T
         ("src_lengths", Optional[Tensor]),  # B x 1
     ],

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -57,11 +57,10 @@ class BaseModel(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(net_output, log_probs, sample)
+        return self.get_normalized_probs_scriptable(net_output, log_probs)
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
     # can't access the base class model in Torchscript.
@@ -70,12 +69,11 @@ class BaseModel(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Scriptable helper function for get_normalized_probs in ~BaseModel"""
         if hasattr(self, "decoder"):
-            return self.decoder.get_normalized_probs(net_output, log_probs, sample)
+            return self.decoder.get_normalized_probs(net_output, log_probs)
         elif torch.is_tensor(net_output):
             # syntactic sugar for simple models which don't have a decoder
             # (e.g., the classification tutorial)

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -51,7 +51,7 @@ class BaseModel(nn.Module):
         """Build a new model instance."""
         raise NotImplementedError("Model must implement the build_model method")
 
-    def get_targets(self, sample, net_output):
+    def get_targets(self, sample):
         """Get targets from either the sample or the net's output."""
         return sample["target"]
 

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -57,7 +57,7 @@ class BaseModel(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         return self.get_normalized_probs_scriptable(net_output, log_probs)
@@ -69,7 +69,7 @@ class BaseModel(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Scriptable helper function for get_normalized_probs in ~BaseModel"""
         if hasattr(self, "decoder"):

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -168,10 +168,6 @@ class BaseModel(nn.Module):
 
         self.apply(apply_prepare_for_onnx_export_)
 
-    @classmethod
-    def hub_models(cls):
-        return {}
-
 
 class EncoderDecoderModel(BaseModel):
     """Base class for encoder-decoder models.

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -169,48 +169,6 @@ class BaseModel(nn.Module):
         self.apply(apply_prepare_for_onnx_export_)
 
     @classmethod
-    def from_pretrained(
-        cls,
-        model_name_or_path,
-        checkpoint_file="model.pt",
-        data_name_or_path=".",
-        skip_prepare_for_inference=False,
-        **kwargs,
-    ):
-        """
-        Load from a pre-trained model file. Downloads and caches the pre-trained
-        model file if needed.
-        The base implementation returns a
-        :class:`~metaseq.hub_utils.GeneratorHubInterface`, which can be used to
-        generate translations or sample from language models.
-        Other models may override this to implement custom hub interfaces.
-        Args:
-            model_name_or_path (str): either the name of a pre-trained model to
-                load or a path/URL to a pre-trained model state dict
-            checkpoint_file (str, optional): colon-separated list of checkpoint
-                files in the model archive to ensemble (default: 'model.pt')
-            data_name_or_path (str, optional): point args.data to the archive
-                at the given path/URL. Can start with '.' or './' to reuse the
-                model archive path.
-        """
-        from metaseq import hub_utils
-
-        x = hub_utils.from_pretrained(
-            model_name_or_path,
-            checkpoint_file,
-            data_name_or_path,
-            archive_map=cls.hub_models(),
-            **kwargs,
-        )
-        logger.info(x["args"])
-        return hub_utils.GeneratorHubInterface(
-            x["args"],
-            x["task"],
-            x["models"],
-            skip_prepare_for_inference=skip_prepare_for_inference,
-        )
-
-    @classmethod
     def hub_models(cls):
         return {}
 

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -7,7 +7,6 @@ Base classes for various metaseq models.
 """
 
 import logging
-from argparse import Namespace
 from typing import Dict, List, Optional, Tuple
 
 import torch

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -267,7 +267,6 @@ class LanguageModel(BaseModel):
         Args:
             src_tokens (LongTensor): tokens on which to condition the decoder,
                 of shape `(batch, tgt_len)`
-            src_lengths (LongTensor): source sentence lengths of shape `(batch)`
 
         Returns:
             tuple:

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -174,7 +174,6 @@ class BaseModel(nn.Module):
         model_name_or_path,
         checkpoint_file="model.pt",
         data_name_or_path=".",
-        moe_disable_padding=True,
         skip_prepare_for_inference=False,
         **kwargs,
     ):
@@ -208,7 +207,6 @@ class BaseModel(nn.Module):
             x["args"],
             x["task"],
             x["models"],
-            moe_disable_padding=moe_disable_padding,
             skip_prepare_for_inference=skip_prepare_for_inference,
         )
 

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -52,7 +52,7 @@ class BaseModel(nn.Module):
         raise NotImplementedError("Model must implement the build_model method")
 
     def get_targets(self, sample):
-        """Get targets from either the sample or the net's output."""
+        """Get targets from sample."""
         return sample["target"]
 
     def get_normalized_probs(
@@ -94,21 +94,6 @@ class BaseModel(nn.Module):
     def max_positions(self):
         """Maximum length supported by the model."""
         return None
-
-    def load_state_dict(
-        self,
-        state_dict,
-        strict=True,
-        model_cfg: Optional[DictConfig] = None,
-        args: Optional[Namespace] = None,
-    ):
-        """Copies parameters and buffers from *state_dict* into this module and
-        its descendants.
-
-        Overrides the method in :class:`nn.Module`. Compared with that method
-        this additionally "upgrades" *state_dicts* from old checkpoints.
-        """
-        return super().load_state_dict(state_dict, strict)
 
     def set_num_updates(self, num_updates):
         """State from trainer to pass along to model at every update."""

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -108,35 +108,7 @@ class BaseModel(nn.Module):
         Overrides the method in :class:`nn.Module`. Compared with that method
         this additionally "upgrades" *state_dicts* from old checkpoints.
         """
-        self.upgrade_state_dict(state_dict)
         return super().load_state_dict(state_dict, strict)
-
-    def upgrade_state_dict(self, state_dict):
-        """Upgrade old state dicts to work with newer code."""
-        self.upgrade_state_dict_named(state_dict, "")
-
-    def upgrade_state_dict_named(self, state_dict, name):
-        """Upgrade old state dicts to work with newer code.
-
-        Args:
-            state_dict (dict): state dictionary to upgrade, in place
-            name (str): the state dict key corresponding to the current module
-        """
-        assert state_dict is not None
-
-        def do_upgrade(m, prefix):
-            if len(prefix) > 0:
-                prefix += "."
-
-            for n, c in m.named_children():
-                name = prefix + n
-                if hasattr(c, "upgrade_state_dict_named"):
-                    c.upgrade_state_dict_named(state_dict, name)
-                elif hasattr(c, "upgrade_state_dict"):
-                    c.upgrade_state_dict(state_dict)
-                do_upgrade(c, name)
-
-        do_upgrade(self, name)
 
     def set_num_updates(self, num_updates):
         """State from trainer to pass along to model at every update."""

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -919,13 +919,6 @@ class TransformerDecoder(IncrementalDecoder):
                         ] = state_dict[k]
                         del state_dict[k]
 
-        version_key = "{}.version".format(name)
-        if utils.item(state_dict.get(version_key, torch.Tensor([1]))[0]) <= 2:
-            # earlier checkpoints did not normalize after the stack of layers
-            self.layer_norm = None
-            self.normalize = False
-            state_dict[version_key] = torch.Tensor([1])
-
         return state_dict
 
 

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -308,13 +308,6 @@ class TransformerEncoder(BaseEncoder):
             self.layers[i].upgrade_state_dict_named(
                 state_dict, "{}.layers.{}".format(name, i)
             )
-
-        version_key = "{}.version".format(name)
-        if utils.item(state_dict.get(version_key, torch.Tensor([1]))[0]) < 2:
-            # earlier checkpoints did not normalize after the stack of layers
-            self.layer_norm = None
-            self.normalize = False
-            state_dict[version_key] = torch.Tensor([1])
         return state_dict
 
 

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -543,7 +543,7 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
-        src_lengths: Optional[Any] = None,
+        src_lengths: Optional[Any] = None,  # TODO(susanz): remove this!
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -314,7 +314,7 @@ class TransformerDecoder(IncrementalDecoder):
                 0, len(layers), self.args.fsdp_checkpoint_wrap_layer_frequency
             ):
                 layer_block = TransformerDecoderMultiLayerBlockModule(
-                    layers[i: i + self.args.fsdp_checkpoint_wrap_layer_frequency]
+                    layers[i : i + self.args.fsdp_checkpoint_wrap_layer_frequency]
                 )
                 checkpoint = getattr(args, "checkpoint_activations", False)
                 if checkpoint:

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -293,23 +293,6 @@ class TransformerEncoder(BaseEncoder):
             return self.max_source_positions
         return min(self.max_source_positions, self.embed_positions.max_positions)
 
-    def upgrade_state_dict_named(self, state_dict, name):
-        """Upgrade a (possibly old) state dict for new versions of metaseq."""
-        if isinstance(self.embed_positions, SinusoidalPositionalEmbedding):
-            weights_key = "{}.embed_positions.weights".format(name)
-            if weights_key in state_dict:
-                print("deleting {0}".format(weights_key))
-                del state_dict[weights_key]
-            state_dict[
-                "{}.embed_positions._float_tensor".format(name)
-            ] = torch.FloatTensor(1)
-        for i in range(self.num_layers):
-            # update layer norms
-            self.layers[i].upgrade_state_dict_named(
-                state_dict, "{}.layers.{}".format(name, i)
-            )
-        return state_dict
-
 
 class TransformerDecoderMultiLayerBlockModule(nn.Module):
     def __init__(self, layers):

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -542,6 +542,7 @@ class TransformerDecoder(IncrementalDecoder):
 
         return x, embed, positions
 
+    # forward for TransformerDecoder
     def forward(
         self,
         prev_output_tokens,

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -233,59 +233,6 @@ class TransformerEncoder(BaseEncoder):
             "l_aux": l_aux,
         }
 
-    @torch.jit.export
-    def reorder_encoder_out(self, encoder_out: Dict[str, List[Tensor]], new_order):
-        """
-        Reorder encoder output according to *new_order*.
-
-        Args:
-            encoder_out: output from the ``forward()`` method
-            new_order (LongTensor): desired order
-
-        Returns:
-            *encoder_out* rearranged according to *new_order*
-        """
-        if len(encoder_out["encoder_out"]) == 0:
-            new_encoder_out = []
-        else:
-            new_encoder_out = [encoder_out["encoder_out"][0].index_select(1, new_order)]
-        if len(encoder_out["encoder_padding_mask"]) == 0:
-            new_encoder_padding_mask = []
-        else:
-            new_encoder_padding_mask = [
-                encoder_out["encoder_padding_mask"][0].index_select(0, new_order)
-            ]
-        if len(encoder_out["encoder_embedding"]) == 0:
-            new_encoder_embedding = []
-        else:
-            new_encoder_embedding = [
-                encoder_out["encoder_embedding"][0].index_select(0, new_order)
-            ]
-
-        if len(encoder_out["src_tokens"]) == 0:
-            src_tokens = []
-        else:
-            src_tokens = [(encoder_out["src_tokens"][0]).index_select(0, new_order)]
-
-        if len(encoder_out["src_lengths"]) == 0:
-            src_lengths = []
-        else:
-            src_lengths = [(encoder_out["src_lengths"][0]).index_select(0, new_order)]
-
-        encoder_states = encoder_out["encoder_states"]
-        if len(encoder_states) > 0:
-            for idx, state in enumerate(encoder_states):
-                encoder_states[idx] = state.index_select(1, new_order)
-
-        return {
-            "encoder_out": new_encoder_out,  # T x B x C
-            "encoder_padding_mask": new_encoder_padding_mask,  # B x T
-            "encoder_embedding": new_encoder_embedding,  # B x T x C
-            "encoder_states": encoder_states,  # List[T x B x C]
-            "src_tokens": src_tokens,  # B x T
-            "src_lengths": src_lengths,  # B x 1
-        }
-
     def max_positions(self):
         """Maximum input length supported by the encoder."""
         if self.embed_positions is None:

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -123,7 +123,6 @@ class TransformerEncoder(BaseEncoder):
         self,
         src_tokens,
         src_lengths: Optional[torch.Tensor] = None,
-        return_all_hiddens: bool = False,
         token_embeddings: Optional[torch.Tensor] = None,
     ):
         """
@@ -132,8 +131,6 @@ class TransformerEncoder(BaseEncoder):
                 `(batch, src_len)`
             src_lengths (torch.LongTensor): lengths of each source sentence of
                 shape `(batch)`
-            return_all_hiddens (bool, optional): also return all of the
-                intermediate hidden states (default: False).
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
 
@@ -145,12 +142,9 @@ class TransformerEncoder(BaseEncoder):
                   padding elements of shape `(batch, src_len)`
                 - **encoder_embedding** (Tensor): the (scaled) embedding lookup
                   of shape `(batch, src_len, embed_dim)`
-                - **encoder_states** (List[Tensor]): all intermediate
-                  hidden states of shape `(src_len, batch, embed_dim)`.
-                  Only populated if *return_all_hiddens* is True.
         """
         return self.forward_scriptable(
-            src_tokens, src_lengths, return_all_hiddens, token_embeddings
+            src_tokens, src_lengths, token_embeddings
         )
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
@@ -161,7 +155,6 @@ class TransformerEncoder(BaseEncoder):
         self,
         src_tokens,
         src_lengths: Optional[torch.Tensor] = None,
-        return_all_hiddens: bool = False,
         token_embeddings: Optional[torch.Tensor] = None,
     ):
         """
@@ -170,8 +163,6 @@ class TransformerEncoder(BaseEncoder):
                 `(batch, src_len)`
             src_lengths (torch.LongTensor): lengths of each source sentence of
                 shape `(batch)`
-            return_all_hiddens (bool, optional): also return all of the
-                intermediate hidden states (default: False).
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
 
@@ -183,9 +174,6 @@ class TransformerEncoder(BaseEncoder):
                   padding elements of shape `(batch, src_len)`
                 - **encoder_embedding** (Tensor): the (scaled) embedding lookup
                   of shape `(batch, src_len, embed_dim)`
-                - **encoder_states** (List[Tensor]): all intermediate
-                  hidden states of shape `(src_len, batch, embed_dim)`.
-                  Only populated if *return_all_hiddens* is True.
         """
         # compute padding mask
         encoder_padding_mask = src_tokens.eq(self.padding_idx)
@@ -200,20 +188,12 @@ class TransformerEncoder(BaseEncoder):
         # B x T x C -> T x B x C
         x = x.transpose(0, 1)
 
-        encoder_states = []
-
-        if return_all_hiddens:
-            encoder_states.append(x)
-
         # encoder layers
         l_aux = []
         for layer in self.layers:
             x, l_aux_i = layer(
                 x, encoder_padding_mask=encoder_padding_mask if has_pads else None
             )
-            if return_all_hiddens:
-                assert encoder_states is not None
-                encoder_states.append(x)
             l_aux.append(l_aux_i)
 
         if self.layer_norm is not None:
@@ -227,7 +207,6 @@ class TransformerEncoder(BaseEncoder):
             "encoder_out": [x],  # T x B x C
             "encoder_padding_mask": [encoder_padding_mask],  # B x T
             "encoder_embedding": [encoder_embedding],  # B x T x C
-            "encoder_states": encoder_states,  # List[T x B x C]
             "src_tokens": [],
             "src_lengths": [],
             "l_aux": l_aux,
@@ -584,7 +563,6 @@ class TransformerDecoder(IncrementalDecoder):
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         src_lengths: Optional[Any] = None,
-        return_all_hiddens: bool = False,
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -549,7 +549,6 @@ class TransformerDecoder(IncrementalDecoder):
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
         alignment_layer: Optional[int] = None,
-        alignment_heads: Optional[int] = None,
         src_lengths: Optional[Any] = None,
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
@@ -569,8 +568,6 @@ class TransformerDecoder(IncrementalDecoder):
                 applying output layer (default: False).
             alignment_layer (int, optional): return mean alignment over
                 heads at this layer (default: last layer).
-            alignment_heads (int, optional): only average alignment over
-                this many heads (default: all heads).
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
             self_attn_padding_mask (torch.Tensor, optional): precomputed padding
@@ -589,7 +586,6 @@ class TransformerDecoder(IncrementalDecoder):
             encoder_out=encoder_out,
             incremental_state=incremental_state,
             alignment_layer=alignment_layer,
-            alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
         )
@@ -603,7 +599,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         alignment_layer: Optional[int] = None,
-        alignment_heads: Optional[int] = None,
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
@@ -612,7 +607,6 @@ class TransformerDecoder(IncrementalDecoder):
             encoder_out=encoder_out,
             incremental_state=incremental_state,
             alignment_layer=alignment_layer,
-            alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
         )
@@ -623,7 +617,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         alignment_layer: Optional[int] = None,
-        alignment_heads: Optional[int] = None,
         token_embeddings: Optional[Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
@@ -692,9 +685,6 @@ class TransformerDecoder(IncrementalDecoder):
 
         inner_states.append(x)
         if attn is not None:
-            if alignment_heads is not None:
-                attn = attn[:alignment_heads]
-
             # average probabilities over heads
             attn = attn.mean(dim=0)
 

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -20,7 +20,6 @@ from metaseq.modules import (
     Dropout,
     LayerNorm,
     PositionalEmbedding,
-    SinusoidalPositionalEmbedding,
     TransformerDecoderLayer,
     TransformerEncoderLayer,
 )

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -881,46 +881,6 @@ class TransformerDecoder(IncrementalDecoder):
         else:
             return self._future_mask[:cur_seq_len, :cur_seq_len]
 
-    def upgrade_state_dict_named(self, state_dict, name):
-        """Upgrade a (possibly old) state dict for new versions of metaseq."""
-        if isinstance(self.embed_positions, SinusoidalPositionalEmbedding):
-            weights_key = "{}.embed_positions.weights".format(name)
-            if weights_key in state_dict:
-                del state_dict[weights_key]
-            state_dict[
-                "{}.embed_positions._float_tensor".format(name)
-            ] = torch.FloatTensor(1)
-
-        if f"{name}.output_projection.weight" not in state_dict:
-            if self.share_input_output_embed:
-                embed_out_key = f"{name}.embed_tokens.weight"
-            else:
-                embed_out_key = f"{name}.embed_out"
-            if embed_out_key in state_dict:
-                state_dict[f"{name}.output_projection.weight"] = state_dict[
-                    embed_out_key
-                ]
-                if not self.share_input_output_embed:
-                    del state_dict[embed_out_key]
-
-        for i in range(self.num_layers):
-            # update layer norms
-            layer_norm_map = {
-                "0": "self_attn_layer_norm",
-                "1": "encoder_attn_layer_norm",
-                "2": "final_layer_norm",
-            }
-            for old, new in layer_norm_map.items():
-                for m in ("weight", "bias"):
-                    k = "{}.layers.{}.layer_norms.{}.{}".format(name, i, old, m)
-                    if k in state_dict:
-                        state_dict[
-                            "{}.layers.{}.{}.{}".format(name, i, new, m)
-                        ] = state_dict[k]
-                        del state_dict[k]
-
-        return state_dict
-
 
 def Embedding(
     num_embeddings, embedding_dim, padding_idx, initialize_params_on_gpu=False

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -143,9 +143,7 @@ class TransformerEncoder(BaseEncoder):
                 - **encoder_embedding** (Tensor): the (scaled) embedding lookup
                   of shape `(batch, src_len, embed_dim)`
         """
-        return self.forward_scriptable(
-            src_tokens, src_lengths, token_embeddings
-        )
+        return self.forward_scriptable(src_tokens, src_lengths, token_embeddings)
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
     # can't access the base class model in Torchscript.
@@ -165,15 +163,6 @@ class TransformerEncoder(BaseEncoder):
                 shape `(batch)`
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
-
-        Returns:
-            dict:
-                - **encoder_out** (Tensor): the last encoder layer's output of
-                  shape `(src_len, batch, embed_dim)`
-                - **encoder_padding_mask** (ByteTensor): the positions of
-                  padding elements of shape `(batch, src_len)`
-                - **encoder_embedding** (Tensor): the (scaled) embedding lookup
-                  of shape `(batch, src_len, embed_dim)`
         """
         # compute padding mask
         encoder_padding_mask = src_tokens.eq(self.padding_idx)

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -548,7 +548,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
-        full_context_alignment: bool = False,
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         src_lengths: Optional[Any] = None,
@@ -568,8 +567,6 @@ class TransformerDecoder(IncrementalDecoder):
                 :ref:`Incremental decoding`
             features_only (bool, optional): only return features without
                 applying output layer (default: False).
-            full_context_alignment (bool, optional): don't apply
-                auto-regressive mask to self-attention (default: False).
             alignment_layer (int, optional): return mean alignment over
                 heads at this layer (default: last layer).
             alignment_heads (int, optional): only average alignment over
@@ -591,7 +588,6 @@ class TransformerDecoder(IncrementalDecoder):
             prev_output_tokens,
             encoder_out=encoder_out,
             incremental_state=incremental_state,
-            full_context_alignment=full_context_alignment,
             alignment_layer=alignment_layer,
             alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
@@ -606,7 +602,6 @@ class TransformerDecoder(IncrementalDecoder):
         prev_output_tokens,
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        full_context_alignment: bool = False,
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         token_embeddings: Optional[torch.Tensor] = None,
@@ -616,7 +611,6 @@ class TransformerDecoder(IncrementalDecoder):
             prev_output_tokens,
             encoder_out=encoder_out,
             incremental_state=incremental_state,
-            full_context_alignment=full_context_alignment,
             alignment_layer=alignment_layer,
             alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
@@ -628,7 +622,6 @@ class TransformerDecoder(IncrementalDecoder):
         prev_output_tokens,
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        full_context_alignment: bool = False,
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         token_embeddings: Optional[Tensor] = None,
@@ -656,7 +649,7 @@ class TransformerDecoder(IncrementalDecoder):
 
         # see IncrementalDecoder for important information about
         # incremental state. Note that it may be an empty dictionary.
-        if not incremental_state and not full_context_alignment:
+        if not incremental_state:
             self_attn_mask = self.buffered_future_mask(x, prev_output_tokens)
         else:
             self_attn_mask = None

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -96,14 +96,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
             )
         },
     )
-    use_stable_embedding: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Use bitsandbytes StableEmbeddingLayer which saves embedding state in fp32",
-            "argparse_alias": "--stable-emb",
-        },
-    )
-
     # ALiBi
     alibi: bool = field(
         default=False,
@@ -192,24 +184,14 @@ class TransformerLanguageModel(LanguageModel):
 
     @classmethod
     def build_embedding(cls, args, dictionary, embed_dim, path=None):
-        if getattr(args, "use_stable_embedding", False):
-            import bitsandbytes as bnb
-
-            if not args.no_scale_embedding:
-                logger.warning(
-                    "It is recommended to pass --no-scale-embedding with --use-stable-embedding"
-                )
-            return bnb.nn.StableEmbedding(len(dictionary), embed_dim, dictionary.pad())
-
-        else:
-            return Embedding(
-                len(dictionary),
-                embed_dim,
-                dictionary.pad(),
-                initialize_params_on_gpu=getattr(
-                    args, "tensor_parallel_init_model_on_gpu", False
-                ),
-            )
+        return Embedding(
+            len(dictionary),
+            embed_dim,
+            dictionary.pad(),
+            initialize_params_on_gpu=getattr(
+                args, "tensor_parallel_init_model_on_gpu", False
+            ),
+        )
 
 
 def base_lm_architecture(args):

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -103,20 +103,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
             "argparse_alias": "--stable-emb",
         },
     )
-    # NormFormer
-    scale_fc: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Insert LayerNorm between fully connected layers",
-        },
-    )
-    scale_attn: Optional[bool] = field(
-        default=False, metadata={"help": "Insert LayerNorm after attention"}
-    )
-    scale_heads: Optional[bool] = field(
-        default=False,
-        metadata={"help": "Learn a scale coefficient for each attention head"},
-    )
 
     # ALiBi
     alibi: bool = field(

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -146,11 +146,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
         default=0.006,
         metadata={"help": "Sigma for megatron initialization"},
     )
-    sync_ln_variance: Optional[bool] = field(
-        default=False,
-        metadata={"help": "sync_ln_variance stats", "argparse_alias": "--sync-ln"},
-    )
-
     no_emb_dropout: Optional[bool] = field(
         default=False, metadata={"help": "Avoid emb dropout for decoder"}
     )

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -248,15 +248,3 @@ def transformer_lm_gpt2_tiny(args):
     args.attention_dropout = getattr(args, "attention_dropout", 0.1)
     args.activation_fn = getattr(args, "activation_fn", "gelu")
     base_lm_architecture(args)
-
-
-@register_model_architecture("transformer_lm", "transformer_lm_gpt2_bigger")
-def transformer_lm_gpt2_bigger(args):
-    args.decoder_embed_dim = getattr(args, "decoder_embed_dim", 2048)
-    args.decoder_ffn_embed_dim = getattr(args, "decoder_ffn_embed_dim", 8192)
-    args.decoder_layers = getattr(args, "decoder_layers", 48)
-    args.decoder_attention_heads = getattr(args, "decoder_attention_heads", 32)
-    args.dropout = getattr(args, "dropout", 0.1)
-    args.attention_dropout = getattr(args, "attention_dropout", 0.1)
-    args.activation_fn = getattr(args, "activation_fn", "gelu")
-    base_lm_architecture(args)

--- a/metaseq/modules/layer_norm.py
+++ b/metaseq/modules/layer_norm.py
@@ -6,9 +6,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from metaseq import distributed_utils as dist_utils
-from typing import Tuple
-import torch.distributed as dist
 
 try:
     from apex.normalization import FusedLayerNorm as _FusedLayerNorm
@@ -49,83 +46,3 @@ class Fp32LayerNorm(nn.LayerNorm):
             self.eps,
         )
         return output.type_as(input)
-
-
-class SyncedModelParallelFusedLayerNorm(nn.Module):
-    def __init__(
-        self,
-        hidden_size,
-        mp_size,
-        mp_rank=0,
-        eps=1e-5,
-        initialize_params_on_gpu=False,
-        use_bias=True,
-        mean_center=True,
-    ):
-        super().__init__()
-        assert hidden_size % mp_size == 0
-        partition_size = hidden_size // mp_size
-        self.use_bias = use_bias
-        self.mean_center = mean_center
-        self.weight = nn.Parameter(torch.ones(partition_size, dtype=torch.float32))
-        self.bias = (
-            nn.Parameter(torch.zeros(partition_size, dtype=torch.float32))
-            if self.use_bias
-            else None
-        )
-        self.variance_epsilon = eps
-        self.mp_world_size = float(dist_utils.get_model_parallel_world_size())
-        self.mp_rank = mp_rank
-        if initialize_params_on_gpu:
-            self.weight.cuda().half()
-            if self.bias is not None:
-                self.bias.cuda().half()
-
-    @staticmethod
-    def get_statistics_from_all_workers(stat, rank, world_size):
-        """Retuns tensor shaped (world_size, *stat_size)"""
-        buffer_size: Tuple[int] = (int(world_size),) + tuple(stat.size())
-        assert isinstance(
-            buffer_size, tuple
-        ), f"b{buffer_size} {world_size} {stat.size()}"
-        buffer = torch.zeros(buffer_size, dtype=stat.dtype, device=stat.device)
-        buffer[rank] = stat
-        dist.all_reduce(buffer, group=dist_utils.get_model_parallel_group())
-        return buffer
-
-    def forward(self, hidden_states):
-        hid_fp32 = hidden_states.float()
-        local_variance = torch.var(hid_fp32, -1, keepdim=True, unbiased=True)
-        local_mean = hid_fp32.mean(-1, keepdim=True)
-        vs = SyncedModelParallelFusedLayerNorm.get_statistics_from_all_workers(
-            local_variance, self.mp_rank, self.mp_world_size
-        )
-        ms = SyncedModelParallelFusedLayerNorm.get_statistics_from_all_workers(
-            local_mean, self.mp_rank, self.mp_world_size
-        )
-        variance, mean = variance_formula(
-            ms, vs, self.mp_world_size, hidden_states.size(-1)
-        )
-        denom = torch.rsqrt(variance + self.variance_epsilon).to(hidden_states.dtype)
-        mean = mean.to(hidden_states.dtype)
-
-        if self.mean_center:
-            hidden_states = (hidden_states - mean) * denom
-        else:
-            hidden_states = hidden_states * denom
-
-        if self.use_bias:
-            return (self.weight * hidden_states) + self.bias
-        else:
-            return self.weight * hidden_states
-
-
-def variance_formula(means, vs, g, k) -> Tuple[torch.Tensor]:
-    """This only works with unbiased=False (No Bessel Correction)"""
-    d = g * k
-    var_ej = means.var(0)  # Need unbiased True here (at least in  toy example)
-    summation = vs.sum(0)
-    inner_coeff: float = (k * (g - 1)) / (k - 1)
-    outer_coeff: float = (k - 1) / (d - 1)
-    out: torch.Tensor = outer_coeff * (summation + (inner_coeff * var_ej))
-    return out, means.mean(0)

--- a/metaseq/modules/transformer_layer.py
+++ b/metaseq/modules/transformer_layer.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from metaseq import distributed_utils as dist_utils, utils
+from metaseq import utils
 from metaseq.modules import gelu, MultiheadAttention
 from metaseq.modules.dropout import Dropout
 from metaseq.modules.fused_bias_gelu import (
@@ -18,7 +18,7 @@ from metaseq.modules.fused_bias_gelu import (
     has_fused_bias_gelu,
     load_megatron_fused_kernel,
 )
-from metaseq.modules.layer_norm import LayerNorm, SyncedModelParallelFusedLayerNorm
+from metaseq.modules.layer_norm import LayerNorm
 from metaseq.modules.linear import Linear
 
 

--- a/metaseq/modules/transformer_layer.py
+++ b/metaseq/modules/transformer_layer.py
@@ -142,20 +142,6 @@ class TransformerEncoderLayer(nn.Module):
     def residual_connection(self, x, residual):
         return residual + x
 
-    def upgrade_state_dict_named(self, state_dict, name):
-        """
-        Rename layer norm states from `...layer_norms.0.weight` to
-        `...self_attn_layer_norm.weight` and `...layer_norms.1.weight` to
-        `...final_layer_norm.weight`
-        """
-        layer_norm_map = {"0": "self_attn_layer_norm", "1": "final_layer_norm"}
-        for old, new in layer_norm_map.items():
-            for m in ("weight", "bias"):
-                k = "{}.layer_norms.{}.{}".format(name, old, m)
-                if k in state_dict:
-                    state_dict["{}.{}.{}".format(name, new, m)] = state_dict[k]
-                    del state_dict[k]
-
     def forward(
         self,
         x,

--- a/metaseq/modules/transformer_layer.py
+++ b/metaseq/modules/transformer_layer.py
@@ -57,37 +57,6 @@ def _ffn(x, fc1, activation_fn, fc2, dropout_module):
     return x
 
 
-class FeedForwardNetwork(nn.Module):
-    """
-    Feed Forward Network layer in the Transformer model
-    """
-
-    def __init__(self, args, embed_dim, ffn_dim, dropout_module=None):
-        super().__init__()
-        self.embed_dim = embed_dim
-        self.activation_fn = utils.get_activation_fn(
-            activation=str(args.activation_fn)
-            if getattr(args, "activation_fn", None) is not None
-            else "relu"
-        )
-        self.fc1 = Linear(self.embed_dim, ffn_dim)
-        self.fc2 = Linear(ffn_dim, self.embed_dim)
-        self.dropout_module = (
-            Dropout(args.dropout, module_name=self.__class__.__name__)
-            if not dropout_module
-            else dropout_module
-        )
-
-    def forward(self, x):
-        return _ffn(
-            x,
-            fc1=self.fc1,
-            activation_fn=self.activation_fn,
-            fc2=self.fc2,
-            dropout_module=self.dropout_module,
-        )
-
-
 class TransformerEncoderLayer(nn.Module):
     """Encoder layer block.
 

--- a/metaseq/optim/adam.py
+++ b/metaseq/optim/adam.py
@@ -90,42 +90,6 @@ class MetaseqAdam(BaseOptimizer):
         }
 
 
-@register_optimizer("adam8bit", dataclass=MetaseqAdamConfig)
-class MetaseqAdam8Bit(BaseOptimizer):
-    def __init__(self, cfg: DictConfig, params):
-        super().__init__(cfg)
-        try:
-            import bitsandbytes as bnb
-        except ImportError:
-            raise ImportError(
-                "adam8bit requires bits and bytes: see https://gist.github.com/TimDettmers/c4ffe346f095ee4481aa3d4b4ad2ffe0"
-            )
-        bnb.optim.GlobalOptimManager.get_instance().register_parameters(params)
-        self._optimizer = bnb.optim.Adam(
-            params, optim_bits=8, **self.optimizer_config
-        )  # equivalent
-
-    @property
-    def optimizer_config(self):
-        return {
-            "lr": self.cfg.lr[0]
-            if isinstance(self.cfg.lr, Collection)
-            else self.cfg.lr,
-            "betas": eval(self.cfg.adam_betas),
-            "eps": self.cfg.adam_eps,
-            "weight_decay": self.cfg.weight_decay,
-            "block_wise": self.cfg.block_wise,
-        }
-
-    @property
-    def supports_memory_efficient_fp16(self):
-        return True
-
-    @property
-    def supports_flat_params(self):
-        return True
-
-
 class Adam(torch.optim.Optimizer):
     r"""Implements Adam algorithm.
 

--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -92,8 +92,6 @@ def worker_main(cfg: MetaseqConfig):
     glued = glue_megatron_parts(model_parts)
     # glued['decoder.output_projection.weight'] = glued['decoder.embed_tokens.weight']
 
-    glued["decoder.version"] = model["model"]["decoder.version"].cpu()
-
     if "decoder.output_projection.weight" in glued:
         del glued["decoder.output_projection.weight"]
 

--- a/metaseq/scripts/reshard_mp.py
+++ b/metaseq/scripts/reshard_mp.py
@@ -94,7 +94,7 @@ def reshard_mp(
     state = _merge_flat_fsdp_shards([torch_load_cpu(f) for f in paths_to_load])
     model_state = state.pop("model")
 
-    dummy_model_state = {}  # for decoder.version and other useless keys
+    dummy_model_state = {}  # metadata keys
 
     local_state_dicts: List[dict] = [{} for _ in range(target_ddp_size)]
     for k, v in model_state.items():

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -181,7 +181,7 @@ class SequenceGenerator(nn.Module):
         model_out[0].div_(self.temperature, rounding_mode="trunc")
         # lprobs is the log probability of each possible token in every position
         # lprobs \in FloatTensor(bsz * beam_size, prompt_len, vocab_size)
-        lprobs = self.model.get_normalized_probs(model_out, log_probs=True, sample=None)
+        lprobs = self.model.get_normalized_probs(model_out, log_probs=True)
 
         # don't allow generation of eos/pad
         model_out[0][:, :, self.eos] = -math.inf
@@ -250,9 +250,7 @@ class SequenceGenerator(nn.Module):
                 incremental_state=incremental_states,
             )
             model_out[0].div_(self.temperature)
-            lprobs = self.model.get_normalized_probs(
-                model_out, log_probs=True, sample=None
-            )
+            lprobs = self.model.get_normalized_probs(model_out, log_probs=True)
             lprobs = lprobs[:, -1, :]
             if self.need_logprobs:
                 all_lprobs[:, step] = lprobs

--- a/metaseq/sequence_scorer.py
+++ b/metaseq/sequence_scorer.py
@@ -71,7 +71,9 @@ class SequenceScorer(object):
             vocab_dist = []
             for bd, tgt, is_single in batched:
                 sample["target"] = tgt
-                curr_prob = model.get_normalized_probs(bd, log_probs=len(models) == 1).data
+                curr_prob = model.get_normalized_probs(
+                    bd, log_probs=len(models) == 1
+                ).data
                 if is_single:
                     probs = gather_target_probs(curr_prob, orig_target)
                     if self.compute_vocab_dist:

--- a/metaseq/sequence_scorer.py
+++ b/metaseq/sequence_scorer.py
@@ -71,9 +71,7 @@ class SequenceScorer(object):
             vocab_dist = []
             for bd, tgt, is_single in batched:
                 sample["target"] = tgt
-                curr_prob = model.get_normalized_probs(
-                    bd, log_probs=len(models) == 1, sample=sample
-                ).data
+                curr_prob = model.get_normalized_probs(bd, log_probs=len(models) == 1).data
                 if is_single:
                     probs = gather_target_probs(curr_prob, orig_target)
                     if self.compute_vocab_dist:

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -70,13 +70,7 @@ class Trainer(object):
                     "Please update to fairscale 0.4.0 or newer when combining "
                     "--update-freq with FullyShardedDataParallel"
                 )
-            if self.cfg.optimizer == "adam8bit":
-                assert (
-                    self.use_sharded_state
-                ), "adam8bit + FSDP requires --use-sharded-state"
             if self.use_sharded_state:
-                import fairscale
-
                 assert (
                     fairscale.__version__ >= "0.3.9"
                 ), "--use-sharded-state requires newer fairscale. pip install -U fairscale"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -431,7 +431,6 @@ class TestEncoder(BaseEncoder):
             encoder_out=src_tokens,
             encoder_padding_mask=None,
             encoder_embedding=None,
-            encoder_states=None,
             src_tokens=None,
             src_lengths=None,
         )
@@ -514,7 +513,6 @@ class TestReshapingEncoder(BaseEncoder):
             encoder_out=x.view(b_sz, -1, 2),
             encoder_padding_mask=None,
             encoder_embedding=None,
-            encoder_states=None,
             src_tokens=None,
             src_lengths=None,
         )
@@ -543,7 +541,6 @@ class TestAdditionalInputEncoder(BaseEncoder):
             encoder_out=src_tokens,
             encoder_padding_mask=None,
             encoder_embedding=None,
-            encoder_states=None,
             src_tokens=None,
             src_lengths=None,
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -484,7 +484,7 @@ class TestIncrementalDecoder(IncrementalDecoder):
         dev = prev_output_tokens.device
         return probs.to(dev), {"attn": [attn.to(dev)]}
 
-    def get_normalized_probs(self, net_output, log_probs, _):
+    def get_normalized_probs(self, net_output, log_probs):
         # the decoder returns probabilities directly
         probs = net_output[0]
         if log_probs:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -436,16 +436,6 @@ class TestEncoder(BaseEncoder):
             src_lengths=None,
         )
 
-    def reorder_encoder_out(self, encoder_out, new_order):
-        return EncoderOut(
-            encoder_out=encoder_out.encoder_out.index_select(0, new_order),
-            encoder_padding_mask=None,
-            encoder_embedding=None,
-            encoder_states=None,
-            src_tokens=None,
-            src_lengths=None,
-        )
-
 
 class TestIncrementalDecoder(IncrementalDecoder):
     def __init__(self, args, dictionary):
@@ -529,16 +519,6 @@ class TestReshapingEncoder(BaseEncoder):
             src_lengths=None,
         )
 
-    def reorder_encoder_out(self, encoder_out, new_order):
-        return EncoderOut(
-            encoder_out=encoder_out.encoder_out.index_select(0, new_order),
-            encoder_padding_mask=None,
-            encoder_embedding=None,
-            encoder_states=None,
-            src_tokens=None,
-            src_lengths=None,
-        )
-
 
 class TestReshapingModel(EncoderDecoderModel):
     def __init__(self, encoder, decoder):
@@ -561,16 +541,6 @@ class TestAdditionalInputEncoder(BaseEncoder):
         assert kwargs["fancy_other_input"] is not None
         return EncoderOut(
             encoder_out=src_tokens,
-            encoder_padding_mask=None,
-            encoder_embedding=None,
-            encoder_states=None,
-            src_tokens=None,
-            src_lengths=None,
-        )
-
-    def reorder_encoder_out(self, encoder_out, new_order):
-        return EncoderOut(
-            encoder_out=encoder_out.encoder_out.index_select(0, new_order),
             encoder_padding_mask=None,
             encoder_embedding=None,
             encoder_states=None,


### PR DESCRIPTION
Tackling https://github.com/facebookresearch/metaseq/issues/165

Only checkpoints to work with here are with OPT models so far.

More cleanup around unused args / logic in preparation for reducing complexity around configuration / checkpointing logic.

* Removed all normformer args & related classes (sync ln)
* Removed stable embeddings 
* Removed FeedForwardNetwork class