### PR TITLE
[gen] Fix assert boundary

### DIFF
--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -63,7 +63,7 @@ class SequenceGenerator(nn.Module):
             topp = 0.0
         self.sampling_topp = max(0, topp)
         self.temperature = temperature
-        assert temperature > 0, "--temperature must be greater than 0"
+        assert temperature >= 0, "--temperature must be >=0"
 
         self.model.eval()
         self.profile = profile


### PR DESCRIPTION
**Patch Description**
This assert is incorrect. Temperature = 0.0 is allowed just fine.

**Testing steps**
Greedy generation in some evals.