### PR TITLE
Flash Attention

### DIFF
--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -518,16 +518,12 @@ class ModelParallelMultiheadAttention(nn.Module):
             with get_cuda_rng_tracker().fork():
                 attn_probs = self.dropout_module(attn_weights)
 
-        # logger.info("attn_probs:" + str(attn_probs.float().norm().item()))
         assert v is not None
-        # attn = torch.bmm(attn_probs, v)
 
-        attn = xops.memory_efficient_attention(q, k, v)
-        import metaseq.pdb
+        attn = xops.memory_efficient_attention(
+            q, k, v, attn_bias=xops.LowerTriangularMask()
+        )
 
-        # metaseq.pdb.set_trace_rank0()
-
-        # logger.info("attn:" + str(attn.float().norm().item()))
         assert list(attn.size()) == [
             tgt_len,
             bsz * self.num_heads_partition,

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -335,10 +335,9 @@ class ModelParallelMultiheadAttention(nn.Module):
             k, _ = self.k_proj(key)
             v, _ = self.v_proj(value)
 
-        # Megatron's fused kernel: "ScaledUpperTriangMaskedSoftmax" seems to
-        # crash with odd shape across seq_len dimension.  This is okay for
-        # training cause training we have all seq_len nice power of 2s but
-        # during evaluation and generation, we have seq_lens not power of 2.
+        # Megatron's fused kernel: "ScaledUpperTriangMaskedSoftmax" seems to crash with odd shape across seq_len dimension.
+        # This is okay for training cause training we have all seq_len nice power of 2s but during evaluation and generation,
+        # we have seq_lens not power of 2.
         CHANGES = not getattr(self, "inference", False)
 
         if CHANGES:
@@ -358,47 +357,6 @@ class ModelParallelMultiheadAttention(nn.Module):
                     .view(-1, bsz * self.num_heads_partition, self.head_dim)
                     .transpose(0, 1)
                 )
-            # matmul_result = torch.empty(
-            #     output_size[0] * output_size[1],
-            #     output_size[2],
-            #     output_size[3],
-            #     dtype=q.dtype,
-            #     device=torch.cuda.current_device(),
-            # )
-
-            # Scale q,k before matmul for stability see https://tinyurl.com/sudb9s96 for math
-            # matmul_result = torch.baddbmm(
-            #     matmul_result,
-            #     math.sqrt(self.scaling) * q.transpose(0, 1),  # [b * np, sq, hn]
-            #     math.sqrt(self.scaling)
-            #     * k.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
-            #     beta=0.0,
-            # )
-
-            # # Replace any non-finite values with finite equivalents, since otherwise
-            # # we may get NaN when adding attn_mask or computing softmax.
-            # if attn_mask is not None:
-            #     matmul_result = torch.nan_to_num(matmul_result)
-
-            # The attn_mask shape can be either seq_length x seq_length, or batch_size x seq_length x seq_length
-            # depending on whether we are broadcasting the same attention mask across the batch, or
-            # masking dynamically based on the data (e.g. for document attention).
-            # If we have a per sequence mask, the condition len(attn_mask.size()) == 3
-            # is true.
-            # if (attn_mask is not None) and (len(attn_mask.size()) == 3):
-            #     # Going back to original scaled_masked_softmax to accomodate
-            #     # non-causal attention masking (use the given input attention)
-            #     attention_scores = matmul_result.view(*output_size)
-            #     attn_mask = attn_mask < -0.5
-            #     attn_mask = attn_mask.unsqueeze(1)
-            #     attn_probs = ScaledMaskedSoftmax.apply(attention_scores, attn_mask, 1.0)
-            #     attn_probs = attn_probs.view(
-            #         output_size[0] * output_size[1], output_size[2], output_size[3]
-            #     )
-            # else:
-            #     attn_probs = ScaledUpperTriangMaskedSoftmax.apply(matmul_result, 1.0)
-            # with get_cuda_rng_tracker().fork():
-            #     attn_probs = self.dropout_module(attn_probs)
 
         else:
             q *= self.scaling
@@ -479,12 +437,11 @@ class ModelParallelMultiheadAttention(nn.Module):
             ]
 
             if attn_mask is not None:
-                # The attn_mask shape can be either seq_length x seq_length, or
-                # batch_size x seq_length x seq_length depending on whether we
-                # are broadcasting the same attention mask across the batch, or
-                # masking dynamically based on the data (e.g. for document
-                # attention).  If we have a per sequence mask, the condition
-                # len(attn_mask.size()) == 3 is true.
+                # The attn_mask shape can be either seq_length x seq_length, or batch_size x seq_length x seq_length
+                # depending on whether we are broadcasting the same attention mask across the batch, or
+                # masking dynamically based on the data (e.g. for document attention).
+                # If we have a per sequence mask, the condition len(attn_mask.size()) == 3
+                # is true.
                 if len(attn_mask.size()) == 3:
                     attn_mask = attn_mask.unsqueeze(1)
                     attn_mask = attn_mask.repeat(1, self.num_heads_partition, 1, 1)


### PR DESCRIPTION
# Update: buggy. These results are invalid.

**Patch Description**
Switches us to flashattention. Did it quick and dirty to test.

**Experimental Setup**
Tried launching the 2.7B OPT baseline on 64 gpus. Observed that flashattention didn't like this, because its dimensionality of the attention heads is 40, and flashattention only supports 32/64/128. Resolved this by swapping # heads and head dimension, so that we have 40 heads in R^32 instead of 32 heads in R^40.

To control for this, launched 3 versions:
* (green) Our Megatron-based attention implementation, with the original OPT setup
* (orange) A Megatron-based attention implementation with 40 heads in R^32
* (purple) Flash attention based with 40 heads in R^32

**Results**
We observe the flash attention _significantly_ reduces memory usage:

<img width="367" alt="image" src="https://user-images.githubusercontent.com/31896/181028043-e7a413e3-5ff2-4be4-b4ca-b238cd8e58a4.png">

We observe that flash attention significantly increases throughput:
<img width="367" alt="image" src="https://user-images.githubusercontent.com/31896/181028161-a581956c-eae7-496b-a0e8-d71b6f90522f.png">

I was quite surprised by how extreme this speedup is. Based on other's reports and the known FLOPS ratio, it should've been closer to 1.1x, not the 1.6x we're observing. Perhaps the key is that we get to avoid the transpose now? Our FLOPS/GPU aren't particularly high in any of these cases: the baseline is 77 TFLOPS/GPU and flash attention is 128 TFLOPS/GPU, neither of which is particularly _great_. We did not spend very much time ever optimizing the 2.7B, but it seems like we must be doing something really bad with it.

But here's the downside. It seems to significantly hurt stability and decrease convergence
<img width="745" alt="image" src="https://user-images.githubusercontent.com/31896/181028934-3aac7d3b-0a86-44a8-93b1-b88970f698ff.png">

Unfortunately, unless the stability is resolved, I can't recommend flash attention replace our current implementation.

**Next steps**
A version based on the triton implementation is likely preferable.