### PR TITLE
[api] Fix logit outputs

### DIFF
--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -718,6 +718,7 @@ class GeneratorInterface:
                 # simply skip pads
                 mask.append(False)
                 continue
+            # TODO(roller): Don't hardcode the special tokens
             if t <= 3 and i > 0:
                 # and other special tokens should end things
                 mask.append(False)

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -627,28 +627,18 @@ class GeneratorInterface:
                     tokens = all_tokens[i, j].tolist()
                     scores = all_scores[i, j].tolist()
                     distributions = all_distributions[i, j] if logprobs > 0 else None
-                    from metaseq.utils import print_r0
 
                     prompt_len = lengths[i]
-                    print_r0("prmopt_len:", prompt_len)
-                    print_r0("scores:", scores)
-                    print_r0("tokens:", tokens)
 
                     tokens, scores, distributions = GeneratorInterface._filter_special(
                         tokens, scores, distributions
                     )
-                    print_r0("prmopt_len2:", prompt_len)
-                    print_r0("scores2:", scores)
-                    print_r0("tokens2:", tokens)
-                    print_r0("")
 
                     if echo:
                         # don't cut off prompt
                         pass
                     else:
                         # cut off prompt
-                        print_r0("tokens after prompt_len:", tokens[prompt_len + 1 :])
-                        print_r0("scores after prompt_len:", scores[prompt_len + 1 :])
                         tokens = tokens[prompt_len + 1 :][: max_tokens[i]]
                         scores = scores[prompt_len + 1 :][: max_tokens[i]]
                         if logprobs > 0:
@@ -721,13 +711,6 @@ class GeneratorInterface:
         # scores is a 1D list of log-probability scores for those tokens (length seqlen)
         # distributions (optional) is a seqlen x vocab_size tensor corresponding to
         # the full distribution of predictions at each timestep
-
-        from metaseq.utils import print_r0
-
-        print_r0("fs tok:", len(tokens))
-        print_r0("fs sco:", len(scores))
-        print_r0("fs dis:", distributions.shape)
-
         output = []
         mask = []
         for i, (t, s) in enumerate(zip(tokens, scores)):

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -265,12 +265,6 @@ class SequenceGenerator(nn.Module):
         tokens = tokens[sorted_indices]
         scores = scores[sorted_indices]
 
-        from metaseq.utils import print_r0
-
-        print_r0("all_lprobs", all_lprobs.shape)
-        print_r0("tokens", tokens.shape)
-        print_r0("scores", scores.shape)
-
         # prepare the return value
         retval = {
             "tokens": tokens.view(bsz, beam_size, -1),

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -140,12 +140,10 @@ class SequenceGenerator(nn.Module):
         new_order = new_order.to(src_tokens.device).long()
 
         # initialize buffers
-        scores = (
-            torch.zeros(bsz * beam_size, max_len).to(src_tokens).float()
-        )  # +1 for eos; pad is never chosen for scoring
+        scores = torch.zeros(bsz * beam_size, max_len).to(src_tokens).float()
         tokens = (
             torch.zeros(bsz * beam_size, max_len).to(src_tokens).long().fill_(self.pad)
-        )  # +1 for final eos
+        )
 
         # notes:
         # - scores \in FloatTensor(bsz * beam_size, max_len)

--- a/metaseq/service/constants.py
+++ b/metaseq/service/constants.py
@@ -5,7 +5,7 @@
 
 import os
 
-MAX_SEQ_LEN = 2047
+MAX_SEQ_LEN = 2048
 BATCH_SIZE = 2048  # silly high bc we dynamically batch by MAX_BATCH_TOKENS
 MAX_BATCH_TOKENS = 3072
 DEFAULT_PORT = 6010

--- a/metaseq/service/constants.py
+++ b/metaseq/service/constants.py
@@ -5,7 +5,7 @@
 
 import os
 
-MAX_SEQ_LEN = 2048
+MAX_SEQ_LEN = 2047
 BATCH_SIZE = 2048  # silly high bc we dynamically batch by MAX_BATCH_TOKENS
 MAX_BATCH_TOKENS = 3072
 DEFAULT_PORT = 6010


### PR DESCRIPTION
**Patch Description**
@tbmihailov pointed out that our logits differ from the openai's, in that we (previously) started our logprobs with the first generated token, rather than including a sentinel `null` logprob and including the first token.

This PR fixes that so we are more consistent with OpenAI

**Testing steps**
So much manual testing.