### PR TITLE
[jsonl] Re-use caches for symlinks.

### DIFF
--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -49,8 +49,11 @@ class JsonlDataset(torch.utils.data.Dataset):
         self.tokenizer = tokenizer
 
         self.threadlocal = threading.local()
+        # resolve symlinks to for cached indexes. This lets us re-use indexes
+        # across our experiments using differently composed datasets
+        resolved_path = Path(path).resolve()
         # TODO(susan): Fix this fairseq reference. _build_index fails otherwise.
-        self.cache = Path(f"{path}.fairseq.idx.npy")
+        self.cache = Path(f"{resolved_path}.fairseq.idx.npy")
         # only build the cache in on the primary worker to prevent overloading nfs
         if distributed_utils.get_global_rank() != 0:
             distributed_utils.global_barrier()


### PR DESCRIPTION
**Patch Description**
We've been doing a lot of training on different corpora, and using symbolic links to create the mixture. Because of the way the caching system works, this means we rebuild our line indexes every time we create a new mix of corpora.

This patch builds the indexes next to the original data, not the symlink. This helps re-use indexes across distinct runs.

**Testing steps**
Been using this for a week plus.