### PR TITLE
[checkpoint] Change logic around is_checkpoint_sharded

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -323,7 +323,7 @@ def _is_checkpoint_sharded(checkpoint_files) -> bool:
             "you failed to fsdp_wrap or you have an unnecessary fsdp_wrap."
         )
     sd = torch_load_cpu(checkpoint_files[0])
-    return sd['cfg']['distributed_training']['use_sharded_state']
+    return sd["cfg"]["distributed_training"]["use_sharded_state"]
 
 
 def get_paths_to_load(local_path, suffix="rank-"):

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -311,13 +311,20 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
 
 
 def _is_checkpoint_sharded(checkpoint_files) -> bool:
-    """Infer if state is sharded based on whether largest file is more than 10% larger than smallest."""
-    sizes = [os.path.getsize(p) for p in checkpoint_files]
-    size_ratio = max(sizes) / min(sizes)
-    if size_ratio >= 1.1:
-        return False
-    else:
-        return True
+    """
+    Infer if state is sharded based on whether largest file is much larger than
+    smallest.
+    """
+    if not checkpoint_files:
+        raise FileNotFoundError(
+            "We weren't able to find any checkpoints corresponding to the parameters "
+            "you set. This could mean you have a typo, or it could mean you have a "
+            "mismatch in distributed training parameters, especially --fsdp or"
+            "--model-parallel. If you are working on a new script, it may also mean "
+            "you failed to fsdp_wrap or you have an unnecessary fsdp_wrap."
+        )
+    sd = torch_load_cpu(checkpoint_files[0])
+    return sd['cfg']['distributed_training']['use_sharded_state']
 
 
 def get_paths_to_load(local_path, suffix="rank-"):

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -312,8 +312,7 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
 
 def _is_checkpoint_sharded(checkpoint_files) -> bool:
     """
-    Infer if state is sharded based on whether largest file is much larger than
-    smallest.
+    Infer if state is sharded based on recorded configuration in the checkpoint file.
     """
     if not checkpoint_files:
         raise FileNotFoundError(


### PR DESCRIPTION
**Patch Description**
Recent changes to dataloaders have resulted in us creating checkpoint files that are more unequal in size, as shard0 contains the data state. This breaks this older heuristic we used to determine if a checkpoint was Zero2 or Zero3.

This patch changes the heuristic to just read from the config of the file itself.

This patch also gives a better error message for a common mistake.

**Testing steps**
Internal evaluations.