### PR TITLE
Better validation in JSONL datasets

### DIFF
--- a/cpu_tests/test_jsonl_dataset.py
+++ b/cpu_tests/test_jsonl_dataset.py
@@ -10,11 +10,11 @@ import string
 import tempfile
 import unittest
 from unittest.mock import MagicMock
-
+from metaseq import pdb
 from metaseq.data import JsonlDataset
 
 
-def write_one_jsonl_(jsonl_path, num_lines=5, text_len_min=5, text_len_max=50):
+def write_one_jsonl_(jsonl_path, num_lines=5, text_len_min=5, text_len_max=50, truncate = False):
     data = []
     with open(jsonl_path, "w") as h:
         for _ in range(num_lines):
@@ -23,6 +23,10 @@ def write_one_jsonl_(jsonl_path, num_lines=5, text_len_min=5, text_len_max=50):
                 {"text": "".join(random.choices(string.ascii_letters, k=text_len))}
             )
             print(json.dumps(data[-1]), file=h)
+            if truncate and _ == 0:
+                line = "".join(random.choices(string.ascii_letters, k=text_len))
+                data.append(line)
+                print(line,file=h)
     return data
 
 
@@ -68,6 +72,18 @@ class TestJsonlDataset(unittest.TestCase):
             foo = dataset[4]
             assert foo == list(orig_data[4]["text"])
             assert tokenizer.call_count == 3
+
+    def test_non_empty_jsonl(self):
+        with tempfile.NamedTemporaryFile() as jsonl_file:
+            orig_data = write_one_jsonl_(jsonl_file.name, num_lines= 0)
+            assert len(orig_data) == 0
+            self.assertRaises(ValueError, JsonlDataset , jsonl_file.name)
+
+    def test_formatting_json(self):
+        with tempfile.NamedTemporaryFile() as jsonl_file:
+            orig_data = write_one_jsonl_(jsonl_file.name, num_lines= 5, truncate = True)
+            assert len(orig_data) == 6 # it's 6 because we add an extra line of badly formatted json 
+            self.assertRaises(AssertionError, JsonlDataset , jsonl_file.name)
 
     def _test_jsonl_dataset(self, num_lines, tokenizer=None):
         with tempfile.NamedTemporaryFile() as jsonl_file:

--- a/cpu_tests/test_jsonl_dataset.py
+++ b/cpu_tests/test_jsonl_dataset.py
@@ -10,11 +10,12 @@ import string
 import tempfile
 import unittest
 from unittest.mock import MagicMock
-from metaseq import pdb
 from metaseq.data import JsonlDataset
 
 
-def write_one_jsonl_(jsonl_path, num_lines=5, text_len_min=5, text_len_max=50, truncate = False):
+def write_one_jsonl_(
+    jsonl_path, num_lines=5, text_len_min=5, text_len_max=50, truncate=False
+):
     data = []
     with open(jsonl_path, "w") as h:
         for _ in range(num_lines):
@@ -26,7 +27,7 @@ def write_one_jsonl_(jsonl_path, num_lines=5, text_len_min=5, text_len_max=50, t
             if truncate and _ == 0:
                 line = "".join(random.choices(string.ascii_letters, k=text_len))
                 data.append(line)
-                print(line,file=h)
+                print(line, file=h)
     return data
 
 
@@ -75,15 +76,17 @@ class TestJsonlDataset(unittest.TestCase):
 
     def test_non_empty_jsonl(self):
         with tempfile.NamedTemporaryFile() as jsonl_file:
-            orig_data = write_one_jsonl_(jsonl_file.name, num_lines= 0)
+            orig_data = write_one_jsonl_(jsonl_file.name, num_lines=0)
             assert len(orig_data) == 0
-            self.assertRaises(ValueError, JsonlDataset , jsonl_file.name)
+            self.assertRaises(ValueError, JsonlDataset, jsonl_file.name)
 
     def test_formatting_json(self):
         with tempfile.NamedTemporaryFile() as jsonl_file:
-            orig_data = write_one_jsonl_(jsonl_file.name, num_lines= 5, truncate = True)
-            assert len(orig_data) == 6 # it's 6 because we add an extra line of badly formatted json 
-            self.assertRaises(AssertionError, JsonlDataset , jsonl_file.name)
+            orig_data = write_one_jsonl_(jsonl_file.name, num_lines=5, truncate=True)
+            assert (
+                len(orig_data) == 6
+            )  # it's 6 because we add an extra line of badly formatted json
+            self.assertRaises(AssertionError, JsonlDataset, jsonl_file.name)
 
     def _test_jsonl_dataset(self, num_lines, tokenizer=None):
         with tempfile.NamedTemporaryFile() as jsonl_file:

--- a/cpu_tests/test_jsonl_dataset.py
+++ b/cpu_tests/test_jsonl_dataset.py
@@ -86,7 +86,9 @@ class TestJsonlDataset(unittest.TestCase):
             assert (
                 len(orig_data) == 6
             )  # it's 6 because we add an extra line of badly formatted json
-            self.assertRaises(AssertionError, JsonlDataset, jsonl_file.name)
+            self.assertRaises(
+                json.decoder.JSONDecodeError, JsonlDataset, jsonl_file.name
+            )
 
     def _test_jsonl_dataset(self, num_lines, tokenizer=None):
         with tempfile.NamedTemporaryFile() as jsonl_file:

--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -15,7 +15,7 @@ from typing import Callable, Optional
 
 import numpy as np
 import torch
-from metaseq import pdb
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,12 +88,13 @@ class JsonlDataset(torch.utils.data.Dataset):
         cur = 0
         while True:
             line = f.readline()
-            # pdb.set_trace()
             if line != b"":
                 try:
                     json.loads(line)
                 except json.decoder.JSONDecodeError:
-                    raise AssertionError("Unable to load truncated or corrupted JSON file")
+                    raise AssertionError(
+                        "Unable to load truncated or corrupted JSON file"
+                    )
             if line == b"":
                 break
             offsets.append(cur)
@@ -143,7 +144,6 @@ if __name__ == "__main__":
     from glob import glob
 
     from tqdm import tqdm
-
 
     for f in tqdm(list(glob(args.pattern))):
         JsonlDataset(f, recache=True)

--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -15,7 +15,7 @@ from typing import Callable, Optional
 
 import numpy as np
 import torch
-
+from metaseq import pdb
 logger = logging.getLogger(__name__)
 
 
@@ -88,6 +88,12 @@ class JsonlDataset(torch.utils.data.Dataset):
         cur = 0
         while True:
             line = f.readline()
+            # pdb.set_trace()
+            if line != b"":
+                try:
+                    json.loads(line)
+                except json.decoder.JSONDecodeError:
+                    raise AssertionError("Unable to load truncated or corrupted JSON file")
             if line == b"":
                 break
             offsets.append(cur)
@@ -137,6 +143,7 @@ if __name__ == "__main__":
     from glob import glob
 
     from tqdm import tqdm
+
 
     for f in tqdm(list(glob(args.pattern))):
         JsonlDataset(f, recache=True)

--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -86,19 +86,23 @@ class JsonlDataset(torch.utils.data.Dataset):
         f.seek(0)
         offsets = []
         cur = 0
+        line_num = 0
         while True:
             line = f.readline()
             if line != b"":
                 try:
                     json.loads(line)
                 except json.decoder.JSONDecodeError:
-                    raise AssertionError(
-                        "Unable to load truncated or corrupted JSON file"
+                    raise json.decoder.JSONDecodeError(
+                        doc=path,
+                        pos=line_num,
+                        msg=f"Error while loading JSONL file {path} at line {line_num + 1}",
                     )
             if line == b"":
                 break
             offsets.append(cur)
             cur += len(line)
+            line_num += 1
         return offsets
 
     def __setstate__(self, state):


### PR DESCRIPTION
**Patch Description**
Added code to check for validity of json in jsonl files in the index building function. Also added two new tests to make sure that empty jsonl files as well as corrupt jsonl files throw up the right errors.

**Testing steps**
ran the new tests to ensure that it works as expected 

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests? Yes
-->
