### PR TITLE
[jsonl] Make skipping entries in the dataloader significantly faster

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install locally
-      run: |
-        python -m pip install --upgrade pip
-        python setup.py build_ext --inplace
-        python -m pip install --editable '.[dev]'
+    # - name: Install locally
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     python setup.py build_ext --inplace
+    #     python -m pip install --editable '.[dev]'
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Lint with flake8
       run: |
+        pip install flake8
         flake8 . --count --exit-zero --statistics
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # - name: Install locally
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     python setup.py build_ext --inplace
-    #     python -m pip install --editable '.[dev]'
+    - name: Install locally
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --editable '.[dev]'
+
+        python setup.py build_ext --inplace
 
     - name: Lint with flake8
       run: |

--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -196,7 +196,7 @@ class TestStreamingIterators(unittest.TestCase):
             value2 = next(iter(dataset2))
             assert torch.allclose(value1["block"], value2["block"])
             # check that we didn't actually query all the dataset to do the fast forward
-            assert fake_dataset2.queried == len(value2["ids"])
+            assert fake_dataset2.queried <= len(value2["ids"]) + 1
 
         run_test(drop_last=True, break_mode="complete")
         run_test(drop_last=False, break_mode="complete")

--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -7,9 +7,9 @@ import unittest
 
 import torch
 
-from metaseq.data import iterators
+from metaseq.data import iterators, StreamingShuffleDataset, StreamingTokenBlockDataset, PartitionedStreamingDataset
 from metaseq.data.deferred import DeferredDataset, SkipDeferredDataset
-
+import random
 
 class TensorListDataset(torch.utils.data.Dataset):
     def __init__(self, tensor_list):
@@ -109,6 +109,84 @@ class TestStreamingIterators(unittest.TestCase):
         assert epoch_batch_itr.end_of_epoch()
         with self.assertRaises(StopIteration):
             next(itr)
+
+    def test_deferred_iterator(self):
+        class FakeTensorData(torch.utils.data.Dataset):
+            def __init__(self):
+                self.rng = random.Random(0)
+                self.trng = torch.Generator()
+                self.trng.manual_seed(0)
+                self.items = [torch.randint(256, size=(self.rng.randrange(512, 8192),), generator=self.trng) for _ in range(len(self))]
+                self.queried = 0
+
+            def __len__(self):
+                return 128
+
+            def __getitem__(self, idx):
+                self.queried += 1
+                return self.items[idx]
+
+            def __iter__(self):
+                for i in range(len(self)):
+                    yield self[i]
+
+        def create_dataset(break_mode="none", drop_last=True, sentence_size=2049, num_shards=1):
+            dataset = FakeTensorData()
+            defer_dataset = DeferredDataset(dataset)
+            shuffle_dataset = StreamingShuffleDataset(defer_dataset, seed=42)
+            shuffle_dataset.set_epoch(0)
+            token_dataset = StreamingTokenBlockDataset(
+                shuffle_dataset,
+                # We generate blocks with one extra token, so that we have a target
+                # for the final input token. This results in slight data loss.
+                block_size=sentence_size,
+                break_mode=break_mode,
+                # we drop the remainder block during training
+                drop_last=drop_last,
+                padding_idx=1,
+                # 1284 is a randomly-generated offset to decouple the seed used here
+                # from the seed used above in StreamingShuffleDataset
+                seed=1284 + 42,
+            )
+            token_dataset.set_shuffle_buffer_size(4)
+            skip_dataset = SkipDeferredDataset(token_dataset, 0)
+            partitioned_dataset = PartitionedStreamingDataset(
+                  skip_dataset,
+                  num_shards=num_shards,
+                  shard_id=0,
+                  drop_last=True,
+            )
+            return partitioned_dataset, dataset, defer_dataset, skip_dataset
+
+        def run_test(drop_last, break_mode):
+            dataset, fake_dataset, defer_dataset, skip_dataset = create_dataset(drop_last=drop_last, break_mode=break_mode)
+            num_iters = 0
+            for i, x in enumerate(dataset):
+                assert isinstance(x['block'], torch.Tensor)
+                assert x['block'].shape[0] == 2049 or (drop_last and x['block'].shape[0] <= 2049) or break_mode == "eos_pad_8"
+                num_iters += 1
+
+            a_fourth = num_iters // 4
+            dataset2, fake_dataset2, defer_dataset2, skip_dataset2 = create_dataset(drop_last=drop_last, break_mode=break_mode)
+
+            defer_dataset2.len_cache = defer_dataset.len_cache
+            skip_dataset2.to_skip = a_fourth
+            value1 = list(dataset)[a_fourth]
+            value2 = next(iter(dataset2))
+            assert torch.allclose(value1['block'], value2['block'])
+            # check that we didn't actually query all the dataset to do the fast forward
+            assert  fake_dataset2.queried == len(value2['ids'])
+
+
+        run_test(drop_last=True, break_mode="complete")
+        run_test(drop_last=False, break_mode="complete")
+
+        run_test(drop_last=True, break_mode="eos_pad_8")
+        run_test(drop_last=False, break_mode="eos_pad_8")
+
+        run_test(drop_last=True, break_mode="none")
+        run_test(drop_last=False, break_mode="none")
+
 
 
 if __name__ == "__main__":

--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -212,7 +212,9 @@ class TestStreamingIterators(unittest.TestCase):
         # number of workers, we have to restore where the first requested batch is from
         # to a worker (n % num_workers) that isn't worker 0. However, DataLoader returns data from worker 0 first.
         # So we shift what each worker thinks its ID is by n so worker 0 will behave as worker (n % num_workers).
-        dataset, fake_dataset, defer_dataset, skip_dataset = create_dataset(drop_last=True, break_mode="none")
+        dataset, fake_dataset, defer_dataset, skip_dataset = create_dataset(
+            drop_last=True, break_mode="none"
+        )
         dataloader1 = torch.utils.data.DataLoader(
             dataset=dataset,
             batch_size=1,
@@ -226,12 +228,14 @@ class TestStreamingIterators(unittest.TestCase):
                 consumed[i % 2] += 1
 
         len_cache = defer_dataset.len_cache
-        dataset, fake_dataset, defer_dataset, skip_dataset = create_dataset(drop_last=True, break_mode="none")
+        dataset, fake_dataset, defer_dataset, skip_dataset = create_dataset(
+            drop_last=True, break_mode="none"
+        )
         defer_dataset.len_cache = len_cache
         skip_dataset.to_skip = consumed
         d = dataset
-        while hasattr(d, 'dataset'):
-            if hasattr(d, 'worker_offset'):
+        while hasattr(d, "dataset"):
+            if hasattr(d, "worker_offset"):
                 d.worker_offset = 7
             d = d.dataset
         dataloader2 = torch.utils.data.DataLoader(
@@ -242,8 +246,7 @@ class TestStreamingIterators(unittest.TestCase):
             drop_last=True,
         )
         first = next(iter(dataloader2))
-        assert torch.allclose(last['block'], first['block'])
-
+        assert torch.allclose(last["block"], first["block"])
 
     def test_deferred_tensor_memory(self):
         num_deleted = 0
@@ -268,6 +271,7 @@ class TestStreamingIterators(unittest.TestCase):
             num_deleted == 2
         ), "DeferredTensors are still live after realize, maybe a reference cycle?"
         del the_result
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -10,10 +10,12 @@ import torch
 from metaseq.data import iterators
 from metaseq.data.deferred import DeferredDataset, SkipDeferredDataset
 
+
 class TensorListDataset(torch.utils.data.Dataset):
     def __init__(self, tensor_list):
         self.tensor_list = tensor_list
         self.queried = 0
+
     def __len__(self):
         return len(self.tensor_list)
 

--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -142,7 +142,7 @@ class TestStreamingIterators(unittest.TestCase):
                     yield self[i]
 
         def create_dataset(
-            break_mode="none", drop_last=True, sentence_size=2049, num_shards=1
+            break_mode="none", drop_last=True, sequence_size=2049, num_shards=1
         ):
             dataset = FakeTensorData()
             defer_dataset = DeferredDataset(dataset)
@@ -152,7 +152,7 @@ class TestStreamingIterators(unittest.TestCase):
                 shuffle_dataset,
                 # We generate blocks with one extra token, so that we have a target
                 # for the final input token. This results in slight data loss.
-                block_size=sentence_size,
+                block_size=sequence_size,
                 break_mode=break_mode,
                 # we drop the remainder block during training
                 drop_last=drop_last,

--- a/cpu_tests/test_streaming_language_modeling_task.py
+++ b/cpu_tests/test_streaming_language_modeling_task.py
@@ -152,7 +152,9 @@ class TestDatasetLoading(unittest.TestCase):
         match our expectation from the shard/subshard standpoint.
         """
         self.task.load_dataset("train", epoch=epoch)
-        iterated_data = [doc for doc in self.task.dataset("train").dataset.dataset.dataset]
+        iterated_data = [
+            doc for doc in self.task.dataset("train").dataset.dataset.dataset
+        ]
 
         # For a given epoch, the start offset would be
         offset = (epoch - 1) % data_subshard_count

--- a/cpu_tests/test_streaming_language_modeling_task.py
+++ b/cpu_tests/test_streaming_language_modeling_task.py
@@ -152,7 +152,7 @@ class TestDatasetLoading(unittest.TestCase):
         match our expectation from the shard/subshard standpoint.
         """
         self.task.load_dataset("train", epoch=epoch)
-        iterated_data = [doc for doc in self.task.dataset("train").dataset.dataset]
+        iterated_data = [doc for doc in self.task.dataset("train").dataset.dataset.dataset]
 
         # For a given epoch, the start offset would be
         offset = (epoch - 1) % data_subshard_count

--- a/metaseq/data/deferred.cpp
+++ b/metaseq/data/deferred.cpp
@@ -19,7 +19,7 @@ void atomic_read_all(uint64_t dst_ptr, uint64_t src_ptr,  int64_t size) {
     }
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+PYBIND11_MODULE(atomic, m) {
     m.def("atomic_write", atomic_write);
     m.def("atomic_read", atomic_read);
     m.def("atomic_read_all", atomic_read_all);

--- a/metaseq/data/deferred.cpp
+++ b/metaseq/data/deferred.cpp
@@ -1,0 +1,26 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void atomic_write(uint64_t buf_ptr, int idx, int value) {
+    __atomic_store((int*)buf_ptr + idx, &value, __ATOMIC_SEQ_CST);
+}
+
+int atomic_read(uint64_t buf_ptr, int idx) {
+    // on x86 this is just a normal load....
+    int dst;
+    __atomic_load((int*)buf_ptr + idx, &dst, __ATOMIC_SEQ_CST);
+    return dst;
+}
+
+void atomic_read_all(uint64_t dst_ptr, uint64_t src_ptr,  int64_t size) {
+    for (int64_t i = 0; i < size; ++i) {
+        atomic_write(dst_ptr, i, atomic_read(src_ptr, i));
+    }
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("atomic_write", atomic_write);
+    m.def("atomic_read", atomic_read);
+    m.def("atomic_read_all", atomic_read_all);
+}

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -3,15 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import torch
-from torch.utils.cpp_extension import load
 from ctypes import addressof, memset, memmove
 from multiprocessing import Array
 import time
 
-
 from metaseq.data.atomic import atomic_read, atomic_write, atomic_read_all
+
 
 class AtomicArray:
     """

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -195,7 +195,11 @@ class SkipDeferredDataset(torch.utils.data.IterableDataset, _DeferredBase):
             to_skip = self.to_skip
         else:
             info = torch.utils.data.get_worker_info()
-            worker_id = ((0 if info is None else info.id) + self.worker_offset) % info.num_workers
+            worker_id = (
+                0
+                if info is None
+                else ((info.id + self.worker_offset) % info.num_workers)
+            )
             to_skip = self.to_skip[worker_id]
         for i, elem in enumerate(self.dataset):
             if i >= to_skip:

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -100,6 +100,10 @@ class DeferredTensor:
             return SliceDeferredTensor(self, s)
         raise NotImplementedError("non-slice getitem")
 
+    def new_full(self, size_tup, value):
+        assert len(size_tup) == 1, "Unimplemented: multi-dim new_full"
+        return DeferredTensor(size_tup[0], lambda: self.realize().new_full(size_tup, value))
+
     def __torch_function__(self, fn, types, args, kwargs={}):
         if (
             fn is torch.cat

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -186,6 +186,7 @@ class SkipDeferredDataset(torch.utils.data.IterableDataset, _DeferredBase):
     def __init__(self, dataset, to_skip: int):
         self.dataset = dataset
         self.to_skip = to_skip
+        self.worker_offset = 0
 
     def __iter__(self):
         skip_time = 0
@@ -194,7 +195,7 @@ class SkipDeferredDataset(torch.utils.data.IterableDataset, _DeferredBase):
             to_skip = self.to_skip
         else:
             info = torch.utils.data.get_worker_info()
-            worker_id = 0 if info is None else info.id
+            worker_id = ((0 if info is None else info.id) + self.worker_offset) % info.num_workers
             to_skip = self.to_skip[worker_id]
         for i, elem in enumerate(self.dataset):
             if i >= to_skip:

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -10,12 +10,8 @@ from ctypes import addressof, memset, memmove
 from multiprocessing import Array
 import time
 
-deferred_c_src = f"{os.path.dirname(os.path.abspath(__file__))}/deferred.cpp"
-deferred_c = load("deferred", deferred_c_src)
-atomic_read = deferred_c.atomic_read
-atomic_write = deferred_c.atomic_write
-atomic_read_all = deferred_c.atomic_read_all
 
+from metaseq.data.atomic import atomic_read, atomic_write, atomic_read_all
 
 class AtomicArray:
     """

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -48,6 +48,9 @@ class AtomicArray:
         self.__init__(l)
         memmove(addressof(self.data), b, len(b))
 
+    def from_tensor(self, t):
+        memmove(addressof(self.data), t.data_ptr(), len(self.data) * 4)
+
 
 def tree_flatten_instance(r, obj):
     if isinstance(obj, dict):

--- a/metaseq/data/deferred.py
+++ b/metaseq/data/deferred.py
@@ -1,0 +1,182 @@
+
+import os
+import torch
+from torch.utils.cpp_extension import load
+from ctypes import addressof, memset
+from multiprocessing import Array, Process
+from collections import namedtuple
+from typing import NamedTuple
+
+
+deferred_c_src = f'{os.path.dirname(os.path.abspath(__file__))}/deferred.cpp'
+deferred_c = load('deferred', deferred_c_src)
+atomic_read = deferred_c.atomic_read
+atomic_write = deferred_c.atomic_write
+atomic_read_all = deferred_c.atomic_read_all
+
+from tqdm import tqdm
+
+class AtomicArray:
+    """
+    A multi-process array array where the read and write operations are atomic.
+    """
+    def __init__(self, size):
+        self.data = Array('i', size, lock=False)
+        memset(addressof(self.data), 0, 4*size)
+
+    def __getitem__(self, idx):
+        return atomic_read(addressof(self.data), idx)
+
+    def __setitem__(self, idx, value):
+        atomic_write(addressof(self.data), idx, value)
+
+    def __len__(self):
+        return len(self.data)
+
+    def as_array(self):
+        r = Array('i', len(self.data), lock=False)
+        atomic_read_all(addressof(r), addressof(self.data), len(self.data))
+        return r
+
+
+def tree_flatten_instance(r, obj):
+    if isinstance(obj, dict):
+        ctors = [tree_flatten_instance(r, v) for v in obj.values()]
+        keys = list(obj.keys())
+        return lambda n: {k: v(n) for k, v in zip(keys, ctors)}
+    elif isinstance(obj, (list, tuple)):
+        t = type(obj)
+        ctors = [tree_flatten_instance(r, v) for v in obj]
+        return lambda n: t(ctor(n) for ctor in ctors)
+    else:
+        r.append(obj)
+        return next
+
+def tree_flatten(tree):
+    r = []
+    ctor = tree_flatten_instance(r, tree)
+    return r, lambda ns: ctor(iter(ns))
+
+def tree_map(fn, tree):
+    vs, unflatten = tree_flatten(tree)
+    return unflatten(fn(v) for v in vs)
+
+class Deferred:
+    pass
+
+class DeferredTensor(Deferred):
+    def __init__(self, size_or_value, ctor=None):
+        if not isinstance(size_or_value, torch.Tensor):
+            self._size = size_or_value
+            self.ctor = ctor
+        else:
+            self._value = size_or_value
+            assert isinstance(self._value, torch.Tensor)
+            self._size = tuple(self._value.shape)
+        assert isinstance(self._size, tuple)
+    def realize(self):
+        if hasattr(self, 'ctor'):
+            # print("REALIZING...")
+            self._value = self.ctor()
+            del self.ctor
+            assert tuple(self._value.shape) == self._size
+        return self._value
+
+    def numel(self):
+        p = 1
+        for x in self.shape:
+            p *= x
+        return p
+
+    @property
+    def shape(self):
+        return self._size
+
+    def __getitem__(self, s):
+        if isinstance(s, slice) and len(self.shape) == 1:
+            return SliceDeferredTensor(self, s)
+        raise NotImplementedError('non-slice getitem')
+
+    def __torch_function__(self, fn, types, args, kwargs={}):
+        if fn is torch.cat and len(args) == 1 and len(kwargs) == 0 and all(len(x.shape) == 1 for x in args[0]):
+            new_size = (sum(x.shape[0] for x in args[0]),)
+            return DeferredTensor(new_size, lambda: torch.cat(tuple(x.realize() for x in args[0])))
+        raise NotImplementedError(f'Unimplemented: {args}, {kwargs}')
+
+# optimization of slice of slice, because otherwise the tokenization code creates a really deep deferred tensor
+# stack and then reaches max recursion
+class SliceDeferredTensor(DeferredTensor):
+    def __init__(self, to_slice, s):
+        indices = s.indices(to_slice.shape[0])
+        new_size = len(range(*indices))
+        super().__init__((new_size,), lambda: to_slice.realize()[s])
+        self.to_slice = to_slice
+        self.indices = indices
+
+    def __getitem__(self, s):
+        orig_start, _, orig_step = self.indices
+        start, end, step = s.indices(self._size[0])
+        assert orig_step > 0 and step > 0
+        return SliceDeferredTensor(self.to_slice, slice(orig_start + start, orig_start + end, orig_step * step))
+
+class DeferredDataset(torch.utils.data.Dataset):
+    """Generate deferred objects that might not be loaded by later stages in the data loader
+
+    """
+
+    def __init__(self, dataset: torch.utils.data.Dataset, len_cache=None, deferred_type=DeferredTensor):
+        super().__init__()
+        self.dataset = dataset
+        self.deferred_type = deferred_type
+        self.len_cache = AtomicArray(len(self.dataset)) if len_cache is None else len_cache
+        self.enabled = True
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def _progress_bar(self):
+        # just to viz how far into the the dataset we get while running
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info and worker_info.id == 0:
+            # put a hacky progress bar here
+            if not hasattr(self, 't'):
+                self.t = tqdm(total=len(self.dataset))
+            self.t.update(1)
+
+
+    def __getitem__(self, idx):
+        self._progress_bar()
+        if not self.enabled:
+            return self.dataset[idx]
+        assert idx >= 0 and idx < len(self.dataset)
+        l = self.len_cache[idx]
+        if l == 0:
+            # print("MISS ", idx)
+            r = self.deferred_type(self.dataset[idx])
+            assert len(r._size) == 1, "can only cache size of 1-dim tensors..."
+            self.len_cache[idx] = r._size[0]
+            return r
+        # print("HIT ", idx)
+        return self.deferred_type((l,), lambda: self.dataset[idx])
+
+class SkipDeferredDataset(torch.utils.data.IterableDataset):
+    def __init__(self, dataset, to_skip: int):
+        self.dataset = dataset
+        self.to_skip = to_skip
+
+        self.batch_size  = 0 # hack to know how many None to return to get timing information
+
+        self.enabled = True
+
+    def __iter__(self):
+        for i, elem in enumerate(self.dataset):
+            if i >= self.to_skip:
+                yield tree_map(lambda x: x.realize() if isinstance(x, Deferred) else x, elem)
+            else:
+                # the real version will not do this, but we need to return a sentinel to the main
+                # process to stop timing of the skip process for benchmarking
+                # if this is the last one we will skip, return enough None to fill an entire batch,
+                if i + 1 == self.to_skip:
+                    for _ in range(self.batch_size):
+                        yield None # dummy return to time the skip process
+

--- a/metaseq/data/iterators.py
+++ b/metaseq/data/iterators.py
@@ -277,7 +277,7 @@ class StreamingEpochBatchIterator(EpochBatchIterating):
         dataset = self.dataset
         while not isinstance(dataset, DeferredDataset):
             dataset = dataset.dataset
-        logger.info(
+        logger.debug(
             f"Saving state_dict so we can skip workers quickly: {len(dataset.len_cache)} "
             f"entries in tokenization_cache, {sentences_consumed} sentences consumed per worker, iteration {n}"
         )
@@ -327,7 +327,9 @@ class StreamingEpochBatchIterator(EpochBatchIterating):
             ):
                 # fast-forward epoch iterator
                 itr_pos = state_dict["iterations_in_epoch"]
-                logger.info(f"Fast-forwarding dataloader by {itr_pos} batches...")
+                logger.info(
+                    f"Fast-forwarding dataloader by {itr_pos} batches using slower logic because checkpoint does not have a tokenization_cache..."
+                )
                 t0 = time.time()
                 next(itertools.islice(self._itr, itr_pos, itr_pos), None)
                 t1 = time.time()

--- a/metaseq/data/iterators.py
+++ b/metaseq/data/iterators.py
@@ -280,7 +280,7 @@ class StreamingEpochBatchIterator(EpochBatchIterating):
             dataset = dataset.dataset
         logger.debug(
             f"Saving state_dict so we can skip workers quickly: {len(dataset.len_cache)} "
-            f"entries in tokenization_cache, {sequences_consumed} sentences consumed per worker, iteration {n}"
+            f"entries in tokenization_cache, {sequences_consumed} sequences consumed per worker, iteration {n}"
         )
 
         return {
@@ -307,7 +307,7 @@ class StreamingEpochBatchIterator(EpochBatchIterating):
             sequences_consumed = state_dict["sequences_consumed"]
             n = state_dict["n"]
 
-            logger.info(f"Skipping {sequences_consumed} sentences in each worker...")
+            logger.info(f"Skipping {sequences_consumed} sequences in each worker...")
             num_workers = 1 if self.num_workers == 0 else self.num_workers
             assert (
                 len(sequences_consumed) == num_workers

--- a/metaseq/data/streaming_shuffle_dataset.py
+++ b/metaseq/data/streaming_shuffle_dataset.py
@@ -28,6 +28,7 @@ class StreamingShuffleDataset(torch.utils.data.IterableDataset):
         assert len(dataset) > 0
 
         self.indices = None
+        self.worker_offset = 0
 
     def set_epoch(self, epoch):
         # shuffle the dataset according to the seed argument and epoch
@@ -45,7 +46,8 @@ class StreamingShuffleDataset(torch.utils.data.IterableDataset):
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is not None and worker_info.num_workers > 1:
             chunks = np.array_split(self.indices, worker_info.num_workers)
-            indices = chunks[worker_info.id]
+            worker_id = (worker_info.id + self.worker_offset) % worker_info.num_workers
+            indices = chunks[worker_id]
         else:
             indices = self.indices
 

--- a/metaseq/data/streaming_token_block_dataset.py
+++ b/metaseq/data/streaming_token_block_dataset.py
@@ -132,7 +132,6 @@ def yield_single_sentences_pad_8(iterable, block_size, drop_last, padding_idx):
     return the example as is, without packing, truncating to block_size in cases of
     very long examples.
     """
-
     for idx, item in enumerate(iterable):
         cur_block = []
         cur_block_ids = []
@@ -207,7 +206,8 @@ def yield_token_blocks(iterable, block_size, drop_last, padding_idx):
     for idx, item in enumerate(iterable):
         cur_block_ids.append(idx)
         while item.numel() > 0:
-            num_to_take = min(item.numel(), cur_block_remain)
+            numel = item.numel()
+            num_to_take = min(numel, cur_block_remain)
 
             cur_block.append(item[:num_to_take])
             item = item[num_to_take:]  # remainder
@@ -224,7 +224,7 @@ def yield_token_blocks(iterable, block_size, drop_last, padding_idx):
                 }
 
                 cur_block = []
-                cur_block_ids = []
+                cur_block_ids = [idx] if numel > num_to_take else []
                 cur_block_remain = block_size
 
     if not drop_last and len(cur_block) > 0:

--- a/metaseq/data/streaming_token_block_dataset.py
+++ b/metaseq/data/streaming_token_block_dataset.py
@@ -206,8 +206,7 @@ def yield_token_blocks(iterable, block_size, drop_last, padding_idx):
     for idx, item in enumerate(iterable):
         cur_block_ids.append(idx)
         while item.numel() > 0:
-            numel = item.numel()
-            num_to_take = min(numel, cur_block_remain)
+            num_to_take = min(item.numel(), cur_block_remain)
 
             cur_block.append(item[:num_to_take])
             item = item[num_to_take:]  # remainder
@@ -224,7 +223,7 @@ def yield_token_blocks(iterable, block_size, drop_last, padding_idx):
                 }
 
                 cur_block = []
-                cur_block_ids = [idx] if numel > num_to_take else []
+                cur_block_ids = []
                 cur_block_remain = block_size
 
     if not drop_last and len(cur_block) > 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython"]
+requires = ["setuptools", "wheel", "cython", "torch"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 from setuptools import Extension, find_packages, setup
+from torch.utils.cpp_extension import include_paths
 
 if sys.version_info < (3, 6):
     sys.exit("Sorry, Python >= 3.6 is required for metaseq.")
@@ -78,6 +79,10 @@ extensions = [
         language="c++",
         extra_compile_args=extra_compile_args,
     ),
+    Extension('metaseq.data.atomic',
+    sources=['metaseq/data/deferred.cpp'],
+    include_dirs=include_paths(),
+    language="c++")
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ def do_setup(package_data):
             "cython",
             'numpy; python_version>="3.7"',
             "setuptools>=18.0",
+            "torch",
         ],
         install_requires=[
             # protobuf version pinned due to tensorboard not pinning a version.

--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,12 @@ extensions = [
         language="c++",
         extra_compile_args=extra_compile_args,
     ),
-    Extension('metaseq.data.atomic',
-    sources=['metaseq/data/deferred.cpp'],
-    include_dirs=include_paths(),
-    language="c++")
+    Extension(
+        "metaseq.data.atomic",
+        sources=["metaseq/data/deferred.cpp"],
+        include_dirs=include_paths(),
+        language="c++",
+    ),
 ]
 
 
@@ -136,7 +138,6 @@ def do_setup(package_data):
             "cython",
             'numpy; python_version>="3.7"',
             "setuptools>=18.0",
-            "torch",
         ],
         install_requires=[
             # protobuf version pinned due to tensorboard not pinning a version.


### PR DESCRIPTION
**Patch Description**
Introduce machinery to skip ahead in the dataset without having to re-tokenize or read the files in the dataset again. 

Measuring in a separate benchmark script in the internal repo indicates this can run reduce the 'fast-forward' stage of data loader from ~20mins to 14 seconds (around 70x speedup).

This works by storing a cache from document idx -> number of tokens that can be stored in a snapshot as a array of numbers. When the token count is known, the `DeferredDataset` creates `DeferredTensor` objects that know their size, how to compute the value if need and how to generate new tensors via slices and concatenates. Another object `SkipDeferredDataset` skips the first `to_skip` elements, without ever computing the DeferredTensors values, bypassing tokenization while keeping the state of the data loader (e.g. the shuffle buffer) exactly the same as if it had actually been running.



<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
