### PR TITLE
[checkpoint] Fix race condition with blob.

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -381,10 +381,9 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
             checkpoint_path_to_load = save_dir_last
 
     logger.info(f"attempting to load checkpoint from: {checkpoint_path_to_load}")
-    import torch.distributed
-    import metaseq.distributed.utils as dist_utils
 
-    torch.distributed.barrier(dist_utils.get_global_group())
+    # make sure everyone is done downloading their checkpoints before we load
+    dist_utils.global_barrier()
 
     extra_state = trainer.load_checkpoint(
         checkpoint_path_to_load,

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -381,6 +381,11 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
             checkpoint_path_to_load = save_dir_last
 
     logger.info(f"attempting to load checkpoint from: {checkpoint_path_to_load}")
+    import torch.distributed
+    import metaseq.distributed.utils as dist_utils
+
+    torch.distributed.barrier(dist_utils.get_global_group())
+
     extra_state = trainer.load_checkpoint(
         checkpoint_path_to_load,
         reset_optimizer,


### PR DESCRIPTION
**Patch Description**
When downloading checkpoints from blob, we have a race condition where not all checkpoints may have finished downloading to local workers, thus causing an exception. This ensures everyone patiently waits on everyone else.

**Testing steps**
cm3 branch