### PR TITLE
moving future_mask to cuda for document attenion

### DIFF
--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -724,7 +724,7 @@ class TransformerDecoder(IncrementalDecoder):
         if need_to_make_new_mask:
             self._future_mask = torch.triu(
                 utils.fill_with_neg_inf(torch.zeros([max_seq_len, max_seq_len])), 1
-            )
+            ).to(tensor)
             if self.self_attn_doc_sep != UNSPECIFIED_DOC_SEP:
                 # Code to accomodate dynamic attention when document seperator is used
                 assert input_tokens is not None

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.nn as nn
 from torch import Tensor
-import time
 from metaseq.dataclass.constants import UNSPECIFIED_DOC_SEP
 
 from metaseq import utils

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.nn as nn
 from torch import Tensor
-
+import time
 from metaseq.dataclass.constants import UNSPECIFIED_DOC_SEP
 
 from metaseq import utils
@@ -723,8 +723,11 @@ class TransformerDecoder(IncrementalDecoder):
         # self._future_mask.device != tensor.device is not working in TorchScript. This is a workaround.
         if need_to_make_new_mask:
             self._future_mask = torch.triu(
-                utils.fill_with_neg_inf(torch.zeros([max_seq_len, max_seq_len])), 1
-            ).to(tensor)
+                utils.fill_with_neg_inf(
+                    torch.zeros([max_seq_len, max_seq_len], device=tensor.device)
+                ),
+                1,
+            )
             if self.self_attn_doc_sep != UNSPECIFIED_DOC_SEP:
                 # Code to accomodate dynamic attention when document seperator is used
                 assert input_tokens is not None


### PR DESCRIPTION
**Patch Description**
Moved the future mask to CUDA so that all operations for document attention also take place on CUDA. Refer to issue #285 for context. The speedup offered by this is marginal but over multiple runs may cumulate.

To test, I set attn doc seperator to a random number to trigger the code to enter the branch, and timed it using the methods used in #220. Observed that over 436 calls to the function on CPU it takes 0.42 seconds vs 0.09 seconds on GPU. 

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
