### PR TITLE
Set up environment variables for interactive hosted API service

### DIFF
--- a/metaseq_cli/interactive_hosted.py
+++ b/metaseq_cli/interactive_hosted.py
@@ -371,4 +371,14 @@ def cli_main():
 
 
 if __name__ == "__main__":
+    if os.getenv("SLURM_NODEID") is None:
+        logger.warning(
+            f"Missing slurm configuration, defaulting to 'use entire node' for API"
+        )
+        os.environ["SLURM_NODEID"] = "0"
+        os.environ["SLURM_NNODES"] = "1"
+        os.environ["SLURM_NTASKS"] = "1"
+        import socket
+
+        os.environ["SLURM_STEP_NODELIST"] = socket.gethostname()
     cli_main()


### PR DESCRIPTION
When you try to run the API service on a slurm node, but you're not inheriting the slurm environment, you get a very strange error:

```
... snip ...
  File "/shared/home/dgrnbrg/metaseq/metaseq/checkpoint_utils.py", line 316, in _is_checkpoint_sharded
    size_ratio = max(sizes) / min(sizes)
ValueError: max() arg is an empty sequence
```

It turns out this is due to incorrectly inferred config in `metaseq/distributed/utils.py`.


**Patch Description**
This adds a warning & a sane default (use the entire node that the API server is being run on).

**Testing steps**
I tried removing each of these env vars, and they're all necessary: any subset causes different crashes.

I ensured I could run & query the API successfully, using the fully sharded 175b param model.