### PR TITLE
[api] Keep logits in fp32

### DIFF
--- a/metaseq/criterions/cross_entropy.py
+++ b/metaseq/criterions/cross_entropy.py
@@ -86,7 +86,7 @@ class CrossEntropyCriterion(BaseCriterion):
         return loss, sample_size, logging_output
 
     def compute_loss(self, model, net_output, sample, reduce=True):
-        lprobs = model.get_normalized_probs(net_output, log_probs=True)
+        lprobs = model.get_normalized_probs(net_output[0], log_probs=True)
         lprobs = lprobs.view(-1, lprobs.size(-1))
         target = model.get_targets(sample).view(-1)
         loss = nll_loss(

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Optional, Tuple
-
 import torch.nn as nn
 from torch import Tensor
 

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -56,25 +56,16 @@ class BaseDecoder(nn.Module):
         """
         raise NotImplementedError
 
-    def get_normalized_probs(
-        self,
-        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-    ):
+    def get_normalized_probs(self, logits: Tensor, log_probs: bool):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(net_output, log_probs)
+        return self.get_normalized_probs_scriptable(logits, log_probs)
 
     # TorchScript doesn't support super() method so that the scriptable Subclass
     # can't access the base class model in Torchscript.
     # Current workaround is to add a helper function with different name and
     # call the helper function from scriptable Subclass.
-    def get_normalized_probs_scriptable(
-        self,
-        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-    ):
+    def get_normalized_probs_scriptable(self, logits: Tensor, log_probs: bool):
         """Get normalized probabilities (or log probs) from a net's output."""
-        logits = net_output[0]
         if log_probs:
             return utils.log_softmax(logits, dim=-1, onnx_trace=self.onnx_trace)
         else:

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -179,7 +179,8 @@ class SequenceGenerator(nn.Module):
         )
         # normalize
         model_predictions = model_out[0].float()
-        model_predictions.div_(self.temperature)
+        if self.temperature > 0 and self.temperature != 1.0:
+            model_predictions.div_(self.temperature)
         # lprobs is the log probability of each possible token in every position
         # lprobs \in FloatTensor(bsz * beam_size, prompt_len, vocab_size)
         lprobs = self.model.get_normalized_probs(model_predictions, log_probs=True)
@@ -251,7 +252,8 @@ class SequenceGenerator(nn.Module):
                 incremental_state=incremental_states,
             )
             model_predictions = model_out[0].float()
-            model_predictions.div_(self.temperature)
+            if self.temperature > 0 and self.temperature != 1.0:
+                model_predictions.div_(self.temperature)
             lprobs = self.model.get_normalized_probs(model_predictions, log_probs=True)
             lprobs = lprobs[:, -1, :]
             if self.need_logprobs:

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -177,7 +177,10 @@ class SequenceGenerator(nn.Module):
             tokens[:, :start_step],
             incremental_state=incremental_states,
         )
-        # normalize
+        # temperature and normalization
+        # convert to float before the temparture divide to ensure good precision.
+        # Avoid dividing by 1.0 to prevent unnecessary numerical instability
+        # and always log in float
         model_predictions = model_out[0].float()
         if self.temperature > 0 and self.temperature != 1.0:
             model_predictions.div_(self.temperature)
@@ -251,6 +254,7 @@ class SequenceGenerator(nn.Module):
                 tokens[:, : step + 1],
                 incremental_state=incremental_states,
             )
+            # see above for why this must remain float
             model_predictions = model_out[0].float()
             if self.temperature > 0 and self.temperature != 1.0:
                 model_predictions.div_(self.temperature)

--- a/metaseq/sequence_scorer.py
+++ b/metaseq/sequence_scorer.py
@@ -72,7 +72,7 @@ class SequenceScorer(object):
             for bd, tgt, is_single in batched:
                 sample["target"] = tgt
                 curr_prob = model.get_normalized_probs(
-                    bd, log_probs=len(models) == 1
+                    bd[0], log_probs=len(models) == 1
                 ).data
                 if is_single:
                     probs = gather_target_probs(curr_prob, orig_target)

--- a/metaseq/sequence_scorer.py
+++ b/metaseq/sequence_scorer.py
@@ -71,6 +71,8 @@ class SequenceScorer(object):
             vocab_dist = []
             for bd, tgt, is_single in batched:
                 sample["target"] = tgt
+                # note that unlike in sequence generator, we don't need to convert
+                # to float32 because we don't do temperature dividing here
                 curr_prob = model.get_normalized_probs(
                     bd[0], log_probs=len(models) == 1
                 ).data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -485,13 +485,12 @@ class TestIncrementalDecoder(IncrementalDecoder):
         dev = prev_output_tokens.device
         return probs.to(dev), {"attn": [attn.to(dev)]}
 
-    def get_normalized_probs(self, net_output, log_probs):
+    def get_normalized_probs(self, logits, log_probs):
         # the decoder returns probabilities directly
-        probs = net_output[0]
         if log_probs:
-            return probs.log()
+            return logits.log()
         else:
-            return probs
+            return logits
 
     def max_positions(self):
         return self.args.max_decoder_positions


### PR DESCRIPTION
**Patch Description**
This patch keeps our logit scores in fp32 so they are more accurately reported to the user. Has the nice added benefit of fixing a known bug where using temperature 0.1 causes overflow issues.

**Testing steps**
@tbmihailov running evals on this