### PR TITLE
[Cleanup] Delete unused args / classes - Adam8Bit: 5/N

### DIFF
--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -179,7 +179,6 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias_dropout_add_func = bias_dropout_add_fused_train
         else:
             bias_dropout_add_func = bias_dropout_add_fused_inference
-
         x = bias_dropout_add_func(
             attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
         )

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -179,6 +179,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias_dropout_add_func = bias_dropout_add_fused_train
         else:
             bias_dropout_add_func = bias_dropout_add_fused_inference
+
         x = bias_dropout_add_func(
             attn_output, attn_bias.view(1, 1, -1), residual, self.args.dropout
         )

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -96,14 +96,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
             )
         },
     )
-    use_stable_embedding: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Use bitsandbytes StableEmbeddingLayer which saves embedding state in fp32",
-            "argparse_alias": "--stable-emb",
-        },
-    )
-
     # ALiBi
     alibi: bool = field(
         default=False,
@@ -192,24 +184,14 @@ class TransformerLanguageModel(LanguageModel):
 
     @classmethod
     def build_embedding(cls, args, dictionary, embed_dim, path=None):
-        if getattr(args, "use_stable_embedding", False):
-            import bitsandbytes as bnb
-
-            if not args.no_scale_embedding:
-                logger.warning(
-                    "It is recommended to pass --no-scale-embedding with --use-stable-embedding"
-                )
-            return bnb.nn.StableEmbedding(len(dictionary), embed_dim, dictionary.pad())
-
-        else:
-            return Embedding(
-                len(dictionary),
-                embed_dim,
-                dictionary.pad(),
-                initialize_params_on_gpu=getattr(
-                    args, "tensor_parallel_init_model_on_gpu", False
-                ),
-            )
+        return Embedding(
+            len(dictionary),
+            embed_dim,
+            dictionary.pad(),
+            initialize_params_on_gpu=getattr(
+                args, "tensor_parallel_init_model_on_gpu", False
+            ),
+        )
 
 
 def base_lm_architecture(args):

--- a/metaseq/optim/adam.py
+++ b/metaseq/optim/adam.py
@@ -90,42 +90,6 @@ class MetaseqAdam(BaseOptimizer):
         }
 
 
-@register_optimizer("adam8bit", dataclass=MetaseqAdamConfig)
-class MetaseqAdam8Bit(BaseOptimizer):
-    def __init__(self, cfg: DictConfig, params):
-        super().__init__(cfg)
-        try:
-            import bitsandbytes as bnb
-        except ImportError:
-            raise ImportError(
-                "adam8bit requires bits and bytes: see https://gist.github.com/TimDettmers/c4ffe346f095ee4481aa3d4b4ad2ffe0"
-            )
-        bnb.optim.GlobalOptimManager.get_instance().register_parameters(params)
-        self._optimizer = bnb.optim.Adam(
-            params, optim_bits=8, **self.optimizer_config
-        )  # equivalent
-
-    @property
-    def optimizer_config(self):
-        return {
-            "lr": self.cfg.lr[0]
-            if isinstance(self.cfg.lr, Collection)
-            else self.cfg.lr,
-            "betas": eval(self.cfg.adam_betas),
-            "eps": self.cfg.adam_eps,
-            "weight_decay": self.cfg.weight_decay,
-            "block_wise": self.cfg.block_wise,
-        }
-
-    @property
-    def supports_memory_efficient_fp16(self):
-        return True
-
-    @property
-    def supports_flat_params(self):
-        return True
-
-
 class Adam(torch.optim.Optimizer):
     r"""Implements Adam algorithm.
 

--- a/metaseq/optim/adam.py
+++ b/metaseq/optim/adam.py
@@ -37,10 +37,6 @@ class MetaseqAdamConfig(MetaseqDataclass):
     )
     # TODO common vars below in parent
     lr: List[float] = II("optimization.lr")
-    block_wise: bool = field(
-        default=False,
-        metadata={"help": "Enables block-wise optimization for 8-bit Adam"},
-    )
 
 
 @register_optimizer("adam", dataclass=MetaseqAdamConfig)

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -70,13 +70,7 @@ class Trainer(object):
                     "Please update to fairscale 0.4.0 or newer when combining "
                     "--update-freq with FullyShardedDataParallel"
                 )
-            if self.cfg.optimizer == "adam8bit":
-                assert (
-                    self.use_sharded_state
-                ), "adam8bit + FSDP requires --use-sharded-state"
             if self.use_sharded_state:
-                import fairscale
-
                 assert (
                     fairscale.__version__ >= "0.3.9"
                 ), "--use-sharded-state requires newer fairscale. pip install -U fairscale"


### PR DESCRIPTION
Continuing to break down https://github.com/facebookresearch/metaseq/pull/197

(Base branch will switch/be rebased to main once https://github.com/facebookresearch/metaseq/pull/251 is merged)

Removing Adam8bit and stable-emb/block-wise flags which were brought in together in https://github.com/fairinternal/fairseq-py/pull/2063 .