### PR TITLE
Added dynamic configs (profiling)

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -30,6 +30,7 @@ from metaseq import (
 )
 from metaseq.data import iterators, data_utils
 from metaseq.data.plasma_utils import PlasmaStore
+from metaseq.dataclass.configs import DynamicConfig
 from metaseq.dataclass.utils import convert_namespace_to_omegaconf
 from metaseq.distributed import fsdp_enable_wrap, fsdp_wrap, utils as distributed_utils
 from metaseq.file_io import PathManager
@@ -38,7 +39,7 @@ from metaseq.model_parallel.megatron_trainer import MegatronTrainer
 from metaseq.trainer import Trainer
 
 logging.basicConfig(
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    format=f"slurm_procid {os.environ['SLURM_PROCID']} : %(asctime)s | %(levelname)s | %(name)s | %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
     level=os.environ.get("LOGLEVEL", "INFO").upper(),
     stream=sys.stdout,
@@ -308,9 +309,18 @@ def train(
 
         return valid_losses, should_stop
 
+    dcfg = DynamicConfig(
+        json_file_path=cfg.common.dynamic_config_path,
+        timeout=cfg.common.dynamic_config_timeout,
+    )
+
     for i, samples in enumerate(progress):
-        if distributed_utils.get_global_rank() == 0 and cfg.common.profile and i == 5:
-            logger.info("STARTING PROFILER")
+        force_profile = dcfg["force_profile"]
+        do_profile = (distributed_utils.get_global_rank() == 0) and (
+            (cfg.common.profile and i == 5) or force_profile
+        )
+        if do_profile:
+            logger.info(f"STARTING PROFILER: step {i}")
             with profiler.profile(
                 profile_memory=True, with_stack=True, record_shapes=True
             ) as prof:
@@ -326,8 +336,9 @@ def train(
                     file=sourceFile,
                 )
             prof.export_chrome_trace(
-                os.path.join(cfg.checkpoint.save_dir, "profiler_trace.json")
+                os.path.join(cfg.checkpoint.save_dir, f"profiler_trace_step_{i}.json")
             )
+            logger.info(f"FINISHING PROFILER: step {i}")
         else:
             valid_losses, should_stop = train(i, samples)
         if should_stop:


### PR DESCRIPTION
**Patch Description**
Made tombstoning work for RSC:

Added dynamic configs:

enabling:
 Just include  --dynamic-config-path and a specified json file path. The file must exist and will be picked up as the default dynamic config file.
 
using: 
1. when you want to change the value of a dynamic configuration just amend it in the dynamic config json file and save 
2. Allow some time for the changes to propagate (default timeout is 30 sec)

how it works: 
dynamic configuration is a dict with built-in timeout. If you are trying to access a value in the dict before the time is out, it will just give you the value with minimal overhead. If you are trying to access a value after the timeout, the entire dict will be reloaded from file and timer reset.

why it is useful:
If there is some computationally expensive logging/profiling that needs to be done only when weird behavior of the training procedure is observed, one should be able to trigger these operations on demand.

I have added the first dynamic config flag "force_profile" - it enables enabling profiling not only on step 5 but anywhere throughout training, even if cfg.common.profile = False


**Testing steps**

(using metaseq-internal) on Azure, run:
python -m metaseq_internal.projects.zucchini.sweep_baseline -g 8 -n 1 --azure --model-size 125m --data /data/gpt-z/zucchini/consolidated/v1.0 --tokenizer noregex --partition zetta --profile --dynamic-config --prefix dcfg_test

Results are in 
/shared/home/igormolybog/checkpoints/dcfg_test22/
(including traces from mnt/)

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
