### PR TITLE
[dist] Force threads=1 when spawning.

### DIFF
--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -187,6 +187,8 @@ def distributed_init(cfg: MetaseqConfig):
 
 
 def distributed_main(i, main, cfg: MetaseqConfig, kwargs):
+    # don't use MKL/OMP to avoid conflicting processes
+    torch.set_num_threads(1)
     if not cfg.distributed_training.distributed_no_spawn:
         # if in local spawning, i is offset by -1 since torch.multiprocessing.spawn
         # always starts at rank 0


### PR DESCRIPTION
**Patch Description**
Some of our consolidation logic is extremely slow: this is due to the concat's happening on CPU, and the default in pytorch is to use OMP threads to parallelize this. However, we already have spawned multiple processes (or slurm did), so all the threads end up fighting and thrashing for the CPUs.

We could do this individually in every script if we wanted to be careful about optimizing for CPU cases, but given that we basically only ever do GPU logic, we can just bake this assumption right into our distributed code.

**Testing steps**
Before change, loading checkpoints pegged all CPUs to 100%. After change, they do not and it runs faster.