### PR TITLE
fix --benchmark option

### DIFF
--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -74,10 +74,10 @@ def add_extra_options_func(parser):
 def get_grid(args):
     # Infer data path if not given
     DATA_ROOT = ""
+    valid_subsets = VALID_SUBSETS
     if args.data is None and not args.benchmark:
         cluster_env = get_env_from_args(args)
         data_loc_by_env = DATA_LOCATIONS[cluster_env]
-        valid_subsets = VALID_SUBSETS
         if args.circleci:
             data_loc_by_env = "./gpu_tests/circleci"
             valid_subsets = ["BookCorpusFair"]


### PR DESCRIPTION
**Patch Description**
`metaseq.launcher.opt_baselines`'s `--benchmark` option seems to be broken by this commit 1d2d15255db8c5f51165108e53bc40ecb00b73fe


**Testing steps**
### before the change
```
$ python -m metaseq.launcher.opt_baselines --model-size 8m --benchmark -t 1 -g 8 -n 1 -p test-8m1 --azure 
Traceback (most recent call last):
  File "/shared/home/jieru/miniconda3/envs/fairseq-20220503/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/shared/home/jieru/miniconda3/envs/fairseq-20220503/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/shared/home/jieru/fork/metaseq/metaseq/launcher/opt_baselines.py", line 342, in <module>
    cli_main()
  File "/shared/home/jieru/fork/metaseq/metaseq/launcher/opt_baselines.py", line 336, in cli_main
    sweep_main(
  File "/shared/home/jieru/fork/metaseq/metaseq/launcher/sweep.py", line 378, in main
    backend_main(get_grid, postprocess_hyperparams, args)
  File "/shared/home/jieru/fork/metaseq/metaseq/launcher/slurm.py", line 34, in main
    grid = get_grid(args)
  File "/shared/home/jieru/fork/metaseq/metaseq/launcher/opt_baselines.py", line 160, in get_grid
    hyperparam("--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets)),
UnboundLocalError: local variable 'valid_subsets' referenced before assignment
```

### after this commit
```
$ python -m metaseq.launcher.opt_baselines --model-size 8m --benchmark -t 1 -g 8 -n 1 -p test-8m1 --azure 
....

Launched job 84182
Launched 84182
```
Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
