### PR TITLE
Meter logging fix

### DIFF
--- a/metaseq/logging/meters.py
+++ b/metaseq/logging/meters.py
@@ -77,22 +77,12 @@ class HistoryMeter(Meter):
         assert type(val) is list
         self.history.extend(val)
 
-    def state_dict(self):
-        return {
-            "history": self.history,
-            "round": self.round,
-        }
-
-    def load_state_dict(self, state_dict):
-        self.history = state_dict["history"]
-        self.round = state_dict.get("round", None)
-
     @property
     def avg(self):
         if type(self.history[0]) is dict:
-            return sum([h["value"] for h in self.history])
+            return sum([h["value"] for h in self.history])/len(self.history)
         else:
-            return sum(self.history)
+            return sum(self.history)/len(self.history)
 
     @property
     def smoothed_value(self) -> float:

--- a/metaseq/logging/meters.py
+++ b/metaseq/logging/meters.py
@@ -80,9 +80,9 @@ class HistoryMeter(Meter):
     @property
     def avg(self):
         if type(self.history[0]) is dict:
-            return sum([h["value"] for h in self.history])/len(self.history)
+            return sum([h["value"] for h in self.history]) / len(self.history)
         else:
-            return sum(self.history)/len(self.history)
+            return sum(self.history) / len(self.history)
 
     @property
     def smoothed_value(self) -> float:

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -626,6 +626,8 @@ def validate(
             progress.print(stats, tag=subset, step=trainer.get_num_updates())
             valid_losses.append(stats[cfg.checkpoint.best_checkpoint_metric])
     stats = get_valid_stats(cfg, trainer, combined_agg.get_smoothed_values())
+    if "batch_loss" in stats:
+        del stats["batch_loss"]
     progress.print(stats, tag="valid/combined", step=trainer.get_num_updates())
     return valid_losses
 


### PR DESCRIPTION
This PR removes state dict of  HistoryMeter so that we do not write log of history information in this meter into checkpoints. 
