### PR TITLE
making GeneratorHubInterface work with gpt3_eval for generation task

### DIFF
--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -805,7 +805,7 @@ class GeneratorInterface:
                 mask.append(False)
                 continue
             if t in special_token_inds and i > 0:
-                # an special tokens should end things
+                # and other special tokens should end things
                 mask.append(False)
                 break
             mask.append(True)


### PR DESCRIPTION
**Patch Description**
Tis patch fixes a bug when using metaseq_internal.eval for generation task.
Currently, sequence_generator returns a {"token": 3d torch.Tensor, "score": 3d torch.Tensor}, while metaseq_internal.eval expects List[List[{"token": 1d torch.Tensor, "score": 1d torch.Tensor}]]. 

**Testing steps**
Test on any generation task. 
```
CUDA_VISIBLE_DEVICES=0,1 python -m metaseq_internal.eval.gpt3_eval --results-dir {out_dir} --model-name {model_name}    --tasks  ni_v2__task1393_superglue_copa_text_completion   --distributed-port 1234 --distributed-world-size 2  --fsdp  --n 2
```
<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
