### PR TITLE
Re-add supports_rename and rename to PathManager

### DIFF
--- a/metaseq/file_io/common/__init__.py
+++ b/metaseq/file_io/common/__init__.py
@@ -741,6 +741,14 @@ class PathManager:
                 return True
         return False
 
+    def supports_rename(self, path: str) -> bool:
+        # PathManager doesn't yet support renames
+        return not self.path_requires_pathmanager(path)
+
+    @staticmethod
+    def rename(src: str, dst: str):
+        os.rename(src, dst)
+
     # pyre-fixme[24]: Generic type `os.PathLike` expects 1 type parameter.
     def __get_path_handler(self, path: Union[str, os.PathLike]) -> PathHandler:
         """

--- a/metaseq/file_io/common/__init__.py
+++ b/metaseq/file_io/common/__init__.py
@@ -745,9 +745,13 @@ class PathManager:
         # PathManager doesn't yet support renames
         return not self.path_requires_pathmanager(path)
 
-    @staticmethod
-    def rename(src: str, dst: str):
-        os.rename(src, dst)
+    def rename(self, src: str, dst: str) -> None:
+        if self.supports_rename(src):
+            os.rename(src, dst)
+        else:
+            raise ValueError(
+                f"Path {src} requires PathHandler, and so doesn't support renaming."
+            )
 
     # pyre-fixme[24]: Generic type `os.PathLike` expects 1 type parameter.
     def __get_path_handler(self, path: Union[str, os.PathLike]) -> PathHandler:


### PR DESCRIPTION
Addresses #477, and also adds `rename` method to PathManager which is also called in `checkpoint_utils.torch_persistent_save`.

Currently untested, @Xirider should run in his env, as he found the bug.