### PR TITLE
Change deletion of old checkpoints to match new naming

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -150,7 +150,7 @@ def _delete_old_checkpoint_files(
         # remove old checkpoints; checkpoints are sorted in descending order
         for one_suffix in suffixes:
             checkpoints = _checkpoint_paths(
-                cfg.save_dir, pattern=r"checkpoint_\d+_(\d+){}\.pt".format(one_suffix)
+                cfg.save_dir, pattern=r"checkpoint_(\d+){}\.pt".format(one_suffix)
             )
             for old_chk in checkpoints[cfg.keep_interval_updates :]:
                 if os.path.lexists(old_chk):


### PR DESCRIPTION
**Patch Description**
Fix old checkpoint deletion code to match new naming from https://github.com/facebookresearch/metaseq/commit/6c02d8311f3d7db994d1908edca6096eb99ff16d 
**Testing steps**

Checked old checkpoints are being deleted now.
