### PR TITLE
remove deprecated inferencre_step implementation

### DIFF
--- a/metaseq/tasks/language_modeling.py
+++ b/metaseq/tasks/language_modeling.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import numpy as np
-import torch
 from omegaconf import II
 
 from metaseq import utils

--- a/metaseq/tasks/language_modeling.py
+++ b/metaseq/tasks/language_modeling.py
@@ -324,29 +324,6 @@ class LanguageModelingTask(LegacyTask):
             sizes=[np.array(src_lengths)],
         )
 
-    def inference_step(self, generator, models, sample, prefix_tokens=None, **kwargs):
-        with torch.no_grad():
-            # Generation will always be conditioned on bos_token
-            if getattr(self.args, "add_bos_token", False):
-                bos_token = self.source_dictionary.bos()
-            else:
-                bos_token = self.source_dictionary.eos()
-
-            # SequenceGenerator doesn't use src_tokens directly, we need to
-            # pass the `prefix_tokens` argument instead
-            if prefix_tokens is None and sample["net_input"]["src_tokens"].nelement():
-                prefix_tokens = sample["net_input"]["src_tokens"]
-                if prefix_tokens[:, 0].eq(bos_token).all():
-                    prefix_tokens = prefix_tokens[:, 1:]
-
-            return generator.generate(
-                models,
-                sample,
-                prefix_tokens=prefix_tokens,
-                bos_token=bos_token,
-                **kwargs,
-            )
-
     def eval_lm_dataloader(
         self,
         dataset,

--- a/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
+++ b/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 
 import numpy as np
-import torch
 from omegaconf import II
 
 from metaseq import utils

--- a/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
+++ b/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
@@ -306,32 +306,6 @@ class LanguageModelingInferenceForModelsTrainedWithStreamingTask(LegacyTask):
             sizes=[np.array(src_lengths)],
         )
 
-    def inference_step(
-        self, generator, models, sample, prefix_tokens=None, constraints=None
-    ):
-        with torch.no_grad():
-            # Generation will always be conditioned on bos_token
-            if getattr(self.args, "add_bos_token", False):
-                bos_token = self.source_dictionary.bos()
-            else:
-                bos_token = self.source_dictionary.eos()
-
-            if constraints is not None:
-                raise NotImplementedError(
-                    "Constrained decoding with the language_modeling task is not supported"
-                )
-
-            # SequenceGenerator doesn't use src_tokens directly, we need to
-            # pass the `prefix_tokens` argument instead
-            if prefix_tokens is None and sample["net_input"]["src_tokens"].nelement():
-                prefix_tokens = sample["net_input"]["src_tokens"]
-                if prefix_tokens[:, 0].eq(bos_token).all():
-                    prefix_tokens = prefix_tokens[:, 1:]
-
-            return generator.generate(
-                models, sample, prefix_tokens=prefix_tokens, bos_token=bos_token
-            )
-
     def eval_lm_dataloader(
         self,
         dataset,


### PR DESCRIPTION
**Patch Description**
"prefix_tokens" not used by sequence_generator or sequence_score, inference_step() implementation in lanague_modeling and language_modeling_inference_for_models_trained_with_streaming are the same as the one in base_task. 

**Testing steps**


<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
