### PR TITLE
[Cleanup] Delete unused args: 3/N

### DIFF
--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -582,7 +582,6 @@ class TransformerDecoder(IncrementalDecoder):
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
         alignment_layer: Optional[int] = None,
-        alignment_heads: Optional[int] = None,
         src_lengths: Optional[Any] = None,
         return_all_hiddens: bool = False,
         token_embeddings: Optional[torch.Tensor] = None,
@@ -603,8 +602,6 @@ class TransformerDecoder(IncrementalDecoder):
                 applying output layer (default: False).
             alignment_layer (int, optional): return mean alignment over
                 heads at this layer (default: last layer).
-            alignment_heads (int, optional): only average alignment over
-                this many heads (default: all heads).
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
             self_attn_padding_mask (torch.Tensor, optional): precomputed padding
@@ -623,7 +620,6 @@ class TransformerDecoder(IncrementalDecoder):
             encoder_out=encoder_out,
             incremental_state=incremental_state,
             alignment_layer=alignment_layer,
-            alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
         )
@@ -637,7 +633,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         alignment_layer: Optional[int] = None,
-        alignment_heads: Optional[int] = None,
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
@@ -646,7 +641,6 @@ class TransformerDecoder(IncrementalDecoder):
             encoder_out=encoder_out,
             incremental_state=incremental_state,
             alignment_layer=alignment_layer,
-            alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
         )
@@ -657,7 +651,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         alignment_layer: Optional[int] = None,
-        alignment_heads: Optional[int] = None,
         token_embeddings: Optional[Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
@@ -726,9 +719,6 @@ class TransformerDecoder(IncrementalDecoder):
 
         inner_states.append(x)
         if attn is not None:
-            if alignment_heads is not None:
-                attn = attn[:alignment_heads]
-
             # average probabilities over heads
             attn = attn.mean(dim=0)
 

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -581,7 +581,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
-        full_context_alignment: bool = False,
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         src_lengths: Optional[Any] = None,
@@ -602,8 +601,6 @@ class TransformerDecoder(IncrementalDecoder):
                 :ref:`Incremental decoding`
             features_only (bool, optional): only return features without
                 applying output layer (default: False).
-            full_context_alignment (bool, optional): don't apply
-                auto-regressive mask to self-attention (default: False).
             alignment_layer (int, optional): return mean alignment over
                 heads at this layer (default: last layer).
             alignment_heads (int, optional): only average alignment over
@@ -625,7 +622,6 @@ class TransformerDecoder(IncrementalDecoder):
             prev_output_tokens,
             encoder_out=encoder_out,
             incremental_state=incremental_state,
-            full_context_alignment=full_context_alignment,
             alignment_layer=alignment_layer,
             alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
@@ -640,7 +636,6 @@ class TransformerDecoder(IncrementalDecoder):
         prev_output_tokens,
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        full_context_alignment: bool = False,
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         token_embeddings: Optional[torch.Tensor] = None,
@@ -650,7 +645,6 @@ class TransformerDecoder(IncrementalDecoder):
             prev_output_tokens,
             encoder_out=encoder_out,
             incremental_state=incremental_state,
-            full_context_alignment=full_context_alignment,
             alignment_layer=alignment_layer,
             alignment_heads=alignment_heads,
             token_embeddings=token_embeddings,
@@ -662,7 +656,6 @@ class TransformerDecoder(IncrementalDecoder):
         prev_output_tokens,
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        full_context_alignment: bool = False,
         alignment_layer: Optional[int] = None,
         alignment_heads: Optional[int] = None,
         token_embeddings: Optional[Tensor] = None,
@@ -690,7 +683,7 @@ class TransformerDecoder(IncrementalDecoder):
 
         # see IncrementalDecoder for important information about
         # incremental state. Note that it may be an empty dictionary.
-        if not incremental_state and not full_context_alignment:
+        if not incremental_state:
             self_attn_mask = self.buffered_future_mask(x, prev_output_tokens)
         else:
             self_attn_mask = None

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -54,9 +54,7 @@ class TransformerEncoder(BaseEncoder):
         embed_dim = embed_tokens.embedding_dim
         self.padding_idx = embed_tokens.padding_idx
         self.max_source_positions = args.max_source_positions
-
         self.embed_tokens = embed_tokens
-
         self.embed_scale = 1.0 if args.no_scale_embedding else math.sqrt(embed_dim)
 
         self.embed_positions = (
@@ -285,17 +283,13 @@ class TransformerDecoder(IncrementalDecoder):
             self.dropout_module = None
 
         self.share_input_output_embed = args.share_decoder_input_output_embed
-
         input_embed_dim = embed_tokens.embedding_dim
         embed_dim = args.decoder_embed_dim
         self.embed_dim = embed_dim
         self.output_embed_dim = args.decoder_output_dim
-
         self.padding_idx = embed_tokens.padding_idx
         self.max_target_positions = args.max_target_positions
-
         self.embed_tokens = embed_tokens
-
         self.embed_scale = 1.0 if args.no_scale_embedding else math.sqrt(embed_dim)
 
         self.project_in_dim = (
@@ -324,6 +318,7 @@ class TransformerDecoder(IncrementalDecoder):
             if args.decoder_learned_pos and not self.use_alibi
             else None
         )
+
         if initialize_params_on_gpu and self.embed_positions is not None:
             self.embed_positions = utils.floating_point_precision_convertor(
                 self.embed_positions.cuda(),
@@ -335,7 +330,6 @@ class TransformerDecoder(IncrementalDecoder):
         self.cross_self_attention = getattr(args, "cross_self_attention", False)
 
         self.layers = nn.ModuleList([])
-
         layers = []
         for i in range(args.decoder_layers):
             layers.append(
@@ -352,7 +346,7 @@ class TransformerDecoder(IncrementalDecoder):
                 0, len(layers), self.args.fsdp_checkpoint_wrap_layer_frequency
             ):
                 layer_block = TransformerDecoderMultiLayerBlockModule(
-                    layers[i : i + self.args.fsdp_checkpoint_wrap_layer_frequency]
+                    layers[i: i + self.args.fsdp_checkpoint_wrap_layer_frequency]
                 )
                 checkpoint = getattr(args, "checkpoint_activations", False)
                 if checkpoint:
@@ -581,7 +575,6 @@ class TransformerDecoder(IncrementalDecoder):
         encoder_out: Optional[Dict[str, List[Tensor]]] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
-        alignment_layer: Optional[int] = None,
         src_lengths: Optional[Any] = None,
         return_all_hiddens: bool = False,
         token_embeddings: Optional[torch.Tensor] = None,
@@ -600,8 +593,6 @@ class TransformerDecoder(IncrementalDecoder):
                 :ref:`Incremental decoding`
             features_only (bool, optional): only return features without
                 applying output layer (default: False).
-            alignment_layer (int, optional): return mean alignment over
-                heads at this layer (default: last layer).
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
             self_attn_padding_mask (torch.Tensor, optional): precomputed padding
@@ -619,7 +610,6 @@ class TransformerDecoder(IncrementalDecoder):
             prev_output_tokens,
             encoder_out=encoder_out,
             incremental_state=incremental_state,
-            alignment_layer=alignment_layer,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
         )
@@ -632,7 +622,6 @@ class TransformerDecoder(IncrementalDecoder):
         prev_output_tokens,
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        alignment_layer: Optional[int] = None,
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
@@ -640,7 +629,6 @@ class TransformerDecoder(IncrementalDecoder):
             prev_output_tokens,
             encoder_out=encoder_out,
             incremental_state=incremental_state,
-            alignment_layer=alignment_layer,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
         )
@@ -650,7 +638,6 @@ class TransformerDecoder(IncrementalDecoder):
         prev_output_tokens,
         encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        alignment_layer: Optional[int] = None,
         token_embeddings: Optional[Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
@@ -659,8 +646,7 @@ class TransformerDecoder(IncrementalDecoder):
         super().extract_features, but super() is not supported in torchscript. A copy
         of this function is made to be used in the subclass instead.
         """
-        if alignment_layer is None:
-            alignment_layer = self.num_layers - 1
+        last_layer_idx = self.num_layers - 1
 
         # compute self-attention padding mask (involves device-to-host transfer,
         # so put it at the top of the forward)
@@ -710,11 +696,11 @@ class TransformerDecoder(IncrementalDecoder):
                 incremental_state=incremental_state,
                 self_attn_mask=self_attn_mask,
                 self_attn_padding_mask=self_attn_padding_mask,
-                need_attn=bool((idx == alignment_layer)),
-                need_head_weights=bool((idx == alignment_layer)),
+                need_attn=bool((idx == last_layer_idx)),
+                need_head_weights=bool((idx == last_layer_idx)),
             )
             l_aux.append(l_aux_i)
-            if layer_attn is not None and idx == alignment_layer:
+            if layer_attn is not None and idx == last_layer_idx:
                 attn = layer_attn.float().to(x)
 
         inner_states.append(x)

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -346,7 +346,7 @@ class TransformerDecoder(IncrementalDecoder):
                 0, len(layers), self.args.fsdp_checkpoint_wrap_layer_frequency
             ):
                 layer_block = TransformerDecoderMultiLayerBlockModule(
-                    layers[i: i + self.args.fsdp_checkpoint_wrap_layer_frequency]
+                    layers[i : i + self.args.fsdp_checkpoint_wrap_layer_frequency]
                 )
                 checkpoint = getattr(args, "checkpoint_activations", False)
                 if checkpoint:


### PR DESCRIPTION
Continuing the breakdown of https://github.com/facebookresearch/metaseq/pull/197

Remove:
* unused `full_context_alignment` arg (always kept as `False`)
* unused `alignment_heads` arg (default all heads)
* unused `char_inputs` arg (controls an `export` flag that isn't ever used)
* unused `alignment_layer` arg (default is always last layer)