### PR TITLE
[Cleanup] Remove *_scriptable methods

### DIFF
--- a/metaseq/criterions/cross_entropy.py
+++ b/metaseq/criterions/cross_entropy.py
@@ -68,7 +68,7 @@ class CrossEntropyCriterion(BaseCriterion):
         ):
             with torch.no_grad():
                 # yank out the inner states we wish to instrument
-                # see transformer_decoder.py TransformerDecoder.extract_features_scriptable
+                # see transformer_decoder.py TransformerDecoder.extract_features
                 emb, *_, actv = net_output[1]["inner_states"]
                 assert isinstance(
                     emb, dict

--- a/metaseq/model_parallel/criterions/vocab_parallel_cross_entropy.py
+++ b/metaseq/model_parallel/criterions/vocab_parallel_cross_entropy.py
@@ -68,7 +68,7 @@ class VocabParallelCrossEntropyCriterion(BaseCriterion):
         ):
             with torch.no_grad():
                 # yank out the inner states we wish to instrument
-                # see transformer_decoder.py TransformerDecoder.extract_features_scriptable
+                # see transformer_decoder.py TransformerDecoder.extract_features
                 emb, *_, actv = net_output[1]["inner_states"]
                 assert isinstance(
                     emb, dict

--- a/metaseq/models/base_decoder.py
+++ b/metaseq/models/base_decoder.py
@@ -52,14 +52,6 @@ class BaseDecoder(nn.Module):
 
     def get_normalized_probs(self, logits: Tensor, log_probs: bool):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(logits, log_probs)
-
-    # TorchScript doesn't support super() method so that the scriptable Subclass
-    # can't access the base class model in Torchscript.
-    # Current workaround is to add a helper function with different name and
-    # call the helper function from scriptable Subclass.
-    def get_normalized_probs_scriptable(self, logits: Tensor, log_probs: bool):
-        """Get normalized probabilities (or log probs) from a net's output."""
         if log_probs:
             return utils.log_softmax(logits, dim=-1, onnx_trace=self.onnx_trace)
         else:

--- a/metaseq/models/base_model.py
+++ b/metaseq/models/base_model.py
@@ -60,18 +60,6 @@ class BaseModel(nn.Module):
         log_probs: bool,
     ):
         """Get normalized probabilities (or log probs) from a net's output."""
-        return self.get_normalized_probs_scriptable(net_output, log_probs)
-
-    # TorchScript doesn't support super() method so that the scriptable Subclass
-    # can't access the base class model in Torchscript.
-    # Current workaround is to add a helper function with different name and
-    # call the helper function from scriptable Subclass.
-    def get_normalized_probs_scriptable(
-        self,
-        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
-        log_probs: bool,
-    ):
-        """Scriptable helper function for get_normalized_probs in ~BaseModel"""
         if hasattr(self, "decoder"):
             return self.decoder.get_normalized_probs(net_output, log_probs)
         elif torch.is_tensor(net_output):

--- a/metaseq/models/transformer_decoder.py
+++ b/metaseq/models/transformer_decoder.py
@@ -414,25 +414,6 @@ class TransformerDecoder(IncrementalDecoder):
         token_embeddings: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[Tensor] = None,
     ):
-        return self.extract_features_scriptable(
-            prev_output_tokens,
-            incremental_state=incremental_state,
-            token_embeddings=token_embeddings,
-            self_attn_padding_mask=self_attn_padding_mask,
-        )
-
-    def extract_features_scriptable(
-        self,
-        prev_output_tokens,
-        incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        token_embeddings: Optional[Tensor] = None,
-        self_attn_padding_mask: Optional[Tensor] = None,
-    ):
-        """
-        A scriptable subclass of this class has an extract_features method and calls
-        super().extract_features, but super() is not supported in torchscript. A copy
-        of this function is made to be used in the subclass instead.
-        """
         last_layer_idx = self.num_layers - 1
 
         # compute self-attention padding mask (involves device-to-host transfer,

--- a/metaseq/models/transformer_encoder.py
+++ b/metaseq/models/transformer_encoder.py
@@ -126,36 +126,6 @@ class TransformerEncoder(BaseEncoder):
                 - **encoder_embedding** (Tensor): the (scaled) embedding lookup
                   of shape `(batch, src_len, embed_dim)`
         """
-        return self.forward_scriptable(src_tokens, src_lengths, token_embeddings)
-
-    # TorchScript doesn't support super() method so that the scriptable Subclass
-    # can't access the base class model in Torchscript.
-    # Current workaround is to add a helper function with different name and
-    # call the helper function from scriptable Subclass.
-    def forward_scriptable(
-        self,
-        src_tokens,
-        src_lengths: Optional[torch.Tensor] = None,
-        token_embeddings: Optional[torch.Tensor] = None,
-    ):
-        """
-        Args:
-            src_tokens (LongTensor): tokens in the source language of shape
-                `(batch, src_len)`
-            src_lengths (torch.LongTensor): lengths of each source sentence of
-                shape `(batch)`
-            token_embeddings (torch.Tensor, optional): precomputed embeddings
-                default `None` will recompute embeddings
-
-        Returns:
-            dict:
-                - **encoder_out** (Tensor): the last encoder layer's output of
-                  shape `(src_len, batch, embed_dim)`
-                - **encoder_padding_mask** (ByteTensor): the positions of
-                  padding elements of shape `(batch, src_len)`
-                - **encoder_embedding** (Tensor): the (scaled) embedding lookup
-                  of shape `(batch, src_len, embed_dim)`
-        """
         # compute padding mask
         encoder_padding_mask = src_tokens.eq(self.padding_idx)
         has_pads = encoder_padding_mask.any()


### PR DESCRIPTION
* Removed `extract_features_scriptable` from TransformerDecoder
* Removed `get_normalized_probs_scriptable` from BaseModel
* Removed `forward_scriptable` from TransformerEncoder