### PR TITLE
[tboard, QOL] Don't log average train metrics.

### DIFF
--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -351,11 +351,6 @@ def train(
         if should_stop:
             break
 
-    # log end-of-epoch stats
-    logger.info("end of epoch {} (average epoch stats below)".format(epoch_itr.epoch))
-    stats = get_training_stats(metrics.get_smoothed_values("train"))
-    progress.print(stats, tag="train", step=num_updates)
-
     # reset epoch-level meters
     metrics.reset_meters("train")
     return valid_losses, should_stop

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -284,7 +284,6 @@ def train(
     trainer.begin_epoch(epoch_itr.epoch)
     valid_subsets = cfg.dataset.valid_subset.split(",")
     should_stop = False
-    num_updates = trainer.get_num_updates()
     logger.info("Start iterating over samples")
 
     def train(


### PR DESCRIPTION
**Patch Description**
There's an annoying extra tensorboard created from logging average train metrics over the epoch. It's not useful and just creates extra noise.

**Testing steps**
Training models including this change