### PR TITLE
fix a bug where collate function can't be pickled

### DIFF
--- a/metaseq/data/iterators.py
+++ b/metaseq/data/iterators.py
@@ -202,7 +202,6 @@ class _CollateWithWorkerID:
     def __call__(self, items):
         r = self.collate_fn(items)
         worker_info = torch.utils.data.get_worker_info()
-        assert worker_info or self.num_workers == 0
         return (worker_info.id if worker_info else 0, r)
 
 


### PR DESCRIPTION
This only seems to happen when a job is run locally and the worker threads are launched with 'spawn' instead of 'fork', which is why it wasn't caught earlier.