### PR TITLE
[metrics] Stop logging pnorm etc.

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -199,13 +199,6 @@ class CommonConfig(MetaseqDataclass):
     new_profiler: bool = field(
         default=False, metadata={"help": "use pytorch profiler (v2)"}
     )
-    dont_log_param_and_grad_norm: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Don't log grad/param norms for each parameter.",
-            "argparse_alias": "--quiet",
-        },
-    )
 
 
 @dataclass

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -31,7 +31,7 @@ from metaseq.dataclass import MetaseqDataclass
 from metaseq.tasks import LegacyTask, register_task
 
 try:
-    from tokenizers import ByteLevelBPETokenizer
+    from tokenizers import ByteLevelBPETokenizer, Tokenizer
 
     has_hf_tokenizers = True
 except ImportError:
@@ -47,6 +47,9 @@ DEFAULT_MULTICORPUS_MAX = -1
 class StreamingLanguageModelingConfig(MetaseqDataclass):
     data: Optional[str] = field(
         default=None, metadata={"help": "path to data directory with JSONL files"}
+    )
+    hf_tokenizer: Optional[str] = field(
+        default="", metadata={"help": "path to a HF tokenizer json file."}
     )
     vocab_filename: Optional[str] = field(
         default="", metadata={"help": "path to bpe-vocab.json"}
@@ -124,9 +127,12 @@ class StreamingLanguageModelingTask(LegacyTask):
         if not has_hf_tokenizers:
             raise ImportError("Please install tokenizers with: pip install tokenizers")
 
-        self.tokenizer = ByteLevelBPETokenizer.from_file(
-            args.vocab_filename, args.merges_filename
-        )
+        if args.hf_tokenizer:
+            self.tokenizer = Tokenizer.from_file(args.hf_tokenizer)
+        else:
+            self.tokenizer = ByteLevelBPETokenizer.from_file(
+                args.vocab_filename, args.merges_filename
+            )
 
         if max(args.update_freq) > 1:
             raise NotImplementedError(


### PR DESCRIPTION
**Patch Description**
These metrics have been clogging our stderr, but they're no longer relevant to us: pnorm/gnorm/etc all getting to zero is an artifact of fp16 having a very poor range for [xmins](https://nhigham.com/2018/12/03/half-precision-arithmetic-fp16-versus-bfloat16/). While this was important (and harrowing) to track before, the switch to bfloat16 has eliminated this concern for us.

**Testing steps**
`2022-08-20 12:47:21 | INFO | train_inner | {"epoch": 1, "actv_norm": "937.49", "pos_norm": "0.701", "tok_norm": "1", "emb_norm": "0.008", "docsperex": "3.82", "loss": "10.436", "ppl": "1385.32", "wps": "419672", "ups": "0.4", "wpb": "1.04858e+06", "bsz": "512", "num_updates": "293", "lr": "9.84874e-05", "gnorm": "1.139", "clip": "100", "train_wall": "2", "cuda_gb_allocated": "14.7", "cuda_gb_reserved": "21.9", "cuda_gb_free": "64.5", "wall": "965"}`