### PR TITLE
[jsonl] Build cache on main worker only.

### DIFF
--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -8,7 +8,6 @@ import json
 import logging
 import mmap
 import os
-import re
 import sys
 import threading
 from pathlib import Path


### PR DESCRIPTION
**Patch Description**
As a mild convenience, we want the indices of datasets to be built automatically when they're first used. However, if we build them on every worker, we can easily flood NFS and the process is slow. However, if we build them on the primary worker, then it only takes a couple minutes to handle several TB.

This PR causes the indexes to be built on the main worker, while the rest take a break.

**Testing steps**
Used in internal ablation