### PR TITLE
fix valid subset when benchmarking

### DIFF
--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -155,9 +155,12 @@ def get_grid(args):
 
     no_save_params = args.no_save_dir
     args.snapshot_code = True
+
+    if args.data is None and not args.benchmark:
+        grid += [hyperparam("--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets))]
+
     grid += [
         hyperparam("--train-subset", "train"),
-        hyperparam("--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets)),
         hyperparam("--ignore-unused-valid-subsets"),
         hyperparam("--num-workers", 8),
         hyperparam("--num-workers-valid", 1),

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -157,7 +157,11 @@ def get_grid(args):
     args.snapshot_code = True
 
     if args.data is None and not args.benchmark:
-        grid += [hyperparam("--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets))]
+        grid += [
+            hyperparam(
+                "--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets)
+            )
+        ]
 
     grid += [
         hyperparam("--train-subset", "train"),


### PR DESCRIPTION
**Patch Description**
fix #287 
When I test training code and enabled benchmarking, it will throw `valid_subsets` referenced before assignment error

Command:
```
opt-baselines -n 1 -g 8 -p test_v0 --model-size 125m --aws --benchmark --checkpoints-dir /fsx/metaseq_models/ --no-save-dir
```


Error:
```
4:     hyperparam("--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets)),
4: UnboundLocalError
4: : local variable 'valid_subsets' referenced before assignment
```

**Testing steps**

After this fix works fine with `--benchmark` argument

Considerations before submitting:

- [x] Was this discussed/approved via a Github issue?
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
