### PR TITLE
Disable fused gelu until we validate ppl

### DIFF
--- a/metaseq/modules/feedforward_network.py
+++ b/metaseq/modules/feedforward_network.py
@@ -4,10 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from torch import nn as nn
-from torch.nn import functional as F
 
-from metaseq.modules import Linear, gelu
-from metaseq.modules.fused_bias_gelu import has_fused_bias_gelu, fused_bias_gelu
+from metaseq.modules import Linear
 
 
 def FeedForwardNetwork(x, fc1, activation_fn, fc2, dropout_module):
@@ -24,10 +22,6 @@ def FeedForwardNetwork(x, fc1, activation_fn, fc2, dropout_module):
         # here, we do the bias computation inside fc1 and fc2 AND gather_output
         x = activation_fn(x, fc1(x)[0], model_parallel=True)
         x, _ = fc2(x)
-    elif has_fused_bias_gelu and activation_fn.fn == gelu:
-        x = F.linear(x, fc1.weight, None)
-        x = fused_bias_gelu(x, fc1.bias)
-        x = F.linear(x, fc2.weight, fc2.bias)
     else:
         x = activation_fn(x, fc1(x), model_parallel=False)
         x = fc2(x)


### PR DESCRIPTION
Fused gelu was unintentionally disabled, but it's been re-enabled after https://github.com/facebookresearch/metaseq/pull/395.

Let's explicitly remove the code for now until we make sure PPL matches regular GeLU.

PS: Fused GeLU is only enabled when bias is present.