### PR TITLE
[bf16] Don't convert weights to fp16 during load

### DIFF
--- a/metaseq/file_io.py
+++ b/metaseq/file_io.py
@@ -216,7 +216,9 @@ def torch_load_cpu(path):
         return state
     if "cfg" in state:
         state["cfg"] = recursively_cast_dictconfigs(state["cfg"])
-        if (
+        if state["cfg"]["common"]["bf16"]:
+            state["model"] = {k: v.bfloat16() for k, v in state["model"].items()}
+        elif (
             state["cfg"]["common"]["fp16"]
             or state["cfg"]["common"]["memory_efficient_fp16"]
         ):


### PR DESCRIPTION
**Patch Description**
There's a known bug where training on bf16 and then requeuing will result in the model temporarily being converted to fp16, causing potential noise issues. This avoids this conversion.

This likely explains why some users are seeing some loss explosions after they requeue.

**Testing steps**
Launched the API and manually checked the code path taken.