### PR TITLE
Changes to support fairseq_v3 megatron branch

### DIFF
--- a/metaseq/modules/fused_bias_gelu.py
+++ b/metaseq/modules/fused_bias_gelu.py
@@ -29,12 +29,16 @@ def load_megatron_fused_kernel():
     from argparse import Namespace
 
     if not torch.distributed.is_initialized():
-        args = Namespace(rank=0, masked_softmax_fusion=True)
+        args = Namespace(
+            rank=0, masked_softmax_fusion=True, gradient_accumulation_fusion=False
+        )
         fused_kernels.load(args)
         return
 
     global_rank = torch.distributed.get_rank()
-    args = Namespace(rank=global_rank, masked_softmax_fusion=True)
+    args = Namespace(
+        rank=global_rank, masked_softmax_fusion=True, gradient_accumulation_fusion=False
+    )
 
     # Always build on rank zero first.
     if global_rank == 0:


### PR DESCRIPTION
**Patch Description**
Changes from https://github.com/facebookresearch/metaseq/pull/300 required to make trainers work with fairseq_v3 Megatron branch.

**Testing steps**
`$ python -m sweep_baseline -g 8 -n 1 -t 1 --azure --model-size 125m --prefix fv3_test --local`
