### PR TITLE
updated to ensure cat happens on CUDA

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -733,7 +733,7 @@ def _merge_flat_fsdp_shards(shards_to_load: List[Dict], unpad=False) -> Dict:
         dtype = shards_to_load[0]["model"][k].dtype
         if "flat_param" in k:
             pad_info_k = pad_info[k]
-            catted = torch.cat([x["model"][k] for x in shards_to_load])
+            catted = torch.cat([x["model"][k].cuda() for x in shards_to_load])
             if world_size == 1 and pad_info_k > 0:
                 catted = catted[:-pad_info_k]
             elif world_size > 1 and pad_info_k > 0 and not unpad:


### PR DESCRIPTION
**Patch Description**
Observed during evaluating some models that the torch.cat operation in L732 took up 11.98GB of CPU memory. Used debugger to confirm that this was indeed because all tensors in shards_to_load function was on CPU. Because of this CPU operation, model loading using this function was slower than it needed to be. This speeds that up. 


**Testing steps**
Observed memory traces generated using profiler. Made changes and saw that model loading time using this function dropped anywhere between 10-15% given the same baseline conditions.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
