### PR TITLE
Add argument for max generated tokens

### DIFF
--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -22,6 +22,7 @@ class SequenceGenerator(nn.Module):
         beam_size: int = 1,
         max_len_a: int = 0,
         max_len_b: int = 200,
+        max_gen_tokens: int = 2048,
         min_len: int = 1,
         temperature: float = 1.0,
         need_logprobs: bool = False,
@@ -57,6 +58,7 @@ class SequenceGenerator(nn.Module):
         self.beam_size = min(beam_size, self.vocab_size - 1)
         self.max_len_a = max_len_a
         self.max_len_b = max_len_b
+        self.max_gen_tokens = max_gen_tokens
         self.min_len = min_len
         self.need_logprobs = need_logprobs
         self.stop = stop if stop is not None else []
@@ -128,7 +130,7 @@ class SequenceGenerator(nn.Module):
         bsz, src_len = src_tokens.size()[:2]
         beam_size = self.beam_size
 
-        max_len = min(self.model.max_decoder_positions() - 1, self.max_len_b or 1e99)
+        max_len = min(self.model.max_decoder_positions() - 1, self.max_len_b or 1e99, src_tokens.size(1) + self.max_gen_tokens)
         min_len = min(max_len - 1, self.min_len or 0)
 
         assert (

--- a/metaseq/tasks/base_task.py
+++ b/metaseq/tasks/base_task.py
@@ -365,6 +365,7 @@ class BaseTask(object):
             beam_size=getattr(args, "beam", 5),
             max_len_a=getattr(args, "max_len_a", 0),
             max_len_b=getattr(args, "max_len_b", 200),
+            max_gen_tokens=getattr(args, "max_gen_tokens", 2048),
             min_len=getattr(args, "min_len", 1),
             temperature=getattr(args, "temperature", 1.0),
             topp=sampling_topp,


### PR DESCRIPTION
Added a new argument to restrict generation to a fixed number of tokens

Tested with 
```
CUDA_VISIBLE_DEVICES=0,1 FSD=/fsx-mudslide/rpasunuru/data/instruct-opt/prompt_data/allbenchmarks_io_streaming_after_dedup_v5_sorted \
python metaseq_internal/scripts/eval/schedule_jobs_few_shot_instruct_opt.py \
-t opti_valid_data_to_text__unified_skg__totto__prompt0 \
-m 1.3B_gptz \
-o /fsx-mudslide/sviyer/tmp_100/ \
--slurm-partition instruct-opt \
--batch-size 8 --override-completed --n-eval-samples 100 --max-gen-tokens 100 --local
```

- Confirmed that it is generating 100 tokens for each example with this argument, and without it, it generates > 1800 tokens per argument.
- Conputed rouge metrics and 
      100-tokens = 0.0472
       2048 tokens = 0.0047

Also putting out a PR for MSI