### PR TITLE
[LM] Remove subshards on validation.

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -199,13 +199,6 @@ class CommonConfig(MetaseqDataclass):
     new_profiler: bool = field(
         default=False, metadata={"help": "use pytorch profiler (v2)"}
     )
-    dont_log_param_and_grad_norm: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Don't log grad/param norms for each parameter.",
-            "argparse_alias": "--quiet",
-        },
-    )
 
 
 @dataclass

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -31,7 +31,7 @@ from metaseq.dataclass import MetaseqDataclass
 from metaseq.tasks import LegacyTask, register_task
 
 try:
-    from tokenizers import ByteLevelBPETokenizer
+    from tokenizers import ByteLevelBPETokenizer, Tokenizer
 
     has_hf_tokenizers = True
 except ImportError:
@@ -47,6 +47,9 @@ DEFAULT_MULTICORPUS_MAX = -1
 class StreamingLanguageModelingConfig(MetaseqDataclass):
     data: Optional[str] = field(
         default=None, metadata={"help": "path to data directory with JSONL files"}
+    )
+    hf_tokenizer: Optional[str] = field(
+        default="", metadata={"help": "path to a HF tokenizer json file."}
     )
     vocab_filename: Optional[str] = field(
         default="", metadata={"help": "path to bpe-vocab.json"}
@@ -124,9 +127,12 @@ class StreamingLanguageModelingTask(LegacyTask):
         if not has_hf_tokenizers:
             raise ImportError("Please install tokenizers with: pip install tokenizers")
 
-        self.tokenizer = ByteLevelBPETokenizer.from_file(
-            args.vocab_filename, args.merges_filename
-        )
+        if args.hf_tokenizer:
+            self.tokenizer = Tokenizer.from_file(args.hf_tokenizer)
+        else:
+            self.tokenizer = ByteLevelBPETokenizer.from_file(
+                args.vocab_filename, args.merges_filename
+            )
 
         if max(args.update_freq) > 1:
             raise NotImplementedError(

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -278,7 +278,9 @@ class StreamingLanguageModelingTask(LegacyTask):
         assert min(shards.keys()) == 0
         assert max(shards.keys()) == len(shards) - 1
 
-        shard_idx = ((epoch - 1) // self.args.data_subshard_count) % len(shards)
+        data_subshard_count = self.args.data_subshard_count if split == "train" else 1
+
+        shard_idx = ((epoch - 1) // data_subshard_count) % len(shards)
         cur_shard_str = shards[shard_idx]
         return cur_shard_str
 
@@ -310,6 +312,7 @@ class StreamingLanguageModelingTask(LegacyTask):
 
         # concatenate any jsonl files that are part of the shard
         datasets, corpora = [], []
+        data_subshard_count = self.args.data_subshard_count if split == "train" else 1
         for file in sorted(
             os.listdir(os.path.join(self.args.data, split, cur_shard_str))
         ):
@@ -320,7 +323,7 @@ class StreamingLanguageModelingTask(LegacyTask):
                     path=os.path.join(self.args.data, split, cur_shard_str, file),
                     tokenizer=self._tokenize_one_json,
                     epoch=epoch,
-                    data_subshard_count=self.args.data_subshard_count,
+                    data_subshard_count=data_subshard_count,
                 )
             )
             corpora.append(os.path.splitext(file)[0])


### PR DESCRIPTION
**Patch Description**
#189 added support for subshards, which is important for creating smaller shards (virtually) and allowing faster rewinding of dataloaders. However, subshard values that are reasonable for training (e.g. 50) are not reasonable for validation, as the validation set is much smaller.

This patch makes it so subshards are only enabled in training, and ignored elsewhere.

**Testing steps**
Ran a training run with `--data-subshard-count 50`