### PR TITLE
properly loading model

### DIFF
--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -493,6 +493,7 @@ class GeneratorInterface:
         task = tasks.setup_task(self.cfg.task)
 
         def _build_model(cfg, task):
+            cfg.tensor_parallel_init_model_on_gpu = True
             model = task.build_model(cfg.model).cuda()
             model.make_generation_fast_()
             return fsdp_wrap(model)


### PR DESCRIPTION
**Patch Description**
Fix model initialization for some of the OPT models. 

Issue:
Models up to 13B get loaded but run into an error about a half/float mismatch, while 30B model runs fine (see discussion: https://fb.workplace.com/groups/gogogptzusers/permalink/762243555001669/). 

Debugging: 
After loading model from `/data/gpt-z/models/gptz/1.3B/consolidated_mp_2/consolidated.pt` (azure), and print out `[p.dtype for p in model.parameters()]`, it shows a mix of  torch.float16 and torch.float32. 
Found that `cfg.model.tensor_parallel_init_model_on_gpu = False` in 1.3B model (True in 30B model), so  the model is not properly initialized and it fails silently due to dtype auto cast in model.load_state_dict. 

This patch fix it. 

**Testing steps**
Able to launch internactive_cli.py and interactive_hosted.py with the following model path: 
    f"--path /data/gpt-z/models/gptz/2.7B/consolidated_mp_1/consolidated.pt",
    f"--path /data/gpt-z/models/gptz/30B/consolidated_mp_4/reshard.pt",
    f"--path /data/gpt-z/models/gptz/30B/consolidated_mp_2/consolidated.pt",
    f"--path /data/gpt-z/models/gptz/1.3B/consolidated_mp_2/consolidated.pt",

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
