### PR TITLE
[checkpoints] Don't validate/save after epochs.

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -512,7 +512,7 @@ class CheckpointConfig(MetaseqDataclass):
         default=False, metadata={"help": "don't save models or checkpoints"}
     )
     no_epoch_checkpoints: bool = field(
-        default=False, metadata={"help": "only store last and best checkpoints"}
+        default=False, metadata={"help": "don't store checkpoints at epoch boundaries"}
     )
     no_last_checkpoints: bool = field(
         default=False, metadata={"help": "don't store last checkpoints"}

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -363,9 +363,6 @@ class DatasetConfig(MetaseqDataclass):
         default=False,
         metadata={"help": "do not raise error if valid subsets are ignored"},
     )
-    validate_interval: int = field(
-        default=1, metadata={"help": "validate every N epochs"}
-    )
     validate_interval_updates: int = field(
         default=0, metadata={"help": "validate every N updates"}
     )

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -402,7 +402,11 @@ def validate_and_save(
         )
 
     do_save = (
-        (end_of_epoch and epoch_itr.epoch % cfg.checkpoint.save_interval == 0)
+        (
+            end_of_epoch
+            and epoch_itr.epoch % cfg.checkpoint.save_interval == 0
+            and not cfg.checkpoint.no_epoch_checkpoints
+        )
         or should_stop
         or (
             cfg.checkpoint.save_interval_updates > 0
@@ -416,7 +420,6 @@ def validate_and_save(
         (
             not end_of_epoch and do_save and not cfg.checkpoint.no_best_checkpoints
         )  # validate during mid-epoch saves
-        or (end_of_epoch and epoch_itr.epoch % cfg.dataset.validate_interval == 0)
         or should_stop
         or (
             cfg.dataset.validate_interval_updates > 0


### PR DESCRIPTION
**Patch Description**
Our current logic always validates and saves at the end of an epoch, even when we set flags such that it isn't supposed to. This is because we ignored the "no_epoch_checkpoints" flag, and because the "validate_interval" flag made it impossible (as it's an interval of epochs). I've killed the validate_interval flag and updated the logic appropriately.

**Testing steps**
Been training with this patch.