### PR TITLE
Add support for constants override

### DIFF
--- a/metaseq/cli/README.md
+++ b/metaseq/cli/README.md
@@ -1,0 +1,63 @@
+# Easily running custom metaseq models
+
+Say you're running one of the interactive inference pragroms in `metaseq.cli`.
+You probably needed to make changes to `metaseq.service.constants`: perhaps you changed the `LAUNCH_ARGS` or `MODEL_PARALLEL` setting, or your overrode the `CHECKPOINT_FOLDER`.
+
+This gets inconvenient, since you may be experimenting with multiple models, and you'd like to be able to pull changes without overwriting your modified `constants.py`.
+
+## Using overrides
+
+1. Copy your overridden `constants.py` to another folder (for example, `~/my_constants/my_first_override.py`) [1].
+2. Export an environment variable so that the above folder is in your `PYTHONPATH`: `export PYTHONPATH=$PYTHONPATH:~/my_constants`
+3. Export an environment variable with your override's module name: `export METASEQ_SERVICE_CONSTANTS_MODULE=my_first_override`
+
+Now, when you run an interactive inferencer from this directory, it'll use your overridden constants.
+
+### [1] Example contents of `my_first_override.py`
+
+Note: this is modified from the main branch as of the time of writing.
+Comments highlight changes.
+
+```
+import os
+
+MAX_SEQ_LEN = 1024                                                # <--- changed
+BATCH_SIZE = 2048
+MAX_BATCH_TOKENS = 3072
+DEFAULT_PORT = 6010
+MODEL_PARALLEL = 2                                                # <--- changed
+TOTAL_WORLD_SIZE = 8
+MAX_BEAM = 32
+
+CHECKPOINT_FOLDER = "/shared/my_cool_checkpoint"                  # <--- changed
+
+# tokenizer files
+BPE_MERGES = os.path.join(CHECKPOINT_FOLDER, "gpt2-merges.txt")
+BPE_VOCAB = os.path.join(CHECKPOINT_FOLDER, "gpt2-vocab.json")
+MODEL_FILE = os.path.join(CHECKPOINT_FOLDER, "reshard.pt")
+
+LAUNCH_ARGS = [
+    f"--model-parallel-size {MODEL_PARALLEL}",
+    f"--distributed-world-size {TOTAL_WORLD_SIZE}",
+    "--ddp-backend fully_sharded",                                # <--- changed
+    "--task language_modeling",
+    f"--bpe-merges {BPE_MERGES}",
+    f"--bpe-vocab {BPE_VOCAB}",
+    "--bpe hf_byte_bpe",
+    f"--merges-filename {BPE_MERGES}",
+    f"--vocab-filename {BPE_VOCAB}",
+    f"--path {MODEL_FILE}",
+    "--beam 1 --nbest 1",
+    "--distributed-port 13000",
+    "--checkpoint-shard-count 1",
+    f"--batch-size {BATCH_SIZE}",
+    f"--buffer-size {BATCH_SIZE * MAX_SEQ_LEN}",
+    f"--max-tokens {BATCH_SIZE * MAX_SEQ_LEN}",
+    "/tmp",  # required "data" argument.
+]
+```
+
+## Suggested serving
+
+You can create an override for each of the models you'd like to be able to use, and you can put them all in the same folder.
+Then, when you'd like to swap to use a different model, just change the environment variable we exported in step 3 above and relaunch.

--- a/metaseq/cli/interactive_cli.py
+++ b/metaseq/cli/interactive_cli.py
@@ -119,4 +119,14 @@ def cli_main():
 
 
 if __name__ == "__main__":
+    if os.getenv("SLURM_NODEID") is None:
+        logger.warning(
+            f"Missing slurm configuration, defaulting to 'use entire node' for API"
+        )
+        os.environ["SLURM_NODEID"] = "0"
+        os.environ["SLURM_NNODES"] = "1"
+        os.environ["SLURM_NTASKS"] = "1"
+        import socket
+
+        os.environ["SLURM_STEP_NODELIST"] = socket.gethostname()
     cli_main()

--- a/metaseq/cli/interactive_cli.py
+++ b/metaseq/cli/interactive_cli.py
@@ -23,11 +23,18 @@ from metaseq.dataclass.configs import MetaseqConfig
 from metaseq.dataclass.utils import convert_namespace_to_omegaconf
 from metaseq.distributed import utils as distributed_utils
 from metaseq.hub_utils import GeneratorInterface
-from metaseq.service.constants import (
-    TOTAL_WORLD_SIZE,
-    LAUNCH_ARGS,
-)
 from metaseq.service.utils import build_logger
+
+import importlib
+
+if "METASEQ_SERVICE_CONSTANTS_MODULE" not in os.environ:
+    constants_module = importlib.import_module("metaseq.service.constants")
+else:
+    constants_module = importlib.import_module(
+        os.environ["METASEQ_SERVICE_CONSTANTS_MODULE"]
+    )
+TOTAL_WORLD_SIZE = constants_module.TOTAL_WORLD_SIZE
+LAUNCH_ARGS = constants_module.LAUNCH_ARGS
 
 logger = build_logger()
 

--- a/metaseq/cli/interactive_hosted.py
+++ b/metaseq/cli/interactive_hosted.py
@@ -29,17 +29,27 @@ from metaseq.distributed import utils as distributed_utils
 from metaseq.hub_utils import GeneratorInterface
 from metaseq.service.queue import PriorityQueueRingShard
 from metaseq.service.workers import WorkItem
-from metaseq.service.constants import (
-    MAX_SEQ_LEN,
-    MAX_BATCH_TOKENS,
-    MAX_BEAM,
-    DEFAULT_PORT,
-    TOTAL_WORLD_SIZE,
-    LAUNCH_ARGS,
-)
 from metaseq.service.utils import get_my_ip, build_logger
 from metaseq.service.responses import OAIResponse
 
+import importlib
+
+if "METASEQ_SERVICE_CONSTANTS_MODULE" not in os.environ:
+    constants_module = importlib.import_module("metaseq.service.constants")
+else:
+    constants_module = importlib.import_module(
+        os.environ["METASEQ_SERVICE_CONSTANTS_MODULE"]
+    )
+    # Don't forget to patch OAIResponse
+    import metaseq.service.responses
+
+    metaseq.service.responses.CHECKPOINT_FOLDER = constants_module.CHECKPOINT_FOLDER
+MAX_SEQ_LEN = constants_module.MAX_SEQ_LEN
+MAX_BATCH_TOKENS = constants_module.MAX_BATCH_TOKENS
+MAX_BEAM = constants_module.MAX_BEAM
+DEFAULT_PORT = constants_module.DEFAULT_PORT
+TOTAL_WORLD_SIZE = constants_module.TOTAL_WORLD_SIZE
+LAUNCH_ARGS = constants_module.LAUNCH_ARGS
 
 app = Flask(__name__)
 

--- a/metaseq/service/responses.py
+++ b/metaseq/service/responses.py
@@ -5,7 +5,9 @@
 
 import uuid
 import time
-from metaseq.service.constants import CHECKPOINT_FOLDER
+import metaseq.service.constants
+
+CHECKPOINT_FOLDER = metaseq.service.constants.CHECKPOINT_FOLDER
 
 
 class OAIResponse:


### PR DESCRIPTION
**Patch Description**
`constants.py` needs to be changed for every model configuration. Rather than editing the file in place, this change allows you to _optionally_ export an environment variable `METASEQ_SERVICE_CONSTANTS_MODULE` which is on the python path. When you do this, it will be used for the `interactive_hosted.py` configuration instead.

This allows you to have multiple, local flavors of constants that you can easily refer to.


**Testing steps**
I made a local override and successfully loaded a model that uses different `LAUNCH_ARGS` than what are commited.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
