### PR TITLE
add warning for beam size, and seq length reset

### DIFF
--- a/metaseq_cli/interactive_hosted.py
+++ b/metaseq_cli/interactive_hosted.py
@@ -297,6 +297,8 @@ def completions(engine=None):
         generation_args["top_p"] = 1.0
     # beam search top n
     if "n" in generation_args:
+        if int(generation_args["n"]) > MAX_BEAM:
+            logger.warning(f'beam size/sampling size of {int(generation_args["n"])} too large, using {MAX_BEAM} to avoid OOM')
         generation_args["n"] = min(MAX_BEAM, max(1, int(generation_args["n"])))
     else:
         generation_args["n"] = 1
@@ -307,6 +309,7 @@ def completions(engine=None):
         if gen_len + len(prompt) + 1 > MAX_SEQ_LEN:
             # cut off the prompt to always fit with number of generations we need
             # +1 to always have the EOS token
+            logger.warning(f'input too long, truncated to {MAX_SEQ_LEN - gen_len - 1} to avoid OOM')
             prompt = prompt[-(MAX_SEQ_LEN - gen_len - 1) :]
         request_object = {"input": prompt, **generation_args}
         BATCH_QUEUE.put(


### PR DESCRIPTION
**Patch Description**
For robust inference (especially avoiding OOM), interactive_hosted set maximal value for beam_size, and also truncate input. When running evaluation using API, this silently changes evaluation configuration and causes issues. 
Adding warnings when that happens. 

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
