### PR TITLE
[Cleanup] Remove unused plasma* related stuff: 10.2/N

### DIFF
--- a/metaseq/data/plasma_utils.py
+++ b/metaseq/data/plasma_utils.py
@@ -190,7 +190,7 @@ class PlasmaStore:
     @staticmethod
     def start(path=DEFAULT_PLASMA_PATH, nbytes: int = GB100) -> subprocess.Popen:
         if not PYARROW_AVAILABLE:
-            raise ImportError("please run pip install pyarrow to use --use_plasma_view")
+            raise ImportError("please run pip install pyarrow")
         # best practice is to allocate more space than we need. The limitation seems to be the size of /dev/shm
         _server = subprocess.Popen(["plasma_store", "-m", str(nbytes), "-s", path])
         plasma.connect(path, num_retries=200)  # If we can't connect we fail immediately

--- a/metaseq/data/plasma_utils.py
+++ b/metaseq/data/plasma_utils.py
@@ -89,25 +89,3 @@ class PlasmaArray:
             self._server = None
             self._server_tmp.close()
             self._server_tmp = None
-
-
-DEFAULT_PLASMA_PATH = "/tmp/plasma"
-GB100 = (1024**3) * 100
-
-
-class PlasmaStore:
-    def __init__(self, path=DEFAULT_PLASMA_PATH, nbytes: int = GB100):
-
-        self.server = self.start(path, nbytes)
-
-    def __del__(self):
-        self.server.kill()
-
-    @staticmethod
-    def start(path=DEFAULT_PLASMA_PATH, nbytes: int = GB100) -> subprocess.Popen:
-        if not PYARROW_AVAILABLE:
-            raise ImportError("please run pip install pyarrow")
-        # best practice is to allocate more space than we need. The limitation seems to be the size of /dev/shm
-        _server = subprocess.Popen(["plasma_store", "-m", str(nbytes), "-s", path])
-        plasma.connect(path, num_retries=200)  # If we can't connect we fail immediately
-        return _server

--- a/metaseq/data/plasma_utils.py
+++ b/metaseq/data/plasma_utils.py
@@ -4,11 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import hashlib
-import json
 import subprocess
 import tempfile
-from typing import Hashable
 
 try:
     import pyarrow.plasma as plasma
@@ -95,87 +92,6 @@ class PlasmaArray:
 
 
 DEFAULT_PLASMA_PATH = "/tmp/plasma"
-
-
-class PlasmaView:
-    """Interface to write and read from shared memory. Whereas PlasmaArray writes to plasma on serialization,
-    PlasmaView writes to shared memory on instantiation."""
-
-    def __init__(self, array, split_path: str, hash_data: Hashable, plasma_path=None):
-        """
-        Args:
-            array: numpy array to store. This can be read with ``PlasmaView().array``
-            split_path: the path whence the data was read, used for hashing
-            hash_data: other metadata about the array that can be used to create a unique key.
-                as of writing, the 3 callers in ``TokenBlockDataset`` use::
-
-                    hash_data = ((block_size, document_sep_len, str(break_mode), len(dataset)), 0|1|2)
-
-
-        """
-        assert PYARROW_AVAILABLE
-        assert split_path is not None
-        if plasma_path is None:
-            plasma_path = DEFAULT_PLASMA_PATH
-
-        self.path = plasma_path
-        self.split_path = split_path
-        self._client = None  # Initialize lazily for pickle. plasma clients should not be deep copied or serialized.
-        self._n = None
-
-        self.object_id = self.get_object_id(self.split_path, hash_data)
-        try:
-            self.client.put(array, object_id=self.object_id)
-        except plasma.PlasmaObjectExists:
-            pass
-
-    @property
-    def client(self):
-        if self._client is None:
-            self._client = plasma.connect(self.path, num_retries=200)
-        return self._client
-
-    @property
-    def array(self):
-        """Fetch a read only view of an np.array, stored in plasma."""
-        ret = self.client.get(self.object_id)
-        return ret
-
-    @staticmethod
-    def get_object_id(split_path: str, hash_data: Hashable):
-        """Returns plasma.ObjectID from hashing split_path and object_num."""
-        hash = hashlib.blake2b(bytes(split_path, "utf-8"), digest_size=20)
-        harg = json.dumps(hash_data).encode("utf-8")
-        hash.update(harg)
-        return plasma.ObjectID(hash.digest())
-
-    def __getstate__(self):
-        """Called on pickle save"""
-        self.disconnect()
-        state = self.__dict__.copy()
-        assert state["_client"] is None
-        assert "object_id" in state
-        return state
-
-    def __setstate__(self, state):
-        """Called on pickle load"""
-        self.__dict__.update(state)
-
-    def __del__(self):
-        self.disconnect()
-
-    def disconnect(self):
-        if self._client is not None:
-            self._client.disconnect()
-            self._client = None
-
-    def __len__(self):
-        """Save reads by caching len"""
-        if self._n is None:
-            self._n = len(self.array)
-        return self._n
-
-
 GB100 = (1024**3) * 100
 
 

--- a/metaseq/data/token_block_dataset.py
+++ b/metaseq/data/token_block_dataset.py
@@ -45,8 +45,6 @@ class TokenBlockDataset(BaseDataset):
         break_mode=None,
         include_targets=False,
         document_sep_len=1,
-        split_path=None,
-        plasma_path=None,
     ):
 
         super().__init__()
@@ -71,7 +69,7 @@ class TokenBlockDataset(BaseDataset):
     @staticmethod
     def _build_slice_indices(
         sizes, break_mode, document_sep_len, block_size
-    ) -> Tuple[np.ndarray]:
+    ):
         """Use token_block_utils_fast to build arrays for indexing into self.dataset"""
         try:
             from metaseq.data.token_block_utils_fast import (

--- a/metaseq/data/token_block_dataset.py
+++ b/metaseq/data/token_block_dataset.py
@@ -62,14 +62,10 @@ class TokenBlockDataset(BaseDataset):
 
         self._slice_indices = plasma_utils.PlasmaArray(slice_indices)
         self._sizes = plasma_utils.PlasmaArray(_sizes)
-        self._block_to_dataset_index = plasma_utils.PlasmaArray(
-            block_to_dataset_index
-        )
+        self._block_to_dataset_index = plasma_utils.PlasmaArray(block_to_dataset_index)
 
     @staticmethod
-    def _build_slice_indices(
-        sizes, break_mode, document_sep_len, block_size
-    ):
+    def _build_slice_indices(sizes, break_mode, document_sep_len, block_size):
         """Use token_block_utils_fast to build arrays for indexing into self.dataset"""
         try:
             from metaseq.data.token_block_utils_fast import (

--- a/metaseq/data/token_block_dataset.py
+++ b/metaseq/data/token_block_dataset.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple
-
 import numpy as np
 import torch
 

--- a/metaseq/data/token_block_dataset.py
+++ b/metaseq/data/token_block_dataset.py
@@ -45,7 +45,6 @@ class TokenBlockDataset(BaseDataset):
         break_mode=None,
         include_targets=False,
         document_sep_len=1,
-        use_plasma_view=False,
         split_path=None,
         plasma_path=None,
     ):
@@ -62,26 +61,12 @@ class TokenBlockDataset(BaseDataset):
         _sizes, block_to_dataset_index, slice_indices = self._build_slice_indices(
             sizes, break_mode, document_sep_len, block_size
         )
-        if use_plasma_view:
-            plasma_id = (block_size, document_sep_len, str(break_mode), len(dataset))
-            self._slice_indices = plasma_utils.PlasmaView(
-                slice_indices, split_path, (plasma_id, 0), plasma_path=plasma_path
-            )
-            self._sizes = plasma_utils.PlasmaView(
-                _sizes, split_path, (plasma_id, 1), plasma_path=plasma_path
-            )
-            self._block_to_dataset_index = plasma_utils.PlasmaView(
-                block_to_dataset_index,
-                split_path,
-                (plasma_id, 2),
-                plasma_path=plasma_path,
-            )
-        else:
-            self._slice_indices = plasma_utils.PlasmaArray(slice_indices)
-            self._sizes = plasma_utils.PlasmaArray(_sizes)
-            self._block_to_dataset_index = plasma_utils.PlasmaArray(
-                block_to_dataset_index
-            )
+
+        self._slice_indices = plasma_utils.PlasmaArray(slice_indices)
+        self._sizes = plasma_utils.PlasmaArray(_sizes)
+        self._block_to_dataset_index = plasma_utils.PlasmaArray(
+            block_to_dataset_index
+        )
 
     @staticmethod
     def _build_slice_indices(

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -184,9 +184,6 @@ class CommonConfig(MetaseqDataclass):
     profile: bool = field(
         default=False, metadata={"help": "enable autograd profiler emit_nvtx"}
     )
-    use_plasma_view: bool = field(
-        default=False, metadata={"help": "Store indices and sizes in shared memory"}
-    )
     plasma_path: Optional[str] = field(
         default="/tmp/plasma",
         metadata={

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -184,12 +184,6 @@ class CommonConfig(MetaseqDataclass):
     profile: bool = field(
         default=False, metadata={"help": "enable autograd profiler emit_nvtx"}
     )
-    plasma_path: Optional[str] = field(
-        default="/tmp/plasma",
-        metadata={
-            "help": "path to run plasma_store, defaults to /tmp/plasma. Paths outside /tmp tend to fail."
-        },
-    )
     log_nvidia_smi: bool = field(
         default=False, metadata={"help": "log output from nvidia-smi during training"}
     )

--- a/metaseq/tasks/language_modeling.py
+++ b/metaseq/tasks/language_modeling.py
@@ -121,7 +121,6 @@ class LanguageModelingConfig(MetaseqDataclass):
         "dataset.dataset_impl"
     )
     data_buffer_size: int = II("dataset.data_buffer_size")
-    plasma_path: str = II("common.plasma_path")
 
 
 # TODO(susanz): Deprecate this task. This pre-date StreamingLanguageModelingTask,
@@ -225,8 +224,6 @@ class LanguageModelingTask(LegacyTask):
                 eos=self.dictionary.eos(),
                 break_mode="complete_doc",
                 include_targets=False,
-                split_path=split_path,
-                plasma_path=self.args.plasma_path,
             )
             with data_utils.numpy_seed(self.args.seed + epoch):
                 shuffle = np.random.permutation(len(dataset))
@@ -246,8 +243,6 @@ class LanguageModelingTask(LegacyTask):
             eos=self.dictionary.eos(),
             break_mode=self.args.sample_break_mode,
             include_targets=True,
-            split_path=split_path,
-            plasma_path=self.args.plasma_path,
         )
         add_eos_for_other_targets = (
             self.args.sample_break_mode is not None

--- a/metaseq/tasks/language_modeling.py
+++ b/metaseq/tasks/language_modeling.py
@@ -121,7 +121,6 @@ class LanguageModelingConfig(MetaseqDataclass):
         "dataset.dataset_impl"
     )
     data_buffer_size: int = II("dataset.data_buffer_size")
-    use_plasma_view: bool = II("common.use_plasma_view")
     plasma_path: str = II("common.plasma_path")
 
 
@@ -226,7 +225,6 @@ class LanguageModelingTask(LegacyTask):
                 eos=self.dictionary.eos(),
                 break_mode="complete_doc",
                 include_targets=False,
-                use_plasma_view=self.args.use_plasma_view,
                 split_path=split_path,
                 plasma_path=self.args.plasma_path,
             )
@@ -248,7 +246,6 @@ class LanguageModelingTask(LegacyTask):
             eos=self.dictionary.eos(),
             break_mode=self.args.sample_break_mode,
             include_targets=True,
-            use_plasma_view=self.args.use_plasma_view,
             split_path=split_path,
             plasma_path=self.args.plasma_path,
         )

--- a/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
+++ b/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
@@ -119,7 +119,6 @@ class LanguageModelingInferenceForModelsTrainedWithStreamingConfig(MetaseqDatacl
     )
     data_buffer_size: int = II("dataset.data_buffer_size")
     tpu: bool = II("common.tpu")
-    plasma_path: str = II("common.plasma_path")
     update_freq: List[int] = II("optimization.update_freq")
 
 
@@ -225,8 +224,6 @@ class LanguageModelingInferenceForModelsTrainedWithStreamingTask(LegacyTask):
             eos=self.dictionary.eos(),
             break_mode=self.args.sample_break_mode,
             include_targets=True,
-            split_path=split_path,
-            plasma_path=self.args.plasma_path,
         )
 
         add_eos_for_other_targets = (

--- a/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
+++ b/metaseq/tasks/language_modeling_inference_for_models_trained_with_streaming.py
@@ -119,7 +119,6 @@ class LanguageModelingInferenceForModelsTrainedWithStreamingConfig(MetaseqDatacl
     )
     data_buffer_size: int = II("dataset.data_buffer_size")
     tpu: bool = II("common.tpu")
-    use_plasma_view: bool = II("common.use_plasma_view")
     plasma_path: str = II("common.plasma_path")
     update_freq: List[int] = II("optimization.update_freq")
 
@@ -226,7 +225,6 @@ class LanguageModelingInferenceForModelsTrainedWithStreamingTask(LegacyTask):
             eos=self.dictionary.eos(),
             break_mode=self.args.sample_break_mode,
             include_targets=True,
-            use_plasma_view=self.args.use_plasma_view,
             split_path=split_path,
             plasma_path=self.args.plasma_path,
         )

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -606,12 +606,6 @@ def cli_main(
     # For training - this is where arg parsing happens.
     cfg = convert_namespace_to_omegaconf(args)
 
-    if cfg.common.use_plasma_view:
-        server = PlasmaStore(path=cfg.common.plasma_path)
-        logger.info(
-            f"Started plasma server pid {server.server.pid} {cfg.common.plasma_path}"
-        )
-
     if args.profile:
         with torch.cuda.profiler.profile():
             with torch.autograd.profiler.emit_nvtx():

--- a/metaseq_cli/train.py
+++ b/metaseq_cli/train.py
@@ -29,7 +29,6 @@ from metaseq import (
     utils,
 )
 from metaseq.data import iterators, data_utils
-from metaseq.data.plasma_utils import PlasmaStore
 from metaseq.dataclass.utils import convert_namespace_to_omegaconf
 from metaseq.distributed import fsdp_enable_wrap, fsdp_wrap, utils as distributed_utils
 from metaseq.file_io import PathManager


### PR DESCRIPTION
Removed:
* `use_plasma_view` flag
* as a result, `split_path` and `plasma_paths` become unused in `TokenBlockDataset`
* `PlasmaView` class
* `PlasmaStore` class