### PR TITLE
Liliyu/bf16 init fix

### DIFF
--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -493,6 +493,7 @@ class GeneratorInterface:
         task = tasks.setup_task(self.cfg.task)
 
         def _build_model(cfg, task):
+            setattr(cfg["model"], "inference", True)
             model = task.build_model(cfg.model).cuda()
             model.make_generation_fast_()
             return fsdp_wrap(model)

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -8,6 +8,7 @@ import math
 import torch
 from torch import nn
 
+import metaseq.utils as utils
 from metaseq.model_parallel.modules import ModelParallelMultiheadAttention
 from metaseq.modules import TransformerDecoderLayer, TransformerEncoderLayer
 
@@ -142,7 +143,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             full_megatron_init=getattr(args, "full_megatron_init", False),
             megatron_init_sigma=getattr(args, "megatron_init_sigma", 0.006),
             num_layers=args.decoder_layers,
-            dtype=self._get_model_init_dtype(),
+            dtype=utils.get_model_init_dtype(args),
             bias=not getattr(args, "disable_bias", False),
         )
 
@@ -157,7 +158,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             full_megatron_init=getattr(args, "full_megatron_init", False),
             megatron_init_sigma=getattr(args, "megatron_init_sigma", 0.006),
             num_layers=args.decoder_layers,
-            dtype=self._get_model_init_dtype(),
+            dtype=utils.get_model_init_dtype(args),
         )
 
     def forward_attention(

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -251,8 +251,6 @@ class TransformerDecoder(IncrementalDecoder):
     def __init__(self, args, dictionary, embed_tokens, no_encoder_attn=False):
         self.args = args
         super().__init__(dictionary)
-        import torch
-
         self.register_buffer("version", torch.Tensor([3]))
         self._future_mask = torch.empty(0)
 
@@ -306,7 +304,7 @@ class TransformerDecoder(IncrementalDecoder):
             if args.decoder_learned_pos and not self.use_alibi
             else None
         )
-        self.embed_positions = self.embed_positions.to(device).to(dtype)
+        self.embed_positions.to(device).to(dtype)
 
         self.cross_self_attention = getattr(args, "cross_self_attention", False)
 
@@ -365,7 +363,7 @@ class TransformerDecoder(IncrementalDecoder):
                 embed_dim,
                 elementwise_affine=not getattr(args, "disable_affine_ln", False),
             )
-            self.layer_norm = self.layer_norm.to(device).to(dtype)
+            self.layer_norm.to(device).to(dtype)
         else:
             self.layer_norm = None
 

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.nn as nn
 from torch import Tensor
-
 from metaseq.dataclass.constants import UNSPECIFIED_DOC_SEP
 
 from metaseq import utils
@@ -38,6 +37,7 @@ class TransformerEncoder(BaseEncoder):
     """
     Transformer encoder consisting of *args.encoder_layers* layers. Each layer
     is a :class:`TransformerEncoderLayer`.
+
     Args:
         args (argparse.Namespace): parsed command-line arguments
         dictionary (~metaseq.data.Dictionary): encoding dictionary
@@ -131,6 +131,7 @@ class TransformerEncoder(BaseEncoder):
                 shape `(batch)`
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
+
         Returns:
             dict:
                 - **encoder_out** (Tensor): the last encoder layer's output of
@@ -160,6 +161,7 @@ class TransformerEncoder(BaseEncoder):
                 shape `(batch)`
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
+
         Returns:
             dict:
                 - **encoder_out** (Tensor): the last encoder layer's output of
@@ -237,6 +239,7 @@ class TransformerDecoder(IncrementalDecoder):
     """
     Transformer decoder consisting of *args.decoder_layers* layers. Each layer
     is a :class:`TransformerDecoderLayer`.
+
     Args:
         args (argparse.Namespace): parsed command-line arguments
         dictionary (~metaseq.data.Dictionary): decoding dictionary
@@ -249,6 +252,7 @@ class TransformerDecoder(IncrementalDecoder):
         self.args = args
         super().__init__(dictionary)
         import torch
+
         self.register_buffer("version", torch.Tensor([3]))
         self._future_mask = torch.empty(0)
 
@@ -266,11 +270,6 @@ class TransformerDecoder(IncrementalDecoder):
         self.max_target_positions = args.max_target_positions
         self.embed_tokens = embed_tokens
         self.embed_scale = 1.0 if args.no_scale_embedding else math.sqrt(embed_dim)
-
-
-        import torch 
-        if torch.distributed.get_rank() == 0:
-            from metaseq import pdb; pdb.set_trace()
 
         initialize_params_on_gpu = getattr(
             args, "tensor_parallel_init_model_on_gpu", False
@@ -572,6 +571,7 @@ class TransformerDecoder(IncrementalDecoder):
         """
         Includes several features from "Jointly Learning to Align and
         Translate with Transformer Models" (Garg et al., EMNLP 2019).
+
         Args:
             prev_output_tokens (LongTensor): previous decoder outputs of shape
                 `(batch, tgt_len)`, for teacher forcing
@@ -585,6 +585,7 @@ class TransformerDecoder(IncrementalDecoder):
                 default `None` will recompute embeddings
             self_attn_padding_mask (torch.Tensor, optional): precomputed padding
                 mask for self-attention (default None will recompute mask)
+
         Returns:
             tuple:
                 - the decoder's output of shape `(batch, tgt_len, vocab)`

--- a/metaseq/models/transformer.py
+++ b/metaseq/models/transformer.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.nn as nn
 from torch import Tensor
+
 from metaseq.dataclass.constants import UNSPECIFIED_DOC_SEP
 
 from metaseq import utils
@@ -21,6 +22,7 @@ from metaseq.modules import (
     PositionalEmbedding,
     TransformerDecoderLayer,
     TransformerEncoderLayer,
+    Linear,
 )
 from metaseq.modules.checkpoint_activations import checkpoint_wrapper
 
@@ -36,7 +38,6 @@ class TransformerEncoder(BaseEncoder):
     """
     Transformer encoder consisting of *args.encoder_layers* layers. Each layer
     is a :class:`TransformerEncoderLayer`.
-
     Args:
         args (argparse.Namespace): parsed command-line arguments
         dictionary (~metaseq.data.Dictionary): encoding dictionary
@@ -130,7 +131,6 @@ class TransformerEncoder(BaseEncoder):
                 shape `(batch)`
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
-
         Returns:
             dict:
                 - **encoder_out** (Tensor): the last encoder layer's output of
@@ -160,7 +160,6 @@ class TransformerEncoder(BaseEncoder):
                 shape `(batch)`
             token_embeddings (torch.Tensor, optional): precomputed embeddings
                 default `None` will recompute embeddings
-
         Returns:
             dict:
                 - **encoder_out** (Tensor): the last encoder layer's output of
@@ -238,7 +237,6 @@ class TransformerDecoder(IncrementalDecoder):
     """
     Transformer decoder consisting of *args.decoder_layers* layers. Each layer
     is a :class:`TransformerDecoderLayer`.
-
     Args:
         args (argparse.Namespace): parsed command-line arguments
         dictionary (~metaseq.data.Dictionary): decoding dictionary
@@ -250,6 +248,7 @@ class TransformerDecoder(IncrementalDecoder):
     def __init__(self, args, dictionary, embed_tokens, no_encoder_attn=False):
         self.args = args
         super().__init__(dictionary)
+        import torch
         self.register_buffer("version", torch.Tensor([3]))
         self._future_mask = torch.empty(0)
 
@@ -268,17 +267,31 @@ class TransformerDecoder(IncrementalDecoder):
         self.embed_tokens = embed_tokens
         self.embed_scale = 1.0 if args.no_scale_embedding else math.sqrt(embed_dim)
 
+
+        import torch 
+        if torch.distributed.get_rank() == 0:
+            from metaseq import pdb; pdb.set_trace()
+
+        initialize_params_on_gpu = getattr(
+            args, "tensor_parallel_init_model_on_gpu", False
+        )
+        device = torch.cuda.current_device() if initialize_params_on_gpu else None
+        dtype = utils.get_model_init_dtype(args)
+
         self.project_in_dim = (
-            Linear(input_embed_dim, embed_dim, bias=False)
+            Linear(
+                input_embed_dim,
+                embed_dim,
+                bias=False,
+                initialize_params_on_gpu=initialize_params_on_gpu,
+                dtype=dtype,
+            )
             if embed_dim != input_embed_dim
             else None
         )
         self.use_alibi: bool = getattr(args, "alibi", False)
         self.self_attn_doc_sep: int = getattr(
             args, "self_attn_doc_sep", UNSPECIFIED_DOC_SEP
-        )
-        initialize_params_on_gpu = getattr(
-            args, "tensor_parallel_init_model_on_gpu", False
         )
 
         self.embed_positions = (
@@ -294,14 +307,7 @@ class TransformerDecoder(IncrementalDecoder):
             if args.decoder_learned_pos and not self.use_alibi
             else None
         )
-
-        if initialize_params_on_gpu and self.embed_positions is not None:
-            self.embed_positions = utils.floating_point_precision_convertor(
-                self.embed_positions.cuda(),
-                fp16=getattr(args, "fp16", False),
-                memory_efficient_fp16=getattr(args, "memory_efficient_fp16", False),
-                bf16=getattr(args, "bf16", False),
-            )
+        self.embed_positions = self.embed_positions.to(device).to(dtype)
 
         self.cross_self_attention = getattr(args, "cross_self_attention", False)
 
@@ -360,34 +366,39 @@ class TransformerDecoder(IncrementalDecoder):
                 embed_dim,
                 elementwise_affine=not getattr(args, "disable_affine_ln", False),
             )
-            if initialize_params_on_gpu:
-                self.layer_norm = utils.floating_point_precision_convertor(
-                    self.layer_norm.cuda(),
-                    fp16=getattr(args, "fp16", False),
-                    memory_efficient_fp16=getattr(args, "memory_efficient_fp16", False),
-                    bf16=getattr(args, "bf16", False),
-                )
-
+            self.layer_norm = self.layer_norm.to(device).to(dtype)
         else:
             self.layer_norm = None
 
         self.project_out_dim = (
-            Linear(embed_dim, self.output_embed_dim, bias=False)
+            Linear(
+                embed_dim,
+                self.output_embed_dim,
+                bias=False,
+                initialize_params_on_gpu=initialize_params_on_gpu,
+                dtype=dtype,
+            )
             if embed_dim != self.output_embed_dim
             else None
         )
 
         self.output_projection = None
         if self.share_input_output_embed:
-            self.output_projection = nn.Linear(
+            self.output_projection = Linear(
                 self.embed_tokens.weight.shape[1],
                 self.embed_tokens.weight.shape[0],
                 bias=False,
+                initialize_params_on_gpu=initialize_params_on_gpu,
+                dtype=dtype,
             )
             self.output_projection.weight = self.embed_tokens.weight
         else:
-            self.output_projection = nn.Linear(
-                self.output_embed_dim, len(dictionary), bias=False
+            self.output_projection = Linear(
+                self.output_embed_dim,
+                len(dictionary),
+                bias=False,
+                initialize_params_on_gpu=initialize_params_on_gpu,
+                dtype=dtype,
             )
             nn.init.normal_(
                 self.output_projection.weight, mean=0, std=self.output_embed_dim**-0.5
@@ -561,7 +572,6 @@ class TransformerDecoder(IncrementalDecoder):
         """
         Includes several features from "Jointly Learning to Align and
         Translate with Transformer Models" (Garg et al., EMNLP 2019).
-
         Args:
             prev_output_tokens (LongTensor): previous decoder outputs of shape
                 `(batch, tgt_len)`, for teacher forcing
@@ -575,7 +585,6 @@ class TransformerDecoder(IncrementalDecoder):
                 default `None` will recompute embeddings
             self_attn_padding_mask (torch.Tensor, optional): precomputed padding
                 mask for self-attention (default None will recompute mask)
-
         Returns:
             tuple:
                 - the decoder's output of shape `(batch, tgt_len, vocab)`
@@ -763,23 +772,20 @@ class TransformerDecoder(IncrementalDecoder):
 
 
 def Embedding(
-    num_embeddings, embedding_dim, padding_idx, initialize_params_on_gpu=False
+    num_embeddings,
+    embedding_dim,
+    padding_idx,
+    initialize_params_on_gpu=False,
+    dtype: Optional[torch.dtype] = None,
 ):
     # Passing weights initialized on GPU.
     device = torch.cuda.current_device() if initialize_params_on_gpu else None
-    dtype = torch.half if initialize_params_on_gpu else torch.float
+    if dtype is None:
+        dtype = torch.float
     weight = torch.empty(num_embeddings, embedding_dim, device=device, dtype=dtype)
     nn.init.normal_(weight, mean=0, std=embedding_dim**-0.5)
     nn.init.constant_(weight[padding_idx], 0)
     m = nn.Embedding(
         num_embeddings, embedding_dim, padding_idx=padding_idx, _weight=weight
     )
-    return m
-
-
-def Linear(in_features, out_features, bias=True):
-    m = nn.Linear(in_features, out_features, bias)
-    nn.init.xavier_uniform_(m.weight)
-    if bias:
-        nn.init.constant_(m.bias, 0.0)
     return m

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -201,6 +201,7 @@ class TransformerLanguageModel(LanguageModel):
             initialize_params_on_gpu=getattr(
                 args, "tensor_parallel_init_model_on_gpu", False
             ),
+            dtype=utils.get_model_init_dtype(args),
         )
 
 

--- a/metaseq/modules/__init__.py
+++ b/metaseq/modules/__init__.py
@@ -12,6 +12,7 @@ from .multihead_attention import MultiheadAttention
 from .positional_embedding import PositionalEmbedding
 from .sinusoidal_positional_embedding import SinusoidalPositionalEmbedding
 from .transformer_layer import TransformerDecoderLayer, TransformerEncoderLayer
+from .linear import Linear
 
 __all__ = [
     "Dropout",
@@ -25,4 +26,5 @@ __all__ = [
     "SinusoidalPositionalEmbedding",
     "TransformerDecoderLayer",
     "TransformerEncoderLayer",
+    "Linear",
 ]

--- a/metaseq/modules/linear.py
+++ b/metaseq/modules/linear.py
@@ -29,13 +29,14 @@ class Linear(Module):
         out_features: int,
         bias: bool = True,
         initialize_params_on_gpu: bool = False,
+        dtype: torch.dtype = None,
     ) -> None:
         super(Linear, self).__init__()
         self.in_features = in_features
         self.out_features = out_features
         device = torch.cuda.current_device() if initialize_params_on_gpu else None
-        dtype = torch.half if initialize_params_on_gpu else torch.float
-
+        if dtype is None:
+            dtype = torch.float
         self.weight = Parameter(
             torch.empty(out_features, in_features, device=device, dtype=dtype)
         )

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -20,7 +20,6 @@ from metaseq.modules.linear import Linear
 @with_incremental_state
 class MultiheadAttention(nn.Module):
     """Multi-headed attention.
-
     See "Attention Is All You Need" for more details.
     """
 
@@ -37,6 +36,7 @@ class MultiheadAttention(nn.Module):
         self_attention=False,
         encoder_decoder_attention=False,
         initialize_params_on_gpu=False,
+        dtype: Optional[torch.dtype] = None,
     ):
         super().__init__()
         self.embed_dim = embed_dim
@@ -66,24 +66,28 @@ class MultiheadAttention(nn.Module):
             embed_dim,
             bias=bias,
             initialize_params_on_gpu=initialize_params_on_gpu,
+            dtype=dtype,
         )
         self.v_proj = Linear(
             self.vdim,
             embed_dim,
             bias=bias,
             initialize_params_on_gpu=initialize_params_on_gpu,
+            dtype=dtype,
         )
         self.q_proj = Linear(
             embed_dim,
             embed_dim,
             bias=bias,
             initialize_params_on_gpu=initialize_params_on_gpu,
+            dtype=dtype,
         )
         self.out_proj = Linear(
             embed_dim,
             embed_dim,
             bias=bias,
             initialize_params_on_gpu=initialize_params_on_gpu,
+            dtype=dtype,
         )
         torch.set_rng_state(random_state)
         if add_bias_kv:
@@ -143,7 +147,6 @@ class MultiheadAttention(nn.Module):
         need_head_weights: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Input shape: Time x Batch x Channel
-
         Args:
             key_padding_mask (ByteTensor, optional): mask to exclude
                 keys that are pads, of shape `(batch, src_len)`, where
@@ -424,4 +427,4 @@ class MultiheadAttention(nn.Module):
         return self.set_incremental_state(incremental_state, "attn_state", buffer)
 
     def apply_sparse_mask(self, attn_weights, tgt_len: int, src_len: int, bsz: int):
-        return attn_weights
+        return 

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -20,6 +20,7 @@ from metaseq.modules.linear import Linear
 @with_incremental_state
 class MultiheadAttention(nn.Module):
     """Multi-headed attention.
+
     See "Attention Is All You Need" for more details.
     """
 
@@ -147,6 +148,7 @@ class MultiheadAttention(nn.Module):
         need_head_weights: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Input shape: Time x Batch x Channel
+
         Args:
             key_padding_mask (ByteTensor, optional): mask to exclude
                 keys that are pads, of shape `(batch, src_len)`, where
@@ -427,4 +429,4 @@ class MultiheadAttention(nn.Module):
         return self.set_incremental_state(incremental_state, "attn_state", buffer)
 
     def apply_sparse_mask(self, attn_weights, tgt_len: int, src_len: int, bsz: int):
-        return 
+        return attn_weights

--- a/metaseq/modules/transformer_layer.py
+++ b/metaseq/modules/transformer_layer.py
@@ -217,7 +217,7 @@ class TransformerDecoderLayer(nn.Module):
         self.self_attn_layer_norm = LayerNorm(
             self.embed_dim, elementwise_affine=affine_ln
         )
-        self.self_attn_layer_norm = self.self_attn_layer_norm.to(device).to(dtype)
+        self.self_attn_layer_norm.to(device).to(dtype)
 
         if no_encoder_attn:
             self.encoder_attn = None
@@ -259,7 +259,7 @@ class TransformerDecoderLayer(nn.Module):
         )
 
         self.final_layer_norm = LayerNorm(self.embed_dim, elementwise_affine=affine_ln)
-        self.final_layer_norm = self.final_layer_norm.to(device).to(dtype)
+        self.final_layer_norm.to(device).to(dtype)
 
         self.need_attn = True
         self.onnx_trace = False

--- a/metaseq/utils.py
+++ b/metaseq/utils.py
@@ -637,7 +637,7 @@ def floating_point_precision_convertor(
 
 
 def get_model_init_dtype(args):
-    if getattr(args, "memory_efficient_fp16", False):
+    if getattr(args, "memory_efficient_fp16", False) or getattr(args, "inference", False):
         return torch.bfloat16 if getattr(args, "bf16", False) else torch.half
     return torch.float32
 

--- a/metaseq/utils.py
+++ b/metaseq/utils.py
@@ -637,7 +637,9 @@ def floating_point_precision_convertor(
 
 
 def get_model_init_dtype(args):
-    if getattr(args, "memory_efficient_fp16", False) or getattr(args, "inference", False):
+    if getattr(args, "memory_efficient_fp16", False) or getattr(
+        args, "inference", False
+    ):
         return torch.bfloat16 if getattr(args, "bf16", False) else torch.half
     return torch.float32
 

--- a/metaseq/utils.py
+++ b/metaseq/utils.py
@@ -636,6 +636,12 @@ def floating_point_precision_convertor(
         return x.half()
 
 
+def get_model_init_dtype(args):
+    if getattr(args, "memory_efficient_fp16", False):
+        return torch.bfloat16 if getattr(args, "bf16", False) else torch.half
+    return torch.float32
+
+
 def get_precise_epoch(epoch: Optional[int], count: int, iterator_size: int) -> float:
     return (
         epoch - 1 + (count + 1) / float(iterator_size)


### PR DESCRIPTION
**Patch Description**
Adding fix to correctly initialize the non-MP model. And correctly infer inference datatype for model trained with mixed precision. 

**Testing steps**
Launch a consolidated model (mp=1) for a model trained with bf16. 

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
