### PR TITLE
[Cleanup] Delete unused methods / imports / args: 1/N

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -584,7 +584,7 @@ def load_model_ensemble_and_task(
                 # build model for ensemble
                 model = task.build_model(cfg.model)
 
-            model.load_state_dict(state["model"], strict=strict, model_cfg=cfg.model)
+            model.load_state_dict(state["model"], strict=strict)
             logger.info("Done loading state dict")
             # reset state so it gets loaded for the next model in ensemble
             state = None

--- a/metaseq/criterions/cross_entropy.py
+++ b/metaseq/criterions/cross_entropy.py
@@ -88,7 +88,7 @@ class CrossEntropyCriterion(BaseCriterion):
     def compute_loss(self, model, net_output, sample, reduce=True):
         lprobs = model.get_normalized_probs(net_output, log_probs=True)
         lprobs = lprobs.view(-1, lprobs.size(-1))
-        target = model.get_targets(sample, net_output).view(-1)
+        target = model.get_targets(sample).view(-1)
         loss = nll_loss(
             lprobs,
             target,

--- a/metaseq/distributed/fully_sharded_data_parallel.py
+++ b/metaseq/distributed/fully_sharded_data_parallel.py
@@ -71,7 +71,7 @@ class FullyShardedDataParallel(FSDP):
                 super().state_dict()
                 return destination or {}
 
-    def load_state_dict(self, state_dict, strict=True, model_cfg=None):
+    def load_state_dict(self, state_dict, strict=True):
         if self.use_sharded_state:
             return super().load_local_state_dict(state_dict, strict=strict)
         else:

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -59,11 +59,10 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(net_output, log_probs, sample)
+        return self.get_normalized_probs_scriptable(net_output, log_probs)
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
     # can't access the base class model in Torchscript.
@@ -72,8 +71,7 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         logits = net_output[0]

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -59,7 +59,7 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         return self.get_normalized_probs_scriptable(net_output, log_probs)
@@ -71,7 +71,7 @@ class BaseDecoder(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         logits = net_output[0]

--- a/metaseq/models/base_encoder.py
+++ b/metaseq/models/base_encoder.py
@@ -60,19 +60,6 @@ class BaseEncoder(nn.Module):
         }
         return self.forward(**encoder_input)
 
-    def reorder_encoder_out(self, encoder_out, new_order):
-        """
-        Reorder encoder output according to `new_order`.
-
-        Args:
-            encoder_out: output from the ``forward()`` method
-            new_order (LongTensor): desired order
-
-        Returns:
-            `encoder_out` rearranged according to `new_order`
-        """
-        raise NotImplementedError
-
     def max_positions(self):
         """Maximum input length supported by the encoder."""
         return 1e6  # an arbitrary large number

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -57,11 +57,10 @@ class BaseModel(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(net_output, log_probs, sample)
+        return self.get_normalized_probs_scriptable(net_output, log_probs)
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
     # can't access the base class model in Torchscript.
@@ -70,12 +69,11 @@ class BaseModel(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-        sample: Optional[Dict[str, Tensor]] = None,
+        log_probs: bool
     ):
         """Scriptable helper function for get_normalized_probs in ~BaseModel"""
         if hasattr(self, "decoder"):
-            return self.decoder.get_normalized_probs(net_output, log_probs, sample)
+            return self.decoder.get_normalized_probs(net_output, log_probs)
         elif torch.is_tensor(net_output):
             # syntactic sugar for simple models which don't have a decoder
             # (e.g., the classification tutorial)

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -51,7 +51,7 @@ class BaseModel(nn.Module):
         """Build a new model instance."""
         raise NotImplementedError("Model must implement the build_model method")
 
-    def get_targets(self, sample, net_output):
+    def get_targets(self, sample):
         """Get targets from either the sample or the net's output."""
         return sample["target"]
 

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -57,7 +57,7 @@ class BaseModel(nn.Module):
     def get_normalized_probs(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
         return self.get_normalized_probs_scriptable(net_output, log_probs)
@@ -69,7 +69,7 @@ class BaseModel(nn.Module):
     def get_normalized_probs_scriptable(
         self,
         net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool
+        log_probs: bool,
     ):
         """Scriptable helper function for get_normalized_probs in ~BaseModel"""
         if hasattr(self, "decoder"):

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -7,7 +7,6 @@ Base classes for various metaseq models.
 """
 
 import logging
-from argparse import Namespace
 from typing import Dict, List, Optional, Tuple
 
 import torch

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -52,7 +52,7 @@ class BaseModel(nn.Module):
         raise NotImplementedError("Model must implement the build_model method")
 
     def get_targets(self, sample):
-        """Get targets from either the sample or the net's output."""
+        """Get targets from sample."""
         return sample["target"]
 
     def get_normalized_probs(
@@ -94,21 +94,6 @@ class BaseModel(nn.Module):
     def max_positions(self):
         """Maximum length supported by the model."""
         return None
-
-    def load_state_dict(
-        self,
-        state_dict,
-        strict=True,
-        model_cfg: Optional[DictConfig] = None,
-        args: Optional[Namespace] = None,
-    ):
-        """Copies parameters and buffers from *state_dict* into this module and
-        its descendants.
-
-        Overrides the method in :class:`nn.Module`. Compared with that method
-        this additionally "upgrades" *state_dicts* from old checkpoints.
-        """
-        return super().load_state_dict(state_dict, strict)
 
     def set_num_updates(self, num_updates):
         """State from trainer to pass along to model at every update."""

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -233,59 +233,6 @@ class TransformerEncoder(BaseEncoder):
             "l_aux": l_aux,
         }
 
-    @torch.jit.export
-    def reorder_encoder_out(self, encoder_out: Dict[str, List[Tensor]], new_order):
-        """
-        Reorder encoder output according to *new_order*.
-
-        Args:
-            encoder_out: output from the ``forward()`` method
-            new_order (LongTensor): desired order
-
-        Returns:
-            *encoder_out* rearranged according to *new_order*
-        """
-        if len(encoder_out["encoder_out"]) == 0:
-            new_encoder_out = []
-        else:
-            new_encoder_out = [encoder_out["encoder_out"][0].index_select(1, new_order)]
-        if len(encoder_out["encoder_padding_mask"]) == 0:
-            new_encoder_padding_mask = []
-        else:
-            new_encoder_padding_mask = [
-                encoder_out["encoder_padding_mask"][0].index_select(0, new_order)
-            ]
-        if len(encoder_out["encoder_embedding"]) == 0:
-            new_encoder_embedding = []
-        else:
-            new_encoder_embedding = [
-                encoder_out["encoder_embedding"][0].index_select(0, new_order)
-            ]
-
-        if len(encoder_out["src_tokens"]) == 0:
-            src_tokens = []
-        else:
-            src_tokens = [(encoder_out["src_tokens"][0]).index_select(0, new_order)]
-
-        if len(encoder_out["src_lengths"]) == 0:
-            src_lengths = []
-        else:
-            src_lengths = [(encoder_out["src_lengths"][0]).index_select(0, new_order)]
-
-        encoder_states = encoder_out["encoder_states"]
-        if len(encoder_states) > 0:
-            for idx, state in enumerate(encoder_states):
-                encoder_states[idx] = state.index_select(1, new_order)
-
-        return {
-            "encoder_out": new_encoder_out,  # T x B x C
-            "encoder_padding_mask": new_encoder_padding_mask,  # B x T
-            "encoder_embedding": new_encoder_embedding,  # B x T x C
-            "encoder_states": encoder_states,  # List[T x B x C]
-            "src_tokens": src_tokens,  # B x T
-            "src_lengths": src_lengths,  # B x 1
-        }
-
     def max_positions(self):
         """Maximum input length supported by the encoder."""
         if self.embed_positions is None:

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -574,6 +574,7 @@ class TransformerDecoder(IncrementalDecoder):
 
         return x, embed, positions
 
+    # forward for TransformerDecoder
     def forward(
         self,
         prev_output_tokens,

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -181,7 +181,7 @@ class SequenceGenerator(nn.Module):
         model_out[0].div_(self.temperature, rounding_mode="trunc")
         # lprobs is the log probability of each possible token in every position
         # lprobs \in FloatTensor(bsz * beam_size, prompt_len, vocab_size)
-        lprobs = self.model.get_normalized_probs(model_out, log_probs=True, sample=None)
+        lprobs = self.model.get_normalized_probs(model_out, log_probs=True)
 
         # don't allow generation of eos/pad
         model_out[0][:, :, self.eos] = -math.inf
@@ -250,9 +250,7 @@ class SequenceGenerator(nn.Module):
                 incremental_state=incremental_states,
             )
             model_out[0].div_(self.temperature)
-            lprobs = self.model.get_normalized_probs(
-                model_out, log_probs=True, sample=None
-            )
+            lprobs = self.model.get_normalized_probs(model_out, log_probs=True)
             lprobs = lprobs[:, -1, :]
             if self.need_logprobs:
                 all_lprobs[:, step] = lprobs

--- a/metaseq/sequence_scorer.py
+++ b/metaseq/sequence_scorer.py
@@ -71,7 +71,9 @@ class SequenceScorer(object):
             vocab_dist = []
             for bd, tgt, is_single in batched:
                 sample["target"] = tgt
-                curr_prob = model.get_normalized_probs(bd, log_probs=len(models) == 1).data
+                curr_prob = model.get_normalized_probs(
+                    bd, log_probs=len(models) == 1
+                ).data
                 if is_single:
                     probs = gather_target_probs(curr_prob, orig_target)
                     if self.compute_vocab_dist:

--- a/metaseq/sequence_scorer.py
+++ b/metaseq/sequence_scorer.py
@@ -71,9 +71,7 @@ class SequenceScorer(object):
             vocab_dist = []
             for bd, tgt, is_single in batched:
                 sample["target"] = tgt
-                curr_prob = model.get_normalized_probs(
-                    bd, log_probs=len(models) == 1, sample=sample
-                ).data
+                curr_prob = model.get_normalized_probs(bd, log_probs=len(models) == 1).data
                 if is_single:
                     probs = gather_target_probs(curr_prob, orig_target)
                     if self.compute_vocab_dist:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -485,7 +485,7 @@ class TestIncrementalDecoder(IncrementalDecoder):
         dev = prev_output_tokens.device
         return probs.to(dev), {"attn": [attn.to(dev)]}
 
-    def get_normalized_probs(self, net_output, log_probs, _):
+    def get_normalized_probs(self, net_output, log_probs):
         # the decoder returns probabilities directly
         probs = net_output[0]
         if log_probs:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -436,16 +436,6 @@ class TestEncoder(BaseEncoder):
             src_lengths=None,
         )
 
-    def reorder_encoder_out(self, encoder_out, new_order):
-        return EncoderOut(
-            encoder_out=encoder_out.encoder_out.index_select(0, new_order),
-            encoder_padding_mask=None,
-            encoder_embedding=None,
-            encoder_states=None,
-            src_tokens=None,
-            src_lengths=None,
-        )
-
 
 class TestIncrementalDecoder(IncrementalDecoder):
     def __init__(self, args, dictionary):
@@ -529,16 +519,6 @@ class TestReshapingEncoder(BaseEncoder):
             src_lengths=None,
         )
 
-    def reorder_encoder_out(self, encoder_out, new_order):
-        return EncoderOut(
-            encoder_out=encoder_out.encoder_out.index_select(0, new_order),
-            encoder_padding_mask=None,
-            encoder_embedding=None,
-            encoder_states=None,
-            src_tokens=None,
-            src_lengths=None,
-        )
-
 
 class TestReshapingModel(EncoderDecoderModel):
     def __init__(self, encoder, decoder):
@@ -561,16 +541,6 @@ class TestAdditionalInputEncoder(BaseEncoder):
         assert kwargs["fancy_other_input"] is not None
         return EncoderOut(
             encoder_out=src_tokens,
-            encoder_padding_mask=None,
-            encoder_embedding=None,
-            encoder_states=None,
-            src_tokens=None,
-            src_lengths=None,
-        )
-
-    def reorder_encoder_out(self, encoder_out, new_order):
-        return EncoderOut(
-            encoder_out=encoder_out.encoder_out.index_select(0, new_order),
             encoder_padding_mask=None,
             encoder_embedding=None,
             encoder_states=None,


### PR DESCRIPTION
Following https://github.com/facebookresearch/metaseq/pull/229 and continuing to break down https://github.com/facebookresearch/metaseq/pull/197.

Remove:
* unused `handle_legacy_ln_` method
* unused `reorder_encoder_out` method
* unused `net_outputs` arg in `get_targets`
* redundant `load_state_dict` method (previously needed to override given the added step of "upgrade state dict" to be backwards compatible)
* unused `Namespace` import
* unused `sample` arg from `get_normalized_probs_scriptable` and `get_normalized_probs` methods