### PR TITLE
[inference] Allow non-gpt2 tokenizers in certain code paths.

### DIFF
--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -63,7 +63,6 @@ class SequenceGenerator(nn.Module):
             topp = 0.0
         self.sampling_topp = max(0, topp)
         self.temperature = temperature
-        assert temperature > 0, "--temperature must be greater than 0"
 
         self.model.eval()
         self.profile = profile

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -63,6 +63,7 @@ class SequenceGenerator(nn.Module):
             topp = 0.0
         self.sampling_topp = max(0, topp)
         self.temperature = temperature
+        assert temperature > 0, "--temperature must be greater than 0"
 
         self.model.eval()
         self.profile = profile


### PR DESCRIPTION
**Patch Description**
While this is simply fixing code we plan to deprecate anyway, I think we need this.

Some of the code paths (namely the generation path for evals) uses this BPE config to instantiate tokenizers. Unfortunately, since this field is missing from the dataclass, it doesn't get populated so when we load up models over there, we can't tell that the tokenizer should be instantiated, and we end up with this hardcoded gpt2 tokenizer path.

This patch fixes that by allowing the tokenizer to load in this BPE class.

**Testing steps**
Evaluating a model trained with a different tokenizer.