### PR TITLE
restore last checkpoint from the end of the training runs

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -81,7 +81,9 @@ def save_checkpoint(
 
     checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = save_for_epoch
     checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = save_for_updates
-    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = save_for_epoch or save_for_updates
+    checkpoint_conds[f"checkpoint_last{suffix}.pt"] = (
+        training_finished and cfg.save_last_checkpoint
+    )
 
     extra_state = {"train_iterator": epoch_itr.state_dict(), "val_loss": val_loss}
     if hasattr(save_checkpoint, "best"):

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -500,6 +500,10 @@ class CheckpointConfig(MetaseqDataclass):
     save_interval_updates: int = field(
         default=0, metadata={"help": "save a checkpoint (and validate) every N updates"}
     )
+    save_last_checkpoint: bool = field(
+        default=True,
+        metadata={"help": "store a last checkpoint at the end of the training run."},
+    )
     keep_last_epochs: int = field(
         default=-1, metadata={"help": "keep only the last N epoch checkpoints"}
     )

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -396,15 +396,19 @@ def validate_and_save(
         )
 
     do_save = (
-        end_of_epoch
-        and cfg.checkpoint.save_interval_epochs > 0
-        and epoch_itr.epoch % cfg.checkpoint.save_interval_epochs == 0
-    ) or (
-        cfg.checkpoint.save_interval_updates > 0
-        and num_updates > 0
-        and num_updates % cfg.checkpoint.save_interval_updates == 0
-        and num_updates >= cfg.dataset.validate_after_updates
-        and was_successful_step
+        (
+            end_of_epoch
+            and cfg.checkpoint.save_interval_epochs > 0
+            and epoch_itr.epoch % cfg.checkpoint.save_interval_epochs == 0
+        )
+        or (
+            cfg.checkpoint.save_interval_updates > 0
+            and num_updates > 0
+            and num_updates % cfg.checkpoint.save_interval_updates == 0
+            and num_updates >= cfg.dataset.validate_after_updates
+            and was_successful_step
+        )
+        or should_stop
     )
     do_validate = (
         (not end_of_epoch and do_save)  # validate during mid-epoch saves


### PR DESCRIPTION
After https://github.com/facebookresearch/metaseq/commit/e3ea5070a8c1bae77703aef7fc0f5537bd437963 we stopped storing checkpoints at the end of the runs. Let's bring them back.

I'm repurposing last_.* checkpoints to be only the ones corresponding to the end of training. In practice, with previous code they were never stored because "epoch" or "updates" one would take precedence. Now, if it's the end of the run and we are not at the end of an epoch or a saving interval, we store the checkpoint using "last_" naming (assuming cfg flag is enabled).

To test: Trained a model and checked that last checkpoint was stored in Azure.