### PR TITLE
Add ruanslv as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @suchenzang @stephenroller @ngoyal2707 @punitkoura @moyapchen @klshuster @urielsinger
+*       @suchenzang @stephenroller @ngoyal2707 @punitkoura @moyapchen @klshuster @ruanslv

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We welcome PRs from the community!
 You can find information about contributing to metaseq in our [Contributing](docs/CONTRIBUTING.md) document.
 
 ## The Team
-Metaseq is currently maintained by the CODEOWNERS: [Susan Zhang](https://github.com/suchenzang), [Stephen Roller](https://github.com/stephenroller), [Naman Goyal](https://github.com/ngoyal2707), [Punit Singh Koura](https://github.com/punitkoura), [Moya Chen](https://github.com/moyapchen), [Kurt Shuster](https://github.com/klshuster), and [Uriel Singer](https://github.com/urielsinger).
+Metaseq is currently maintained by the CODEOWNERS: [Susan Zhang](https://github.com/suchenzang), [Stephen Roller](https://github.com/stephenroller), [Naman Goyal](https://github.com/ngoyal2707), [Punit Singh Koura](https://github.com/punitkoura), [Moya Chen](https://github.com/moyapchen), [Kurt Shuster](https://github.com/klshuster), and [Ruan Silva](https://github.com/ruanslv).
 
 Previous maintainers include:
 [Anjali Sridhar](https://github.com/anj-s), [Christopher Dewan](https://github.com/m3rlin45).


### PR DESCRIPTION
Adding @ruanslv as a codeowner to help review PRs.

@urielsinger got swamped with other deadlines, so unfortunately won't be able to take on reviewing work going forward (thanks for being open to doing this before though! ❤️ ).