### PR TITLE
Fix the way batch overflow in API requests is detected

### DIFF
--- a/metaseq_cli/interactive_hosted.py
+++ b/metaseq_cli/interactive_hosted.py
@@ -96,7 +96,7 @@ def batching_loop(timeout=100, max_tokens=MAX_BATCH_TOKENS):
             # fit the max sequence length
             max_prompt_len = max(x.prompt_len for x in [item] + batch)
             max_gen_len = max(x.gen_len for x in [item] + batch)
-            overflow = max_prompt_len + max_gen_len < MAX_SEQ_LEN
+            overflow = (max_prompt_len + max_gen_len) > MAX_SEQ_LEN
             if batch and (batch_cost > max_tokens or overflow):
                 # we're over budget, put it back in the queue
                 target_queue.put(item)


### PR DESCRIPTION
**Patch Description**
I noticed the API might be under-batching because we don't correctly detect when a batch might exceed MAX_SEQ_LEN.

**Testing steps**
Ran the API locally + curl

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
