### PR TITLE
BF16 bug fix:

### DIFF
--- a/metaseq/optim/fp16_optimizer.py
+++ b/metaseq/optim/fp16_optimizer.py
@@ -241,7 +241,8 @@ class _FP16OptimizerMixin(object):
 
         if self.scaler is not None:
             self._multiply_factor = 1.0 / float(self.scaler.loss_scale)
-
+        else:
+            self._multiply_factor = 1.0
 
 class FP16Optimizer(_FP16OptimizerMixin, optim.BaseOptimizer):
     """

--- a/metaseq/optim/fp16_optimizer.py
+++ b/metaseq/optim/fp16_optimizer.py
@@ -244,6 +244,7 @@ class _FP16OptimizerMixin(object):
         else:
             self._multiply_factor = 1.0
 
+
 class FP16Optimizer(_FP16OptimizerMixin, optim.BaseOptimizer):
     """
     Wrap an *optimizer* to support FP16 (mixed precision) training.

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -79,7 +79,10 @@ class Trainer(object):
         self._criterion = criterion
         self._model = model
         if not self.is_fsdp:
-            if cfg.common.fp16:
+            if cfg.common.bf16:
+                self._criterion = self._criterion.bfloat16()
+                self._model = self._model.bfloat16()
+            elif cfg.common.fp16:
                 self._criterion = self._criterion.half()
                 self._model = self._model.half()
         if (


### PR DESCRIPTION
### **in non FSDP mode**
when not in FSDP, the model wasn't converted to bf16 although bf16 was set to True.

### **optimizer._multiply_factor reset to 1.0 each step**
In MemoryEfficientFP16Optimizer.zero_grad (that is applied every training step), the model sets  _multiply_factor back to 1.0:
https://github.com/facebookresearch/metaseq/blob/bbcedfebb4c35f71cdda1f1a358491f3996a9fc3/metaseq/optim/fp16_optimizer.py#L452
A similar thing was applied also in the normal FP16Optimizer. 