### PR TITLE
[api] Fix worker queue logic

### DIFF
--- a/metaseq_cli/interactive_hosted.py
+++ b/metaseq_cli/interactive_hosted.py
@@ -105,8 +105,8 @@ def batching_loop(timeout=100, max_tokens=MAX_BATCH_TOKENS):
                 # batch is empty or under budget
                 batch.append(item)
         except queue.Empty:
+            target_queue = None
             if batch:
-                target_queue = None
                 request_object = {
                     "inputs": [],
                     "min_tokens": [],


### PR DESCRIPTION
**Patch Description**
In #227, we fixed a bug causing unlike-workloads to be batched together, but introduced another. Without resetting the queue outside the if statement, whichever queue was last served would continue to be held onto until work was submitted to it. As a result, no work would be accomplished until someone _happened_ to ask for a generation of that same form.

This fixes our idle loop.

**Testing steps**
Deployed a couple days now.