### PR TITLE
fix bug when counting sequences_consumed near the end of an epoch

### DIFF
--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -82,7 +82,9 @@ class FakeTensorData(torch.utils.data.Dataset):
 
 class TestStreamingIterators(unittest.TestCase):
     def test_streaming_counting_iterator(self):
-        ref = list((0, i) for i in range(10)) # extra 0 is the worker_id that StreamingCountingIterator expects
+        ref = list(
+            (0, i) for i in range(10)
+        )  # extra 0 is the worker_id that StreamingCountingIterator expects
         itr = iterators.StreamingCountingIterator(ref, 0, 1, 1)
         for i, (_, ref_i) in enumerate(ref):
             self.assertTrue(itr.has_next())
@@ -246,7 +248,7 @@ class TestStreamingIterators(unittest.TestCase):
             num_workers=3,
             pin_memory=True,
             drop_last=True,
-            collate_fn=collate_with_worker_id
+            collate_fn=collate_with_worker_id,
         )
         iterator1 = iterators.StreamingCountingIterator(dataloader1, 3, 1, 1)
 

--- a/metaseq/data/iterators.py
+++ b/metaseq/data/iterators.py
@@ -137,9 +137,7 @@ class StreamingCountingIterator(object):
 
     def __next__(self):
         worker_id, r = next(self._peekable_itr)
-        self.sequences_consumed[worker_id] += (
-            self.batch_size * self.num_shards
-        )
+        self.sequences_consumed[worker_id] += self.batch_size * self.num_shards
         self.next_worker = (worker_id + 1) % self.num_workers
         self.n += 1
         return r


### PR DESCRIPTION
I misunderstood how the DataLoader worked. I thought it just round-robin each of the workers in turn for the next batch. This is true until one of the workers runs out of batches. At that point it continues by asking other workers for batches until they all ran out. Previously I thought that it would just stop when the first worker ran out. This means that the code was accounting for `sequences_consumed` on each worker inaccurately at the very end of an epoch when some workers have no data.

This is a small patch that fixes the bug and makes it more robust by passing the worker_id to the StreamingCountingIterator instead of having it try to mimic the logic of which worker the batch came from.