### PR TITLE
[cleanup] Update some f-strings, change checkpoint naming scheme.

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -70,15 +70,15 @@ def save_checkpoint(
 
     suffix = trainer.checkpoint_suffix
     checkpoint_conds = collections.OrderedDict()
-    checkpoint_conds["checkpoint{}{}.pt".format(epoch, suffix)] = (
+    checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = (
         end_of_epoch and not cfg.no_epoch_checkpoints and epoch % cfg.save_interval == 0
     )
-    checkpoint_conds["checkpoint_{}_{}{}.pt".format(epoch, updates, suffix)] = (
+    checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = (
         not end_of_epoch
         and cfg.save_interval_updates > 0
         and updates % cfg.save_interval_updates == 0
     )
-    checkpoint_conds["checkpoint_best{}.pt".format(suffix)] = (
+    checkpoint_conds["checkpoint_best{suffix}.pt"] = (
         val_loss is not None
         and (
             not hasattr(save_checkpoint, "best")
@@ -96,9 +96,7 @@ def save_checkpoint(
         ] = not hasattr(save_checkpoint, "best") or is_better(
             val_loss, save_checkpoint.best
         )
-    checkpoint_conds[
-        "checkpoint_last{}.pt".format(suffix)
-    ] = not cfg.no_last_checkpoints
+    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = not cfg.no_last_checkpoints
 
     extra_state = {"train_iterator": epoch_itr.state_dict(), "val_loss": val_loss}
     if hasattr(save_checkpoint, "best"):

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -78,7 +78,7 @@ def save_checkpoint(
         and cfg.save_interval_updates > 0
         and updates % cfg.save_interval_updates == 0
     )
-    checkpoint_conds["checkpoint_best{suffix}.pt"] = (
+    checkpoint_conds[f"checkpoint_best{suffix}.pt"] = (
         val_loss is not None
         and (
             not hasattr(save_checkpoint, "best")


### PR DESCRIPTION
**Patch Description**
THIS DEPENDS ON METASEQ-INTERNAL CHANGES.

Right now our checkpoint files have this format:

`checkpoint_7_5500.pt` where `7` is the "epoch" number (for our weird definition of epoch). This is rather annoying when you're _searching_ for a particular checkpoint, as I know I want update 5500, but I have no idea what the epoch number should be. This is made worse with Blob store, which can't handle wildcards in the middle of strings.

This patch changes the format to:

`checkpoint_5500.pt`, stripping the epoch number.


**Testing steps**
My latest checkpoints trained with this!