### PR TITLE
[Cleanup] Remove unused args in MHA, cleanup empty returns

### DIFF
--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -510,7 +510,8 @@ class ModelParallelMultiheadAttention(nn.Module):
         embed_dim_partition = embed_dim // self.model_parallel_size
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim_partition)
         attn, attn_bias = self.out_proj(attn)
-        # logger.info("output:" + str(attn.float().norm().item()))
+        # Note that this no longer matches the signature of non-model-parallel version, which returns
+        # Tuple[Tensor, Optional[Tensor]]
         return attn, attn_bias
 
     def _get_input_buffer(

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -510,11 +510,8 @@ class ModelParallelMultiheadAttention(nn.Module):
         embed_dim_partition = embed_dim // self.model_parallel_size
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim_partition)
         attn, attn_bias = self.out_proj(attn)
-        # return attn_weights None to keep the return type same as single gpu multihead attention
-        # This will be deprecated.
-        attn_weights: Optional[Tensor] = None
         # logger.info("output:" + str(attn.float().norm().item()))
-        return (attn, attn_bias), attn_weights
+        return (attn, attn_bias), None
 
     def _get_input_buffer(
         self, incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]]

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -511,7 +511,7 @@ class ModelParallelMultiheadAttention(nn.Module):
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim_partition)
         attn, attn_bias = self.out_proj(attn)
         # logger.info("output:" + str(attn.float().norm().item()))
-        return (attn, attn_bias), None
+        return attn, attn_bias
 
     def _get_input_buffer(
         self, incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]]

--- a/metaseq/model_parallel/modules/multihead_attention.py
+++ b/metaseq/model_parallel/modules/multihead_attention.py
@@ -265,7 +265,6 @@ class ModelParallelMultiheadAttention(nn.Module):
         value: Optional[Tensor],
         key_padding_mask: Optional[Tensor] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
-        static_kv: bool = False,
         attn_mask: Optional[Tensor] = None,
         **unused_kwargs,
     ) -> Tuple[Tensor, Optional[Tensor]]:
@@ -417,11 +416,8 @@ class ModelParallelMultiheadAttention(nn.Module):
                     prev_key = _prev_key.view(
                         bsz * self.num_heads_partition, -1, self.head_dim
                     )
-                    if static_kv:
-                        k = prev_key
-                    else:
-                        assert k is not None
-                        k = torch.cat([prev_key, k], dim=1)
+                    assert k is not None
+                    k = torch.cat([prev_key, k], dim=1)
                     src_len = k.size(1)
                 if "prev_value" in saved_state:
                     _prev_value = saved_state["prev_value"]
@@ -429,11 +425,8 @@ class ModelParallelMultiheadAttention(nn.Module):
                     prev_value = _prev_value.view(
                         bsz * self.num_heads_partition, -1, self.head_dim
                     )
-                    if static_kv:
-                        v = prev_value
-                    else:
-                        assert v is not None
-                        v = torch.cat([prev_value, v], dim=1)
+                    assert v is not None
+                    v = torch.cat([prev_value, v], dim=1)
                 saved_state["prev_key"] = k.view(
                     bsz, self.num_heads_partition, -1, self.head_dim
                 )

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -159,6 +159,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
         incremental_state=None,
         attn_mask=None,
     ):
+        # This is calling into ModelParallelMultiheadAttention.forward
         attn_output, attn_bias = self.self_attn(
             query=query,
             key=key,

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -159,7 +159,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
         incremental_state=None,
         attn_mask=None,
     ):
-        (attn_output, attn_bias), _ = self.self_attn(
+        attn_output, attn_bias = self.self_attn(
             query=query,
             key=key,
             value=value,
@@ -180,4 +180,4 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             training=self.training,
         )
         x = x + residual
-        return x, None
+        return x

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -159,7 +159,7 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
         incremental_state=None,
         attn_mask=None,
     ):
-        (attn_output, attn_bias), attn_weights = self.self_attn(
+        (attn_output, attn_bias), _ = self.self_attn(
             query=query,
             key=key,
             value=value,
@@ -180,4 +180,4 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             training=self.training,
         )
         x = x + residual
-        return x, attn_weights
+        return x, None

--- a/metaseq/model_parallel/modules/transformer_layer.py
+++ b/metaseq/model_parallel/modules/transformer_layer.py
@@ -157,7 +157,6 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
         residual,
         key_padding_mask=None,
         incremental_state=None,
-        need_weights=False,
         attn_mask=None,
     ):
         (attn_output, attn_bias), attn_weights = self.self_attn(
@@ -166,7 +165,6 @@ class ModelParallelTransformerDecoderLayer(TransformerDecoderLayer):
             value=value,
             key_padding_mask=key_padding_mask,
             incremental_state=incremental_state,
-            need_weights=need_weights,
             attn_mask=attn_mask,
         )
         # Note [naman]: got rid off fused bias, dropout and residual cause

--- a/metaseq/models/transformer_decoder.py
+++ b/metaseq/models/transformer_decoder.py
@@ -38,12 +38,11 @@ class TransformerDecoderMultiLayerBlockModule(nn.Module):
         self.layers = nn.ModuleList(layers)
 
     def forward(self, x, **kwargs):
-        l_aux = []
         inner_states = []
         for layer in self.layers:
-            x, layer_attn, _, l_aux_i = layer(x, **kwargs)
+            x, _, _, _ = layer(x, **kwargs)
             inner_states.append(x)
-        return x, layer_attn, inner_states, l_aux
+        return x, None, inner_states, []
 
 
 def _log_weight_stats(tensor, name):

--- a/metaseq/models/transformer_decoder.py
+++ b/metaseq/models/transformer_decoder.py
@@ -37,6 +37,8 @@ class TransformerDecoderMultiLayerBlockModule(nn.Module):
         super().__init__()
         self.layers = nn.ModuleList(layers)
 
+    # TODO[susanz]: Return signature seems off. Cleanup?
+    #  fsdp_checkpoint_wrap_layer_frequency always 1 so this path is not called.
     def forward(self, x, **kwargs):
         inner_states = []
         for layer in self.layers:

--- a/metaseq/models/transformer_encoder.py
+++ b/metaseq/models/transformer_encoder.py
@@ -141,7 +141,7 @@ class TransformerEncoder(BaseEncoder):
 
         # encoder layers
         for layer in self.layers:
-            x, _ = layer(
+            x = layer(
                 x, encoder_padding_mask=encoder_padding_mask if has_pads else None
             )
 
@@ -158,7 +158,6 @@ class TransformerEncoder(BaseEncoder):
             "encoder_embedding": [encoder_embedding],  # B x T x C
             "src_tokens": [],
             "src_lengths": [],
-            "l_aux": [],
         }
 
     def max_positions(self):

--- a/metaseq/models/transformer_encoder.py
+++ b/metaseq/models/transformer_encoder.py
@@ -140,12 +140,10 @@ class TransformerEncoder(BaseEncoder):
         x = x.transpose(0, 1)
 
         # encoder layers
-        l_aux = []
         for layer in self.layers:
-            x, l_aux_i = layer(
+            x, _ = layer(
                 x, encoder_padding_mask=encoder_padding_mask if has_pads else None
             )
-            l_aux.append(l_aux_i)
 
         if self.layer_norm is not None:
             x = self.layer_norm(x)
@@ -160,7 +158,7 @@ class TransformerEncoder(BaseEncoder):
             "encoder_embedding": [encoder_embedding],  # B x T x C
             "src_tokens": [],
             "src_lengths": [],
-            "l_aux": l_aux,
+            "l_aux": [],
         }
 
     def max_positions(self):

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -316,7 +316,7 @@ class MultiheadAttention(nn.Module):
         assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
         attn = self.out_proj(attn)
-        return attn
+        return attn, None  # To match return type of F.multi_head_attention_forward
 
     @torch.jit.export
     def reorder_incremental_state(

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -316,7 +316,7 @@ class MultiheadAttention(nn.Module):
         assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
         attn = self.out_proj(attn)
-        return attn, None
+        return attn
 
     @torch.jit.export
     def reorder_incremental_state(

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -131,7 +131,6 @@ class MultiheadAttention(nn.Module):
         key_padding_mask: Optional[Tensor] = None,
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         attn_mask: Optional[Tensor] = None,
-        before_softmax: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Input shape: Time x Batch x Channel
 
@@ -142,8 +141,6 @@ class MultiheadAttention(nn.Module):
             attn_mask (ByteTensor, optional): typically used to
                 implement causal attention, where the mask prevents the
                 attention from looking forward in time (default: None).
-            before_softmax (bool, optional): return the raw attention
-                weights and values before the attention softmax.
         """
         tgt_len, bsz, embed_dim = query.size()
         src_len = tgt_len
@@ -309,9 +306,6 @@ class MultiheadAttention(nn.Module):
                 float("-inf"),
             )
             attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
-
-        if before_softmax:
-            return attn_weights, v
 
         attn_weights_float = utils.softmax(attn_weights, dim=-1)
         attn_weights = attn_weights_float.type_as(attn_weights)

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -316,8 +316,7 @@ class MultiheadAttention(nn.Module):
         assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
         attn = self.out_proj(attn)
-        attn_weights: Optional[Tensor] = None
-        return attn, attn_weights
+        return attn, None
 
     @torch.jit.export
     def reorder_incremental_state(

--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -134,7 +134,6 @@ class MultiheadAttention(nn.Module):
         static_kv: bool = False,
         attn_mask: Optional[Tensor] = None,
         before_softmax: bool = False,
-        need_head_weights: bool = False,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """Input shape: Time x Batch x Channel
 
@@ -149,13 +148,7 @@ class MultiheadAttention(nn.Module):
                 attention from looking forward in time (default: None).
             before_softmax (bool, optional): return the raw attention
                 weights and values before the attention softmax.
-            need_head_weights (bool, optional): return the attention
-                weights for each head. Implies *need_weights*. Default:
-                return the average attention weights over all heads.
         """
-        if need_head_weights:
-            need_weights = True
-
         tgt_len, bsz, embed_dim = query.size()
         src_len = tgt_len
         assert embed_dim == self.embed_dim, f"query dim {embed_dim} != {self.embed_dim}"
@@ -345,9 +338,8 @@ class MultiheadAttention(nn.Module):
             attn_weights = attn_weights_float.view(
                 bsz, self.num_heads, tgt_len, src_len
             ).transpose(1, 0)
-            if not need_head_weights:
-                # average attention weights over heads
-                attn_weights = attn_weights.mean(dim=0)
+            # average attention weights over heads
+            attn_weights = attn_weights.mean(dim=0)
 
         return attn, attn_weights
 

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -176,7 +176,7 @@ class TransformerDecoderLayer(nn.Module):
         incremental_state=None,
         attn_mask=None,
     ):
-        x, attn = self.self_attn(
+        x, _ = self.self_attn(
             query=query,
             key=key,
             value=value,
@@ -185,7 +185,7 @@ class TransformerDecoderLayer(nn.Module):
             attn_mask=attn_mask,
         )
         x = self.dropout_module(x)
-        return self.residual_connection(x, residual), attn
+        return self.residual_connection(x, residual), None
 
     def forward(
         self,
@@ -204,7 +204,7 @@ class TransformerDecoderLayer(nn.Module):
 
         residual = x
         x = self.self_attn_layer_norm(x)
-        x, attn = self.forward_attention(
+        x, _ = self.forward_attention(
             query=x,
             key=x,
             value=x,
@@ -222,9 +222,8 @@ class TransformerDecoderLayer(nn.Module):
             fc2=self.fc2,
             dropout_module=self.dropout_module,
         )
-        l_aux = None
         x = self.residual_connection(x, residual)
-        return x, attn, None, l_aux
+        return x, None, None, None
 
     def make_generation_fast_(self, **kwargs):
         pass

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -176,7 +176,7 @@ class TransformerDecoderLayer(nn.Module):
         incremental_state=None,
         attn_mask=None,
     ):
-        x, _ = self.self_attn(
+        x = self.self_attn(
             query=query,
             key=key,
             value=value,
@@ -185,7 +185,7 @@ class TransformerDecoderLayer(nn.Module):
             attn_mask=attn_mask,
         )
         x = self.dropout_module(x)
-        return self.residual_connection(x, residual), None
+        return self.residual_connection(x, residual)
 
     def forward(
         self,
@@ -204,7 +204,7 @@ class TransformerDecoderLayer(nn.Module):
 
         residual = x
         x = self.self_attn_layer_norm(x)
-        x, _ = self.forward_attention(
+        x = self.forward_attention(
             query=x,
             key=x,
             value=x,
@@ -223,7 +223,7 @@ class TransformerDecoderLayer(nn.Module):
             dropout_module=self.dropout_module,
         )
         x = self.residual_connection(x, residual)
-        return x, None, None, None
+        return x
 
     def make_generation_fast_(self, **kwargs):
         pass

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -174,7 +174,6 @@ class TransformerDecoderLayer(nn.Module):
         residual,
         key_padding_mask=None,
         incremental_state=None,
-        need_weights=False,
         attn_mask=None,
     ):
         x, attn = self.self_attn(
@@ -183,7 +182,6 @@ class TransformerDecoderLayer(nn.Module):
             value=value,
             key_padding_mask=key_padding_mask,
             incremental_state=incremental_state,
-            need_weights=need_weights,
             attn_mask=attn_mask,
         )
         x = self.dropout_module(x)
@@ -213,7 +211,6 @@ class TransformerDecoderLayer(nn.Module):
             residual=residual,
             key_padding_mask=self_attn_padding_mask,
             incremental_state=incremental_state,
-            need_weights=False,
             attn_mask=self_attn_mask,
         )
         residual = x

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -176,7 +176,7 @@ class TransformerDecoderLayer(nn.Module):
         incremental_state=None,
         attn_mask=None,
     ):
-        x = self.self_attn(
+        x, _ = self.self_attn(
             query=query,
             key=key,
             value=value,

--- a/metaseq/modules/transformer_encoder_layer.py
+++ b/metaseq/modules/transformer_encoder_layer.py
@@ -104,6 +104,5 @@ class TransformerEncoderLayer(nn.Module):
             self.fc2,
             self.dropout_module,
         )
-        l_aux = None
         x = self.residual_connection(x, residual)
-        return x, l_aux
+        return x, None

--- a/metaseq/modules/transformer_encoder_layer.py
+++ b/metaseq/modules/transformer_encoder_layer.py
@@ -84,7 +84,7 @@ class TransformerEncoderLayer(nn.Module):
 
         residual = x
         x = self.self_attn_layer_norm(x)
-        x = self.self_attn(
+        x, _ = self.self_attn(
             query=x,
             key=x,
             value=x,

--- a/metaseq/modules/transformer_encoder_layer.py
+++ b/metaseq/modules/transformer_encoder_layer.py
@@ -89,7 +89,6 @@ class TransformerEncoderLayer(nn.Module):
             key=x,
             value=x,
             key_padding_mask=encoder_padding_mask,
-            need_weights=False,
             attn_mask=attn_mask,
         )
 

--- a/metaseq/modules/transformer_encoder_layer.py
+++ b/metaseq/modules/transformer_encoder_layer.py
@@ -84,7 +84,7 @@ class TransformerEncoderLayer(nn.Module):
 
         residual = x
         x = self.self_attn_layer_norm(x)
-        x, _ = self.self_attn(
+        x = self.self_attn(
             query=x,
             key=x,
             value=x,
@@ -105,4 +105,4 @@ class TransformerEncoderLayer(nn.Module):
             self.dropout_module,
         )
         x = self.residual_connection(x, residual)
-        return x, None
+        return x


### PR DESCRIPTION
From MHA, removed the following args:
* `need_head_weights`
* `need_weights`
* `static_kv`
* `before_softmax`

Cleaned up some cluttered returns from MHA (`attn_weights` and `l_aux`).

Follow-up: https://github.com/facebookresearch/metaseq/issues/423

Tested with 2x model parallel 125m, and non-model-parallel 125m.