### PR TITLE
Do not save checkpoint in benchmark mode

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -48,6 +48,7 @@ def save_checkpoint(
         save_checkpoint.best = best_function(val_loss, prev_best)
 
     if cfg.no_save:
+        logger.info(f"Not saving checkpoints.")
         return
 
     trainer.consolidate_optimizer()  # TODO(SS): we dont need if no_save_optimizer_state

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -48,7 +48,7 @@ def save_checkpoint(
         save_checkpoint.best = best_function(val_loss, prev_best)
 
     if cfg.no_save:
-        logger.info(f"Not saving checkpoints.")
+        logger.warning(f"Not saving checkpoints.")
         return
 
     trainer.consolidate_optimizer()  # TODO(SS): we dont need if no_save_optimizer_state

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -143,6 +143,9 @@ def get_grid(args):
             hyperparam(
                 "--dict-size", 51200 - 4
             ),  # TODO(susan): what is this -4 sorcery? relic of more nmt things?
+            hyperparam(
+                "--no-save"
+            ),
         ]
         total_updates = 50
         warmup_updates = 50

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -143,9 +143,7 @@ def get_grid(args):
             hyperparam(
                 "--dict-size", 51200 - 4
             ),  # TODO(susan): what is this -4 sorcery? relic of more nmt things?
-            hyperparam(
-                "--no-save"
-            ),
+            hyperparam("--no-save"),
         ]
         total_updates = 50
         warmup_updates = 50


### PR DESCRIPTION
**Patch Description**
thanks @stephenroller for the pointer!

Skip saving the checkpoints in when benchmarking

**Testing steps**
Describe how you tested your changes
tested by running a tiny benchmark
```
python -m metaseq.launcher.opt_baselines --model-size 8m --benchmark -t 1 -g 8 -n 1 -p test-8m --azure
```
verified in `train.log`
```
2022-08-09 23:47:29 | INFO | metaseq.checkpoint_utils | Not saving checkpoints.
```
### update in 23b68a996dd58d2c8c36848651895104d838874f
changed to warning
```
2022-08-10 00:09:03 | WARNING | metaseq.checkpoint_utils | Not saving checkpoints.
```

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->


