### PR TITLE
Add support for source target style datasets to DocumentToSequence

### DIFF
--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -62,7 +62,6 @@ class FakeTensorData(torch.utils.data.Dataset):
         self.queried = 0
         self.realized = [False for _ in self.items]
 
-
     def _gen_one(self, source_target):
         n = self.rng.randrange(512, 2048)
         toks = torch.randint(256, size=(n,), generator=self.trng)
@@ -292,7 +291,11 @@ class TestStreamingIterators(unittest.TestCase):
         def get_traditional_iterator(dataset, break_mode, drop_last, source_target):
             shuffle_dataset = StreamingShuffleDataset(dataset, seed=42)
             shuffle_dataset.set_epoch(0)
-            Dataset = StreamingTokenBlockDataset if not source_target else StreamingSrcTgtDataset
+            Dataset = (
+                StreamingTokenBlockDataset
+                if not source_target
+                else StreamingSrcTgtDataset
+            )
             token_dataset = Dataset(
                 shuffle_dataset,
                 # We generate blocks with one extra token, so that we have a target
@@ -309,7 +312,9 @@ class TestStreamingIterators(unittest.TestCase):
             token_dataset.set_shuffle_buffer_size(4)
             return token_dataset
 
-        def get_document_to_sequence_iterator(dataset, break_mode, drop_last, source_target):
+        def get_document_to_sequence_iterator(
+            dataset, break_mode, drop_last, source_target
+        ):
             document_to_sequence_dataset = DocumentToSequenceDataset(
                 dataset,
                 # We generate blocks with one extra token, so that we have a target
@@ -329,9 +334,12 @@ class TestStreamingIterators(unittest.TestCase):
             return document_to_sequence_dataset
 
         def compare(break_mode, drop_last, source_target):
-            a = get_traditional_iterator(FakeTensorData(source_target), break_mode, drop_last, source_target)
+            a = get_traditional_iterator(
+                FakeTensorData(source_target), break_mode, drop_last, source_target
+            )
             b = get_document_to_sequence_iterator(
-                FakeTensorData(source_target), break_mode, drop_last, source_target)
+                FakeTensorData(source_target), break_mode, drop_last, source_target
+            )
             a_values = list(a)
             b_values = list(b)
             self.assertEqual(len(a_values), len(b_values))
@@ -352,7 +360,6 @@ class TestStreamingIterators(unittest.TestCase):
         compare("none", True, False)
         compare("eos_pad_8", True, False)
         compare("complete", True, False)
-
 
         # fine tuning
         compare("none", False, True)

--- a/cpu_tests/test_streaming_iterators.py
+++ b/cpu_tests/test_streaming_iterators.py
@@ -165,7 +165,7 @@ class TestStreamingIterators(unittest.TestCase):
         def create_dataset(
             break_mode="none", drop_last=True, sequence_size=2049, num_shards=1
         ):
-            dataset = FakeTensorData()
+            dataset = FakeTensorData(False)
             token_dataset = DocumentToSequenceDataset(
                 dataset,
                 # We generate blocks with one extra token, so that we have a target

--- a/metaseq/data/document_to_sequence.py
+++ b/metaseq/data/document_to_sequence.py
@@ -150,6 +150,7 @@ class DocumentToSequenceDataset(torch.utils.data.IterableDataset):
             but only before iteration has begun.
         seed (int, optional): seed for shuffling
         permute_documents (bool, optional): randomly permute the order the documents are read (default: True)
+        source_target (bool, optional): the input dataset returns a tuple of tokens lists (source, target) (default: False)
         to_skip (int, optional): skip the first to_skip sequences before iteration begins (Default: 0)
     """
 
@@ -216,7 +217,8 @@ class DocumentToSequenceDataset(torch.utils.data.IterableDataset):
             self.block_iterator = yield_passthrough
         else:
             raise ValueError(
-                f'Invalid value for break_mode = {break_mode}. Available options are "none", "eos_pad_8" or "complete". "passthrough".'
+                f"Invalid value for break_mode = {break_mode}."
+                'Available options are "none", "eos_pad_8", "complete", or "passthrough".'
             )
 
         if not drop_last and padding_idx is None:
@@ -382,7 +384,9 @@ class DocumentToSequenceDataset(torch.utils.data.IterableDataset):
                             # load it now (and for all other SequenceFragments where it hasn't been loaded yet)
                             doc[0] = self.dataset[doc[0]]
                         if self.source_target:
-                            subsequences.append(tuple(elem[start : start + ln] for elem in doc[0]))
+                            subsequences.append(
+                                tuple(elem[start : start + ln] for elem in doc[0])
+                            )
                         else:
                             subsequences.append(doc[0][start : start + ln])
                 if self.source_target:


### PR DESCRIPTION
Training runs using StreamingSrcTgtDataset were failing because they did not do the same token length caching as DocumentsToSequences.

StreamingSrcTgtDataset is really just another instances of StreamingTokenBlockDataset where the the blocks are split into a tuple (src, target). To avoid duplication this PR just adds support for this case directly to DocumentToSequences, and a test to verify this replicates the old behavior.

