### PR TITLE
Fix inclusion of valid subset in opt-baseline

### DIFF
--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -157,7 +157,7 @@ def get_grid(args):
     no_save_params = args.no_save_dir
     args.snapshot_code = True
 
-    if args.data is None and not args.benchmark:
+    if not args.benchmark:
         grid += [
             hyperparam(
                 "--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets)


### PR DESCRIPTION
Brittle logic here, but valid subset currently exists if `args.data` is not None (as in, `args.data` is only None when `args.benchmark` is set ). Without this fix, throws:

```
  File "/shared/home/susanz/repos/metaseq/slurm_snapshot_code_oss/2022-08-20T22_54_06.361518/metaseq/tasks/streaming_language_modeling.py", line 275, in get_shard_str
    int(shard_id) not in shards
ValueError: invalid literal for int() with base 10: 'BookCorpusFair'
```