### PR TITLE
remove fixed lr_schedule references

### DIFF
--- a/metaseq/dataclass/utils.py
+++ b/metaseq/dataclass/utils.py
@@ -397,11 +397,6 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
         cfg.lr_scheduler = Namespace(**vars(args))
         from metaseq.optim.lr_scheduler import LR_SCHEDULER_REGISTRY
 
-        if args.lr_scheduler == "fixed":
-            # hack since we don't want to call a "fixed" LR scheduler.
-            logger.info("Overriding lr_scheduler config from fixed to inverse_sqrt")
-            args.lr_scheduler = "inverse_sqrt"
-
         _set_legacy_defaults(cfg.lr_scheduler, LR_SCHEDULER_REGISTRY[args.lr_scheduler])
         cfg.lr_scheduler._name = args.lr_scheduler
     if cfg.criterion is None and getattr(args, "criterion", None):

--- a/metaseq/optim/lr_scheduler/__init__.py
+++ b/metaseq/optim/lr_scheduler/__init__.py
@@ -18,7 +18,7 @@ from omegaconf import DictConfig
     LR_SCHEDULER_REGISTRY,
     LR_SCHEDULER_DATACLASS_REGISTRY,
 ) = registry.setup_registry(
-    "--lr-scheduler", base_class=BaseLRScheduler, default="fixed"
+    "--lr-scheduler", base_class=BaseLRScheduler, default="inverse_sqrt"
 )
 
 

--- a/metaseq/options.py
+++ b/metaseq/options.py
@@ -148,9 +148,6 @@ def parse_args_and_arch(
 
     for registry_name, REGISTRY in REGISTRIES.items():
         choice = getattr(args, registry_name, None)
-        # hack since we don't want to call "fixed" LR scheduler
-        if choice == "fixed":
-            choice = "inverse_sqrt"
         if choice is not None:
             cls = REGISTRY["registry"][choice]
             if hasattr(cls, "add_args"):


### PR DESCRIPTION
Removed hacks that turn "fixed" lr_schedule to "inverse_sqrt". These seem to come from the default setting in the scheduler setup. By changing this default to "inverse_sqrt" they are not necessary anymore. I checked internal as well, with its own PR.

Tested with opt_baseline.py and sweep_baseline.py with default settings: The results are the same and the setting for sweep_baseline "polynomial_decay" is correctly propagated and overriding the default.

Issue: https://github.com/facebookresearch/metaseq/issues/434
