### PR TITLE
[Cleanup] Delete unused args - NormFormer: 4/N

### DIFF
--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -179,24 +179,17 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias_dropout_add_func = bias_dropout_add_fused_train
         else:
             bias_dropout_add_func = bias_dropout_add_fused_inference
+
         if self.c_attn is not None:
             # NormFormer Head Scaling Logic
             tgt_len, bsz = attn_output.size(0), attn_output.size(1)
             attn_output = attn_output.view(tgt_len, bsz, self.nh, self.head_dim)
             attn_output = torch.einsum("tbhd,h->tbhd", attn_output, self.c_attn)
             attn_output = attn_output.reshape(tgt_len, bsz, self.embed_dim)
-        if self.attn_ln is None:
-            x = bias_dropout_add_func(
-                attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
-            )
-        else:
-            x = torch.nn.functional.dropout(
-                attn_output + attn_bias.view(1, 1, -1),
-                p=self.args.dropout,
-                training=self.training,
-            )
-            x = self.attn_ln(x)
-            x = residual + x
+
+        x = bias_dropout_add_func(
+            attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
+        )
         return x, attn_weights
 
 

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -179,14 +179,6 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias_dropout_add_func = bias_dropout_add_fused_train
         else:
             bias_dropout_add_func = bias_dropout_add_fused_inference
-
-        if self.c_attn is not None:
-            # NormFormer Head Scaling Logic
-            tgt_len, bsz = attn_output.size(0), attn_output.size(1)
-            attn_output = attn_output.view(tgt_len, bsz, self.nh, self.head_dim)
-            attn_output = torch.einsum("tbhd,h->tbhd", attn_output, self.c_attn)
-            attn_output = attn_output.reshape(tgt_len, bsz, self.embed_dim)
-
         x = bias_dropout_add_func(
             attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
         )

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -103,20 +103,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
             "argparse_alias": "--stable-emb",
         },
     )
-    # NormFormer
-    scale_fc: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Insert LayerNorm between fully connected layers",
-        },
-    )
-    scale_attn: Optional[bool] = field(
-        default=False, metadata={"help": "Insert LayerNorm after attention"}
-    )
-    scale_heads: Optional[bool] = field(
-        default=False,
-        metadata={"help": "Learn a scale coefficient for each attention head"},
-    )
 
     # ALiBi
     alibi: bool = field(

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -146,11 +146,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
         default=0.006,
         metadata={"help": "Sigma for megatron initialization"},
     )
-    sync_ln_variance: Optional[bool] = field(
-        default=False,
-        metadata={"help": "sync_ln_variance stats", "argparse_alias": "--sync-ln"},
-    )
-
     no_emb_dropout: Optional[bool] = field(
         default=False, metadata={"help": "Avoid emb dropout for decoder"}
     )

--- a/metaseq/modules/layer_norm.py
+++ b/metaseq/modules/layer_norm.py
@@ -6,9 +6,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from metaseq import distributed_utils as dist_utils
-from typing import Tuple
-import torch.distributed as dist
 
 try:
     from apex.normalization import FusedLayerNorm as _FusedLayerNorm
@@ -49,83 +46,3 @@ class Fp32LayerNorm(nn.LayerNorm):
             self.eps,
         )
         return output.type_as(input)
-
-
-class SyncedModelParallelFusedLayerNorm(nn.Module):
-    def __init__(
-        self,
-        hidden_size,
-        mp_size,
-        mp_rank=0,
-        eps=1e-5,
-        initialize_params_on_gpu=False,
-        use_bias=True,
-        mean_center=True,
-    ):
-        super().__init__()
-        assert hidden_size % mp_size == 0
-        partition_size = hidden_size // mp_size
-        self.use_bias = use_bias
-        self.mean_center = mean_center
-        self.weight = nn.Parameter(torch.ones(partition_size, dtype=torch.float32))
-        self.bias = (
-            nn.Parameter(torch.zeros(partition_size, dtype=torch.float32))
-            if self.use_bias
-            else None
-        )
-        self.variance_epsilon = eps
-        self.mp_world_size = float(dist_utils.get_model_parallel_world_size())
-        self.mp_rank = mp_rank
-        if initialize_params_on_gpu:
-            self.weight.cuda().half()
-            if self.bias is not None:
-                self.bias.cuda().half()
-
-    @staticmethod
-    def get_statistics_from_all_workers(stat, rank, world_size):
-        """Retuns tensor shaped (world_size, *stat_size)"""
-        buffer_size: Tuple[int] = (int(world_size),) + tuple(stat.size())
-        assert isinstance(
-            buffer_size, tuple
-        ), f"b{buffer_size} {world_size} {stat.size()}"
-        buffer = torch.zeros(buffer_size, dtype=stat.dtype, device=stat.device)
-        buffer[rank] = stat
-        dist.all_reduce(buffer, group=dist_utils.get_model_parallel_group())
-        return buffer
-
-    def forward(self, hidden_states):
-        hid_fp32 = hidden_states.float()
-        local_variance = torch.var(hid_fp32, -1, keepdim=True, unbiased=True)
-        local_mean = hid_fp32.mean(-1, keepdim=True)
-        vs = SyncedModelParallelFusedLayerNorm.get_statistics_from_all_workers(
-            local_variance, self.mp_rank, self.mp_world_size
-        )
-        ms = SyncedModelParallelFusedLayerNorm.get_statistics_from_all_workers(
-            local_mean, self.mp_rank, self.mp_world_size
-        )
-        variance, mean = variance_formula(
-            ms, vs, self.mp_world_size, hidden_states.size(-1)
-        )
-        denom = torch.rsqrt(variance + self.variance_epsilon).to(hidden_states.dtype)
-        mean = mean.to(hidden_states.dtype)
-
-        if self.mean_center:
-            hidden_states = (hidden_states - mean) * denom
-        else:
-            hidden_states = hidden_states * denom
-
-        if self.use_bias:
-            return (self.weight * hidden_states) + self.bias
-        else:
-            return self.weight * hidden_states
-
-
-def variance_formula(means, vs, g, k) -> Tuple[torch.Tensor]:
-    """This only works with unbiased=False (No Bessel Correction)"""
-    d = g * k
-    var_ej = means.var(0)  # Need unbiased True here (at least in  toy example)
-    summation = vs.sum(0)
-    inner_coeff: float = (k * (g - 1)) / (k - 1)
-    outer_coeff: float = (k - 1) / (d - 1)
-    out: torch.Tensor = outer_coeff * (summation + (inner_coeff * var_ej))
-    return out, means.mean(0)

--- a/metaseq/modules/transformer_layer.py
+++ b/metaseq/modules/transformer_layer.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from metaseq import distributed_utils as dist_utils, utils
+from metaseq import utils
 from metaseq.modules import gelu, MultiheadAttention
 from metaseq.modules.dropout import Dropout
 from metaseq.modules.fused_bias_gelu import (
@@ -18,7 +18,7 @@ from metaseq.modules.fused_bias_gelu import (
     has_fused_bias_gelu,
     load_megatron_fused_kernel,
 )
-from metaseq.modules.layer_norm import LayerNorm, SyncedModelParallelFusedLayerNorm
+from metaseq.modules.layer_norm import LayerNorm
 from metaseq.modules.linear import Linear
 
 


### PR DESCRIPTION
Continuing to break down https://github.com/facebookresearch/metaseq/pull/197

* Removed `scale_fc`, `scale_attn`, and `scale_heads` flags that were brought in as part of Normformer - might have to bring scale_fc back later, but hoping to clean up configuration / flags before then.
* Removed `sync_ln_variance` which was brought in to speed up NormFormer when we went tensor parallel.