### PR TITLE
loading model as it is trained

### DIFF
--- a/gpu_tests/test_hf_compatibility.py
+++ b/gpu_tests/test_hf_compatibility.py
@@ -40,8 +40,8 @@ def load_mp_model_and_run_eval(cfg: MetaseqConfig, **kwargs):
     task = tasks.setup_task(cfg.task)
 
     def _build_model(cfg, task):
-        # hardcoded to cpu & fp16
-        model = task.build_model(cfg.model).half().cuda()
+        cfg.model.tensor_parallel_init_model_on_gpu = True
+        model = task.build_model(cfg.model).cuda()
         return fsdp_wrap(model)
 
     with fsdp_enable_wrap(

--- a/metaseq/file_io.py
+++ b/metaseq/file_io.py
@@ -216,13 +216,6 @@ def torch_load_cpu(path):
         return state
     if "cfg" in state:
         state["cfg"] = recursively_cast_dictconfigs(state["cfg"])
-        if state["cfg"]["common"].get("bf16", False):
-            state["model"] = {k: v.bfloat16() for k, v in state["model"].items()}
-        elif (
-            state["cfg"]["common"]["fp16"]
-            or state["cfg"]["common"]["memory_efficient_fp16"]
-        ):
-            state["model"] = {k: v.half() for k, v in state["model"].items()}
 
     return state
 

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -493,7 +493,7 @@ class GeneratorInterface:
         task = tasks.setup_task(self.cfg.task)
 
         def _build_model(cfg, task):
-            model = task.build_model(cfg.model).half().cuda()
+            model = task.build_model(cfg.model).cuda()
             model.make_generation_fast_()
             return fsdp_wrap(model)
 

--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -103,7 +103,7 @@ def worker_main(cfg: MetaseqConfig):
 
     def _build_model(cfg, task):
         # hardcoded to cpu & fp16
-        model = task.build_model(cfg.model).half().cuda()
+        model = task.build_model(cfg.model).cuda()
         return fsdp_wrap(model)
 
     with fsdp_enable_wrap(

--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -102,7 +102,7 @@ def worker_main(cfg: MetaseqConfig):
     task = tasks.setup_task(cfg.task)
 
     def _build_model(cfg, task):
-        # hardcoded to cpu & fp16
+        cfg.model.tensor_parallel_init_model_on_gpu = True
         model = task.build_model(cfg.model).cuda()
         return fsdp_wrap(model)
 

--- a/metaseq/scripts/reshard_mp.py
+++ b/metaseq/scripts/reshard_mp.py
@@ -98,7 +98,6 @@ def reshard_mp(
 
     local_state_dicts: List[dict] = [{} for _ in range(target_ddp_size)]
     for k, v in model_state.items():
-        v = v.half()
         if "flat_param" not in k:
             dummy_model_state[k] = v
             continue


### PR DESCRIPTION
**Patch Description**
Fixing [issue #276](https://github.com/facebookresearch/metaseq/issues/276). Converting model data type when loading states is dangerous. Our model is saved as it is trained, so there is no need to further change the datatype when loading correctly saved models . 

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
