### PR TITLE
[jsonl] Fix regression in index building.

### DIFF
--- a/cpu_tests/test_jsonl_dataset.py
+++ b/cpu_tests/test_jsonl_dataset.py
@@ -86,9 +86,8 @@ class TestJsonlDataset(unittest.TestCase):
             assert (
                 len(orig_data) == 6
             )  # it's 6 because we add an extra line of badly formatted json
-            self.assertRaises(
-                json.decoder.JSONDecodeError, JsonlDataset, jsonl_file.name
-            )
+            with self.assertRaises(json.decoder.JSONDecodeError):
+                self._iterate_over_dataset(JsonlDataset(jsonl_file.name))
 
     def _test_jsonl_dataset(self, num_lines, tokenizer=None):
         with tempfile.NamedTemporaryFile() as jsonl_file:

--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -91,9 +91,20 @@ class JsonlDataset(torch.utils.data.Dataset):
         if subshard_idx < 0 or subshard_idx >= len(self.offsets):
             raise IndexError
         f = self._get_mmap()
-        f.seek(self.offsets[subshard_idx])
+        position = self.offsets[subshard_idx]
+        f.seek(position)
         item = f.readline().decode("utf-8")
-        item = json.loads(item)
+        try:
+            item = json.loads(item)
+        except json.decoder.JSONDecodeError:
+            raise json.decoder.JSONDecodeError(
+                doc=self.path,
+                pos=position,
+                msg=(
+                    f"Error while loading JSONL line in file {self.path} at byte "
+                    f"{position}. Contents of line:\n{item}"
+                ),
+            )
         if self.tokenizer is not None:
             item = self.tokenizer(item)
         return item
@@ -128,15 +139,6 @@ class JsonlDataset(torch.utils.data.Dataset):
         line_num = 0
         while True:
             line = f.readline()
-            if line != b"":
-                try:
-                    json.loads(line)
-                except json.decoder.JSONDecodeError:
-                    raise json.decoder.JSONDecodeError(
-                        doc=path,
-                        pos=line_num,
-                        msg=f"Error while loading JSONL file {path} at line {line_num + 1}",
-                    )
             if line == b"":
                 break
             offsets.append(cur)


### PR DESCRIPTION
**Patch Description**
There was a performance regression in the JSONL dataset indexer, where when building the index it parsed the jsonl files when it really just needed start-of-line numbers. This was originally done to skip over bad parses.

This PR returns us to the much older behavior of throwing a hard crash, midway during training, when we come to a bad data point. On the positive side, we still report _where_ the file was bad.

We may need to build a separate validator to deal with bad data parses, but at the end of the day, it doesn't feel like "skipping bad data" is the right thing to do.

**Testing steps**
In progress