### PR TITLE
Improve regex for model loading

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -543,7 +543,7 @@ def load_model_ensemble_and_task(
         assert num_shards > 0
         for shard_idx in range(num_shards):
             if num_shards == 1:
-                filename = filename.replace(".pt", suffix + ".pt")
+                filename = re.sub('.pt$', suffix + ".pt", filename)
             else:
                 filename = orig_filename[:-3] + f"_part{shard_idx}.pt"
             if state is None:


### PR DESCRIPTION
Fix the regex for model loading. Tested with 
```
CUDA_VISIBLE_DEVICES=0,1 FSD=~/data/instruct-opt/prompt_data/allbenchmarks_io_streaming_after_dedup_v5_sorted  python -m metaseq_internal.eval.gpt3_eval --tasks opti
 --opti-eval-set test_text_completion__ni_v2__task215_rocstories_incorrect_answer_generation__prompt0  --model-name opt_instr_test  --nb-few-shot-samples-values 0 --distributed-world-size 2 --fsdp --prediction
s-dump-dir ~/del_clf  --n-eval-samples 10
```

Output:
```
Loaded model
model_loading_time=1177.1 seconds
model_loading_time_cuda=1177.1 seconds
Using max-tokens=2048
task=opti
eval_set=test_text_completion__ni_v2__task215_rocstories_incorrect_answer_generation__prompt0
eval language=en
train_set=None
train_lang=None
template=optinstructbenchmark
calibration_options=[]
scoring=sum
nb_few_shot_samples=0
```