### PR TITLE
Remove no_ and keep_ checkpoint flags

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -68,7 +68,9 @@ def save_checkpoint(
     checkpoint_conds = collections.OrderedDict()
 
     save_for_epoch = (
-        end_of_epoch and cfg.save_interval > 0 and epoch % cfg.save_interval == 0
+        end_of_epoch
+        and cfg.save_interval_epochs > 0
+        and epoch % cfg.save_interval_epochs == 0
     )
 
     save_for_updates = (
@@ -88,34 +90,64 @@ def save_checkpoint(
     checkpoints = [
         os.path.join(cfg.save_dir, fn) for fn, cond in checkpoint_conds.items() if cond
     ]
+    if len(checkpoints) > 0:
+        if PathManager.islink(checkpoints[0]):
+            PathManager.rm(checkpoints[0])
 
-    if PathManager.islink(checkpoints[0]):
-        PathManager.rm(checkpoints[0])
-
-    trainer.save_checkpoint(
-        checkpoints[0],
-        extra_state,
-        training_finished=training_finished,
-        async_callback_fn=async_callback_fn,
-    )
-
-    def _copy_if_not_async(src, dest):
-        if cfg.write_checkpoints_asynchronously:
-            pass  # TODO[ioPath]: Need to implement a delayed asynchronous file copying/moving feature.
-        else:
-            assert PathManager.copy(
-                src, dest, overwrite=True
-            ), f"Failed to copy {src} to {dest}"
-
-    for cp in checkpoints[1:]:
-        _copy_if_not_async(src=checkpoints[0], dest=cp)
-
-    write_timer.stop()
-    logger.info(
-        "Saved checkpoint {} (epoch {} @ {} updates, score {}) (writing took {} seconds)".format(
-            checkpoints[0], epoch, updates, val_loss, write_timer.sum
+        trainer.save_checkpoint(
+            checkpoints[0],
+            extra_state,
+            training_finished=training_finished,
+            async_callback_fn=async_callback_fn,
         )
-    )
+
+        def _copy_if_not_async(src, dest):
+            if cfg.write_checkpoints_asynchronously:
+                pass  # TODO[ioPath]: Need to implement a delayed asynchronous file copying/moving feature.
+            else:
+                assert PathManager.copy(
+                    src, dest, overwrite=True
+                ), f"Failed to copy {src} to {dest}"
+
+        for cp in checkpoints[1:]:
+            _copy_if_not_async(src=checkpoints[0], dest=cp)
+
+        write_timer.stop()
+        logger.info(
+            "Saved checkpoint {} (epoch {} @ {} updates, score {}) (writing took {} seconds)".format(
+                checkpoints[0], epoch, updates, val_loss, write_timer.sum
+            )
+        )
+
+        _delete_old_checkpoint_files(
+            cfg,
+            end_of_epoch,
+            suffix,
+        )
+
+
+def _delete_old_checkpoint_files(
+    cfg: CheckpointConfig, end_of_epoch: bool, suffix: str
+):
+    if not end_of_epoch and cfg.keep_last_updates > 0:
+        suffixes = [suffix]
+
+        # remove old checkpoints; checkpoints are sorted in descending order
+        for one_suffix in suffixes:
+            checkpoints = _checkpoint_paths(
+                cfg.save_dir, pattern=r"checkpoint_(\d+){}\.pt".format(one_suffix)
+            )
+            for old_chk in checkpoints[cfg.keep_last_updates :]:
+                if os.path.lexists(old_chk):
+                    os.remove(old_chk)
+    if cfg.keep_last_epochs > 0:
+        # remove old epoch checkpoints; checkpoints are sorted in descending order
+        checkpoints = _checkpoint_paths(
+            cfg.save_dir, pattern=r"checkpoint(\d+){}\.pt".format(suffix)
+        )
+        for old_chk in checkpoints[cfg.keep_last_epochs :]:
+            if os.path.lexists(old_chk):
+                os.remove(old_chk)
 
 
 def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -47,11 +47,7 @@ def save_checkpoint(
         best_function = max if cfg.maximize_best_checkpoint_metric else min
         save_checkpoint.best = best_function(val_loss, prev_best)
 
-    if cfg.no_save:
-        logger.warning(f"Not saving checkpoints.")
-        return
-
-    trainer.consolidate_optimizer()  # TODO(SS): we dont need if no_save_optimizer_state
+    trainer.consolidate_optimizer()
 
     if not trainer.should_save_checkpoint_on_current_rank:
         return
@@ -71,32 +67,15 @@ def save_checkpoint(
     suffix = trainer.checkpoint_suffix
     checkpoint_conds = collections.OrderedDict()
     checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = (
-        end_of_epoch and not cfg.no_epoch_checkpoints and epoch % cfg.save_interval == 0
+        end_of_epoch and epoch % cfg.save_interval == 0
     )
     checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = (
         not end_of_epoch
         and cfg.save_interval_updates > 0
         and updates % cfg.save_interval_updates == 0
     )
-    checkpoint_conds[f"checkpoint_best{suffix}.pt"] = (
-        val_loss is not None
-        and (
-            not hasattr(save_checkpoint, "best")
-            or is_better(val_loss, save_checkpoint.best)
-        )
-        and not cfg.no_best_checkpoints
-    )
-    if (
-        val_loss is not None
-        and cfg.keep_best_checkpoints > 0
-        and not cfg.no_best_checkpoints
-    ):
-        checkpoint_conds[
-            "checkpoint.best_{}_{:.2f}.pt".format(cfg.best_checkpoint_metric, val_loss)
-        ] = not hasattr(save_checkpoint, "best") or is_better(
-            val_loss, save_checkpoint.best
-        )
-    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = not cfg.no_last_checkpoints
+
+    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = True
 
     extra_state = {"train_iterator": epoch_itr.state_dict(), "val_loss": val_loss}
     if hasattr(save_checkpoint, "best"):
@@ -105,77 +84,34 @@ def save_checkpoint(
     checkpoints = [
         os.path.join(cfg.save_dir, fn) for fn, cond in checkpoint_conds.items() if cond
     ]
-    if len(checkpoints) > 0:
-        if PathManager.islink(checkpoints[0]):
-            PathManager.rm(checkpoints[0])
 
-        trainer.save_checkpoint(
-            checkpoints[0],
-            extra_state,
-            training_finished=training_finished,
-            async_callback_fn=async_callback_fn,
-        )
+    if PathManager.islink(checkpoints[0]):
+        PathManager.rm(checkpoints[0])
 
-        def _copy_if_not_async(src, dest):
-            if cfg.write_checkpoints_asynchronously:
-                pass  # TODO[ioPath]: Need to implement a delayed asynchronous file copying/moving feature.
-            else:
-                assert PathManager.copy(
-                    src, dest, overwrite=True
-                ), f"Failed to copy {src} to {dest}"
-
-        for cp in checkpoints[1:]:
-            _copy_if_not_async(src=checkpoints[0], dest=cp)
-
-        write_timer.stop()
-        logger.info(
-            "Saved checkpoint {} (epoch {} @ {} updates, score {}) (writing took {} seconds)".format(
-                checkpoints[0], epoch, updates, val_loss, write_timer.sum
-            )
-        )
-
-    _delete_old_checkpoint_files(
-        cfg,
-        end_of_epoch,
-        suffix,
+    trainer.save_checkpoint(
+        checkpoints[0],
+        extra_state,
+        training_finished=training_finished,
+        async_callback_fn=async_callback_fn,
     )
 
+    def _copy_if_not_async(src, dest):
+        if cfg.write_checkpoints_asynchronously:
+            pass  # TODO[ioPath]: Need to implement a delayed asynchronous file copying/moving feature.
+        else:
+            assert PathManager.copy(
+                src, dest, overwrite=True
+            ), f"Failed to copy {src} to {dest}"
 
-def _delete_old_checkpoint_files(
-    cfg: CheckpointConfig, end_of_epoch: bool, suffix: str
-):
-    if not end_of_epoch and cfg.keep_interval_updates > 0:
-        suffixes = [suffix]
+    for cp in checkpoints[1:]:
+        _copy_if_not_async(src=checkpoints[0], dest=cp)
 
-        # remove old checkpoints; checkpoints are sorted in descending order
-        for one_suffix in suffixes:
-            checkpoints = _checkpoint_paths(
-                cfg.save_dir, pattern=r"checkpoint_\d+_(\d+){}\.pt".format(one_suffix)
-            )
-            for old_chk in checkpoints[cfg.keep_interval_updates :]:
-                if os.path.lexists(old_chk):
-                    os.remove(old_chk)
-    if cfg.keep_last_epochs > 0:
-        # remove old epoch checkpoints; checkpoints are sorted in descending order
-        checkpoints = _checkpoint_paths(
-            cfg.save_dir, pattern=r"checkpoint(\d+){}\.pt".format(suffix)
+    write_timer.stop()
+    logger.info(
+        "Saved checkpoint {} (epoch {} @ {} updates, score {}) (writing took {} seconds)".format(
+            checkpoints[0], epoch, updates, val_loss, write_timer.sum
         )
-        for old_chk in checkpoints[cfg.keep_last_epochs :]:
-            if os.path.lexists(old_chk):
-                os.remove(old_chk)
-    if cfg.keep_best_checkpoints > 0:
-        # only keep the best N checkpoints according to validation metric
-        checkpoints = _checkpoint_paths(
-            cfg.save_dir,
-            pattern=r"checkpoint\.best_{}_(\d+\.?\d*){}\.pt".format(
-                cfg.best_checkpoint_metric, suffix
-            ),
-        )
-        if not cfg.maximize_best_checkpoint_metric:
-            checkpoints = checkpoints[::-1]
-        for old_chk in checkpoints[cfg.keep_best_checkpoints :]:
-            if os.path.lexists(old_chk):
-                os.remove(old_chk)
+    )
 
 
 def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -66,16 +66,20 @@ def save_checkpoint(
 
     suffix = trainer.checkpoint_suffix
     checkpoint_conds = collections.OrderedDict()
-    checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = (
+
+    save_for_epoch = (
         end_of_epoch and cfg.save_interval > 0 and epoch % cfg.save_interval == 0
     )
-    checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = (
+
+    save_for_updates = (
         not end_of_epoch
         and cfg.save_interval_updates > 0
         and updates % cfg.save_interval_updates == 0
     )
 
-    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = True
+    checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = save_for_epoch
+    checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = save_for_updates
+    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = save_for_epoch or save_for_updates
 
     extra_state = {"train_iterator": epoch_itr.state_dict(), "val_loss": val_loss}
     if hasattr(save_checkpoint, "best"):

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -67,7 +67,7 @@ def save_checkpoint(
     suffix = trainer.checkpoint_suffix
     checkpoint_conds = collections.OrderedDict()
     checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = (
-        end_of_epoch and epoch % cfg.save_interval == 0
+        end_of_epoch and cfg.save_interval > 0 and epoch % cfg.save_interval == 0
     )
     checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = (
         not end_of_epoch

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -491,44 +491,14 @@ class CheckpointConfig(MetaseqDataclass):
         },
     )
     save_interval: int = field(
-        default=1, metadata={"help": "save a checkpoint every N epochs"}
+        default=1,
+        metadata={
+            "help": "save a checkpoint every N epochs"
+            "(note: one epoch is a a run over just one data shard, not of over the whole dataset, see #198)"
+        },
     )
     save_interval_updates: int = field(
         default=0, metadata={"help": "save a checkpoint (and validate) every N updates"}
-    )
-    keep_interval_updates: int = field(
-        default=-1,
-        metadata={
-            "help": "keep the last N checkpoints saved with --save-interval-updates"
-        },
-    )
-    keep_last_epochs: int = field(
-        default=-1, metadata={"help": "keep last N epoch checkpoints"}
-    )
-    keep_best_checkpoints: int = field(
-        default=-1, metadata={"help": "keep best N checkpoints based on scores"}
-    )
-    no_save: bool = field(
-        default=False, metadata={"help": "don't save models or checkpoints"}
-    )
-    no_epoch_checkpoints: bool = field(
-        default=False, metadata={"help": "don't store checkpoints at epoch boundaries"}
-    )
-    no_last_checkpoints: bool = field(
-        default=False, metadata={"help": "don't store last checkpoints"}
-    )
-    no_best_checkpoints: bool = field(
-        default=False, metadata={"help": "don't store best checkpoints"}
-    )
-    no_save_optimizer_state: bool = field(
-        default=False,
-        metadata={"help": "don't save optimizer-state as part of checkpoint"},
-    )
-    no_save_optimizer_state_on_training_finished: bool = field(
-        default=False,
-        metadata={
-            "help": "don't save optimizer-state as part of checkpoint when training is done"
-        },
     )
     best_checkpoint_metric: str = field(
         default="loss", metadata={"help": 'metric to use for saving "best" checkpoints'}

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -490,7 +490,7 @@ class CheckpointConfig(MetaseqDataclass):
             "help": "a dictionary used to override optimizer args when loading a checkpoint"
         },
     )
-    save_interval: int = field(
+    save_interval_epochs: int = field(
         default=1,
         metadata={
             "help": "save a checkpoint every N epochs"
@@ -499,6 +499,12 @@ class CheckpointConfig(MetaseqDataclass):
     )
     save_interval_updates: int = field(
         default=0, metadata={"help": "save a checkpoint (and validate) every N updates"}
+    )
+    keep_last_epochs: int = field(
+        default=-1, metadata={"help": "keep only the last N epoch checkpoints"}
+    )
+    keep_last_updates: int = field(
+        default=-1, metadata={"help": "keep only the last N updates checkpoints"}
     )
     best_checkpoint_metric: str = field(
         default="loss", metadata={"help": 'metric to use for saving "best" checkpoints'}

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -143,7 +143,8 @@ def get_grid(args):
             hyperparam(
                 "--dict-size", 51200 - 4
             ),  # TODO(susan): what is this -4 sorcery? relic of more nmt things?
-            hyperparam("--no-save"),
+            hyperparam("--save_interval", 0),
+            hyperparam("--save_interval_updates", 0),
         ]
         total_updates = 50
         warmup_updates = 50

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -143,8 +143,8 @@ def get_grid(args):
             hyperparam(
                 "--dict-size", 51200 - 4
             ),  # TODO(susan): what is this -4 sorcery? relic of more nmt things?
-            hyperparam("--save_interval", 0),
-            hyperparam("--save_interval_updates", 0),
+            hyperparam("--save-interval-epochs", 0),
+            hyperparam("--save-interval-updates", 0),
         ]
         total_updates = 50
         warmup_updates = 50
@@ -162,7 +162,8 @@ def get_grid(args):
         grid += [
             hyperparam(
                 "--valid-subset", ",".join(f"valid/{ss}" for ss in valid_subsets)
-            )
+            ),
+            hyperparam("--save-interval-updates", 2000),
         ]
 
     grid += [
@@ -171,7 +172,6 @@ def get_grid(args):
         hyperparam("--num-workers", 8),
         hyperparam("--num-workers-valid", 1),
         hyperparam("--validate-interval-updates", 2000),
-        hyperparam("--save-interval-updates", 2000),
         hyperparam(
             "--memory-efficient-fp16",
             save_dir_key=lambda val: "me_fp16" if not no_save_params else "",

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -172,10 +172,6 @@ def get_grid(args):
         hyperparam("--validate-interval-updates", 2000),
         hyperparam("--save-interval-updates", 2000),
         hyperparam(
-            "--no-epoch-checkpoints"
-        ),  # only save checkpoints based on num steps
-        hyperparam("--no-best-checkpoints"),  # don't save checkpoint_best.pt
-        hyperparam(
             "--memory-efficient-fp16",
             save_dir_key=lambda val: "me_fp16" if not no_save_params else "",
         ),

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -322,7 +322,6 @@ class Trainer(object):
 
     def state_dict(self, filename, training_finished=False) -> Dict[str, Dict]:
         model_state_dict = self.model.state_dict()
-        optim_state = None
         optim_state = self._gathered_optim_state or self.optimizer.state_dict()
         model_save_list = [
             (

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -396,7 +396,11 @@ def validate_and_save(
         )
 
     do_save = (
-        (end_of_epoch and epoch_itr.epoch % cfg.checkpoint.save_interval == 0)
+        (
+            end_of_epoch
+            and cfg.checkpoint.save_interval > 0
+            and epoch_itr.epoch % cfg.checkpoint.save_interval == 0
+        )
         or should_stop
         or (
             cfg.checkpoint.save_interval_updates > 0

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -401,7 +401,6 @@ def validate_and_save(
             and cfg.checkpoint.save_interval > 0
             and epoch_itr.epoch % cfg.checkpoint.save_interval == 0
         )
-        or should_stop
         or (
             cfg.checkpoint.save_interval_updates > 0
             and num_updates > 0
@@ -427,7 +426,7 @@ def validate_and_save(
     should_stop |= should_stop_early(cfg, valid_losses[0])
 
     # Save checkpoint
-    if do_save or should_stop:
+    if do_save:
         checkpoint_utils.save_checkpoint(
             cfg.checkpoint,
             trainer,

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -396,18 +396,15 @@ def validate_and_save(
         )
 
     do_save = (
-        (
-            end_of_epoch
-            and cfg.checkpoint.save_interval > 0
-            and epoch_itr.epoch % cfg.checkpoint.save_interval == 0
-        )
-        or (
-            cfg.checkpoint.save_interval_updates > 0
-            and num_updates > 0
-            and num_updates % cfg.checkpoint.save_interval_updates == 0
-            and num_updates >= cfg.dataset.validate_after_updates
-            and was_successful_step
-        )
+        end_of_epoch
+        and cfg.checkpoint.save_interval_epochs > 0
+        and epoch_itr.epoch % cfg.checkpoint.save_interval_epochs == 0
+    ) or (
+        cfg.checkpoint.save_interval_updates > 0
+        and num_updates > 0
+        and num_updates % cfg.checkpoint.save_interval_updates == 0
+        and num_updates >= cfg.dataset.validate_after_updates
+        and was_successful_step
     )
     do_validate = (
         (not end_of_epoch and do_save)  # validate during mid-epoch saves

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -396,11 +396,7 @@ def validate_and_save(
         )
 
     do_save = (
-        (
-            end_of_epoch
-            and epoch_itr.epoch % cfg.checkpoint.save_interval == 0
-            and not cfg.checkpoint.no_epoch_checkpoints
-        )
+        (end_of_epoch and epoch_itr.epoch % cfg.checkpoint.save_interval == 0)
         or should_stop
         or (
             cfg.checkpoint.save_interval_updates > 0
@@ -411,9 +407,7 @@ def validate_and_save(
         )
     )
     do_validate = (
-        (
-            not end_of_epoch and do_save and not cfg.checkpoint.no_best_checkpoints
-        )  # validate during mid-epoch saves
+        (not end_of_epoch and do_save)  # validate during mid-epoch saves
         or should_stop
         or (
             cfg.dataset.validate_interval_updates > 0


### PR DESCRIPTION
**Patch Description**
Removed most of the no_* and keep_* flags and cleaned up their logic.

**Testing steps**
I did have some issues with setting up an environment to test this.

In the end I tested with the opt_baselines script and checked if different `save_intervals `and `save_interval_updates ` correctly create all the checkpoints:
`python3 metaseq/launcher/opt_baselines.py --prefix train.8m --model-size 8m --checkpoints-dir ./test-checkpoint --tensorboard-logdir ./test-checkpoint --num-trials 1 --azure --num-gpus 4 --num-nodes 1 --seed 1 --circleci --local --disable-validation --max-epoch 5 --max-update 200`
