### PR TITLE
[Cleanup] Default to pre-norm throughput: 10.3/N 

### DIFF
--- a/metaseq/model_parallel/models/transformer_lm.py
+++ b/metaseq/model_parallel/models/transformer_lm.py
@@ -108,8 +108,6 @@ def base_lm_architecture(args):
     args.decoder_ffn_embed_dim = getattr(args, "decoder_ffn_embed_dim", 2048)
     args.decoder_layers = getattr(args, "decoder_layers", 6)
     args.decoder_attention_heads = getattr(args, "decoder_attention_heads", 8)
-    # Model training is not stable without this
-    args.decoder_normalize_before = True
     args.share_decoder_input_output_embed = getattr(
         args, "share_decoder_input_output_embed", False
     )

--- a/metaseq/models/transformer_decoder.py
+++ b/metaseq/models/transformer_decoder.py
@@ -175,14 +175,11 @@ class TransformerDecoder(IncrementalDecoder):
 
         self.num_layers = len(self.layers)
 
-        if args.decoder_normalize_before:
-            self.layer_norm = LayerNorm(
-                embed_dim,
-                elementwise_affine=not getattr(args, "disable_affine_ln", False),
-            )
-            self.layer_norm.to(device).to(dtype)
-        else:
-            self.layer_norm = None
+        self.layer_norm = LayerNorm(
+            embed_dim,
+            elementwise_affine=not getattr(args, "disable_affine_ln", False),
+        )
+        self.layer_norm.to(device).to(dtype)
 
         self.project_out_dim = (
             Linear(

--- a/metaseq/models/transformer_encoder.py
+++ b/metaseq/models/transformer_encoder.py
@@ -61,10 +61,7 @@ class TransformerEncoder(BaseEncoder):
             self.layers.append(self.build_encoder_layer(args))
         self.num_layers = len(self.layers)
 
-        if args.encoder_normalize_before:
-            self.layer_norm = LayerNorm(embed_dim)
-        else:
-            self.layer_norm = None
+        self.layer_norm = LayerNorm(embed_dim)
 
     def build_encoder_layer(self, args):
         layer = TransformerEncoderLayer(args)

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -56,9 +56,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
     decoder_attention_heads: int = field(
         default=8, metadata={"help": "num decoder attention heads"}
     )
-    decoder_normalize_before: bool = field(
-        default=False, metadata={"help": "apply layernorm before each decoder block"}
-    )
     share_decoder_input_output_embed: bool = field(
         default=False, metadata={"help": "share decoder input and output embeddings"}
     )
@@ -226,9 +223,6 @@ def base_lm_architecture(args):
         args, "decoder_output_dim", args.decoder_embed_dim
     )
     args.decoder_input_dim = getattr(args, "decoder_input_dim", args.decoder_embed_dim)
-
-    # Model training is not stable without this
-    args.decoder_normalize_before = True
 
     args.no_scale_embedding = getattr(args, "no_scale_embedding", False)
     args.checkpoint_activations = getattr(args, "checkpoint_activations", False)


### PR DESCRIPTION
This PR removes *normalize_before flags and defaults to pre-norm logic throughout. 

Part of https://github.com/facebookresearch/metaseq/issues/368 efforts.