### PR TITLE
[Cleanup] Remove encoder-related cruft in decoder code-paths: 10.4/N

### DIFF
--- a/metaseq/model_parallel/models/transformer.py
+++ b/metaseq/model_parallel/models/transformer.py
@@ -48,8 +48,8 @@ class ModelParallelTransformerDecoder(TransformerDecoder):
     is a :class:`ModelParallelTransformerDecoderLayer`.
     """
 
-    def build_base_decoder_layer(self, args, no_encoder_attn=False, **kwargs):
-        return ModelParallelTransformerDecoderLayer(args, no_encoder_attn)
+    def build_base_decoder_layer(self, args, **kwargs):
+        return ModelParallelTransformerDecoderLayer(args)
 
     def output_layer(self, features, **kwargs):
         """Project features to the vocabulary size."""

--- a/metaseq/model_parallel/models/transformer_lm.py
+++ b/metaseq/model_parallel/models/transformer_lm.py
@@ -56,7 +56,6 @@ class ModelParallelTransformerLanguageModel(TransformerLanguageModel):
             args,
             task.target_dictionary,
             embed_tokens,
-            no_encoder_attn=True,
         )
         return cls(decoder)
 

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -58,6 +58,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
 
     See "Megatron-LM: https://arxiv.org/pdf/1909.08053.pdf" for more details.
     """
+
     # TODO[susanz]: unify method signatures with non-model-parallel version.
     def build_fc1(
         self,

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -148,20 +148,6 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias=not getattr(args, "disable_bias", False),
         )
 
-    def build_encoder_attention(self, embed_dim, args, **unused_kwargs):
-        return ModelParallelMultiheadAttention(
-            embed_dim=embed_dim,
-            num_heads=args.decoder_attention_heads,
-            kdim=getattr(args, "encoder_embed_dim", None),
-            vdim=getattr(args, "encoder_embed_dim", None),
-            dropout=args.attention_dropout,
-            encoder_decoder_attention=True,
-            full_megatron_init=getattr(args, "full_megatron_init", False),
-            megatron_init_sigma=getattr(args, "megatron_init_sigma", 0.006),
-            num_layers=args.decoder_layers,
-            dtype=utils.get_model_init_dtype(args),
-        )
-
     def forward_attention(
         self,
         query,

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -58,7 +58,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
 
     See "Megatron-LM: https://arxiv.org/pdf/1909.08053.pdf" for more details.
     """
-
+    # TODO[susanz]: unify method signatures with non-model-parallel version.
     def build_fc1(
         self,
         input_dim,
@@ -94,6 +94,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             bias=not disable_bias,
         )
 
+    # TODO[susanz]: unify method signatures with non-model-parallel version.
     def build_fc2(
         self,
         input_dim,

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -185,7 +185,6 @@ class TransformerLanguageModel(LanguageModel):
             args,
             task.target_dictionary,
             embed_tokens,
-            no_encoder_attn=True,
         )
         return cls(decoder)
 

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -160,20 +160,6 @@ class TransformerDecoderLayer(nn.Module):
             dtype=utils.get_model_init_dtype(args),
         )
 
-    def build_encoder_attention(self, embed_dim, args):
-        return MultiheadAttention(
-            embed_dim,
-            args.decoder_attention_heads,
-            kdim=getattr(args, "encoder_embed_dim", None),
-            vdim=getattr(args, "encoder_embed_dim", None),
-            dropout=args.attention_dropout,
-            encoder_decoder_attention=True,
-            initialize_params_on_gpu=getattr(
-                args, "tensor_parallel_init_model_on_gpu", False
-            ),
-            dtype=utils.get_model_init_dtype(args),
-        )
-
     def prepare_for_onnx_export_(self):
         self.onnx_trace = True
 

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -31,14 +31,11 @@ class TransformerDecoderLayer(nn.Module):
 
     Args:
         args (argparse.Namespace): parsed command-line arguments
-        no_encoder_attn (bool, optional): whether to attend to encoder outputs
-            (default: False).
     """
 
     def __init__(
         self,
         args,
-        no_encoder_attn=False,
         add_bias_kv=False,
         add_zero_attn=False,
     ):
@@ -70,15 +67,8 @@ class TransformerDecoderLayer(nn.Module):
         )
         self.self_attn_layer_norm.to(device).to(dtype)
 
-        if no_encoder_attn:
-            self.encoder_attn = None
-            self.encoder_attn_layer_norm = None
-        else:
-            self.encoder_attn = self.build_encoder_attention(self.embed_dim, args)
-            self.encoder_attn_layer_norm = LayerNorm(self.embed_dim)
-            self.encoder_attn_layer_norm = self.encoder_attn_layer_norm.to(device).to(
-                dtype
-            )
+        self.encoder_attn = None
+        self.encoder_attn_layer_norm = None
 
         ffn_dim = args.decoder_ffn_embed_dim
 

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -215,8 +215,6 @@ class TransformerDecoderLayer(nn.Module):
         Returns:
             encoded output of shape `(seq_len, batch, embed_dim)`
         """
-        if need_head_weights:
-            need_attn = True
 
         residual = x
 


### PR DESCRIPTION
[ Note: this will be rebased on main after https://github.com/facebookresearch/metaseq/pull/369 is merged in (+ upstream diffs) ]

We currently default to `no_encoder_attn=True` in our decoder-only paths. Remove this cruft to cleanly separate between decoder and encoders.