### PR TITLE
[Cleanup] Remove encoder_out/encoder_padding_mask from decoder stuff: 10.5/N

### DIFF
--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -17,26 +17,22 @@ class BaseDecoder(nn.Module):
         self.dictionary = dictionary
         self.onnx_trace = False
 
-    def forward(self, prev_output_tokens, encoder_out=None, **kwargs):
+    def forward(self, prev_output_tokens, **kwargs):
         """
         Args:
             prev_output_tokens (LongTensor): shifted output tokens of shape
                 `(batch, tgt_len)`, for teacher forcing
-            encoder_out (dict, optional): output from the encoder, used for
-                encoder-side attention
 
         Returns:
             tuple:
                 - the decoder's output of shape `(batch, tgt_len, vocab)`
                 - a dictionary with any model-specific outputs
         """
-        x, extra = self.extract_features(
-            prev_output_tokens, encoder_out=encoder_out, **kwargs
-        )
+        x, extra = self.extract_features(prev_output_tokens, **kwargs)
         x = self.output_layer(x)
         return x, extra
 
-    def extract_features(self, prev_output_tokens, encoder_out=None, **kwargs):
+    def extract_features(self, prev_output_tokens, **kwargs):
         """
         Returns:
             tuple:

--- a/metaseq/models/incremental_decoder.py
+++ b/metaseq/models/incremental_decoder.py
@@ -51,15 +51,11 @@ class IncrementalDecoder(BaseDecoder):
     def __init__(self, dictionary):
         super().__init__(dictionary)
 
-    def forward(
-        self, prev_output_tokens, encoder_out=None, incremental_state=None, **kwargs
-    ):
+    def forward(self, prev_output_tokens, incremental_state=None, **kwargs):
         """
         Args:
             prev_output_tokens (LongTensor): shifted output tokens of shape
                 `(batch, tgt_len)`, for teacher forcing
-            encoder_out (dict, optional): output from the encoder, used for
-                encoder-side attention
             incremental_state (dict, optional): dictionary used for storing
                 state during :ref:`Incremental decoding`. Note that this
                 dictionary is modified inline iff incremental_state is not None.
@@ -71,9 +67,7 @@ class IncrementalDecoder(BaseDecoder):
         """
         raise NotImplementedError
 
-    def extract_features(
-        self, prev_output_tokens, encoder_out=None, incremental_state=None, **kwargs
-    ):
+    def extract_features(self, prev_output_tokens, incremental_state=None, **kwargs):
         """
         Returns:
             tuple:

--- a/metaseq/models/transformer_decoder.py
+++ b/metaseq/models/transformer_decoder.py
@@ -127,6 +127,7 @@ class TransformerDecoder(IncrementalDecoder):
         layers = []
         for i in range(args.decoder_layers):
             layers.append(self.build_decoder_layer(args))
+
         if getattr(self.args, "fsdp_checkpoint_wrap_layer_frequency", 1) > 1:
             assert (
                 len(layers) % self.args.fsdp_checkpoint_wrap_layer_frequency == 0
@@ -366,7 +367,6 @@ class TransformerDecoder(IncrementalDecoder):
     def forward(
         self,
         prev_output_tokens,
-        encoder_out: Optional[Dict[str, List[Tensor]]] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         features_only: bool = False,
         src_lengths: Optional[Any] = None,
@@ -380,8 +380,6 @@ class TransformerDecoder(IncrementalDecoder):
         Args:
             prev_output_tokens (LongTensor): previous decoder outputs of shape
                 `(batch, tgt_len)`, for teacher forcing
-            encoder_out (optional): output from the encoder, used for
-                encoder-side attention
             incremental_state (dict): dictionary used for storing state during
                 :ref:`Incremental decoding`
             features_only (bool, optional): only return features without
@@ -401,7 +399,6 @@ class TransformerDecoder(IncrementalDecoder):
         # incremental state
         x, extra = self.extract_features(
             prev_output_tokens,
-            encoder_out=encoder_out,
             incremental_state=incremental_state,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
@@ -413,14 +410,12 @@ class TransformerDecoder(IncrementalDecoder):
     def extract_features(
         self,
         prev_output_tokens,
-        encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
         return self.extract_features_scriptable(
             prev_output_tokens,
-            encoder_out=encoder_out,
             incremental_state=incremental_state,
             token_embeddings=token_embeddings,
             self_attn_padding_mask=self_attn_padding_mask,
@@ -429,7 +424,6 @@ class TransformerDecoder(IncrementalDecoder):
     def extract_features_scriptable(
         self,
         prev_output_tokens,
-        encoder_out: Optional[Dict[str, List[Tensor]]],
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         token_embeddings: Optional[Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
@@ -470,22 +464,10 @@ class TransformerDecoder(IncrementalDecoder):
         # instead of all inner representations, as thats the only thing being logged and storing
         # all intermediate representation causes OOM for large models during validation.
         inner_states: List[Optional[Tensor]] = [{"tok": tok, "pos": pos, "emb": x}]
-        if encoder_out is None:
-            l_aux = []
-        else:
-            l_aux = encoder_out["l_aux"] if "l_aux" in encoder_out else []
+        l_aux = []
         for idx, layer in enumerate(self.layers):
             x, layer_attn, _, l_aux_i = layer(
                 x,
-                encoder_out=encoder_out["encoder_out"][0]
-                if (encoder_out is not None and len(encoder_out["encoder_out"]) > 0)
-                else None,
-                encoder_padding_mask=encoder_out["encoder_padding_mask"][0]
-                if (
-                    encoder_out is not None
-                    and len(encoder_out["encoder_padding_mask"]) > 0
-                )
-                else None,
                 incremental_state=incremental_state,
                 self_attn_mask=self_attn_mask,
                 self_attn_padding_mask=self_attn_padding_mask,

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -224,7 +224,6 @@ class TransformerDecoderLayer(nn.Module):
                 saved_state["prev_key_padding_mask"] = prev_self_attn_state[2]
             assert incremental_state is not None
             self.self_attn._set_input_buffer(incremental_state, saved_state)
-        _self_attn_input_buffer = self.self_attn._get_input_buffer(incremental_state)
 
         x, attn = self.forward_attention(
             query=x,


### PR DESCRIPTION
[ Note this will be rebased onto main after https://github.com/facebookresearch/metaseq/pull/370 is merged ]

As title suggests, removing `encoder_out` and `encoder_padding_mask` args from decoder methods / classes. 