### PR TITLE
fixing opt loading

### DIFF
--- a/metaseq/file_io.py
+++ b/metaseq/file_io.py
@@ -216,7 +216,7 @@ def torch_load_cpu(path):
         return state
     if "cfg" in state:
         state["cfg"] = recursively_cast_dictconfigs(state["cfg"])
-        if state["cfg"]["common"]["bf16"]:
+        if state["cfg"]["common"].get("bf16", False):
             state["model"] = {k: v.bfloat16() for k, v in state["model"].items()}
         elif (
             state["cfg"]["common"]["fp16"]


### PR DESCRIPTION
**Patch Description**
PR(https://github.com/facebookresearch/metaseq/pull/254) broke loading of old OPT model, this commit fixs it. 

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
