### PR TITLE
added memory profiling for training and finetuning runs

### DIFF
--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -322,9 +322,21 @@ def train(
             and i == 5
         ):
             logger.info("STARTING PROFILER")
-            with profiler.profile() as prof:
+            with profiler.profile(
+                profile_memory=True, with_stack=True, record_shapes=True
+            ) as prof:
                 valid_losses, should_stop = train(i, samples)
             torch.cuda.synchronize()
+            sourceFile = open(
+                os.path.join(cfg.checkpoint.save_dir, "memory_usage.txt"), "w"
+            )
+            print(
+                prof.key_averages(group_by_stack_n=5).table(
+                    sort_by="self_cuda_memory_usage", row_limit=10
+                ),
+                file=sourceFile,
+            )
+            sourceFile.close()
             prof.export_chrome_trace(
                 os.path.join(cfg.checkpoint.save_dir, "profiler_trace.json")
             )


### PR DESCRIPTION
**Patch Description**
Added the ability to generate memory profiling information and save it in the checkpoint directory. Chose to go with PyTorch profiler over other alternatives because of its ability to offer better stack traces. 

**Testing steps**
Ran training for 8m and 125m models to generate traces and observed these traces.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue? N/A
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs? 
- [ ] Did you write any new necessary tests?
-->
