### PR TITLE
isolated PR for seq_par with autograd fn to have more control over op…

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -584,6 +584,13 @@ class CheckpointConfig(MetaseqDataclass):
         metadata={"help": "cluster we are running on: azure/aws/fair/rsc"},
     )
     model_parallel_size: int = II("common.model_parallel_size")
+    sequence_parallel: bool = field(
+        default=False,
+        metadata={
+            "help": "If True, use sequeunce level parallelism as over tensor parallel gpus."
+            " only use this option when --model-parallel-size > 1"
+        },
+    )
 
 
 @dataclass

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -170,6 +170,9 @@ def distributed_init(cfg: MetaseqConfig):
                 initialize_model_parallel,
                 model_parallel_cuda_manual_seed,
             )
+            # Following initializes memory buffer in Megatron code which uses
+            # buffered memory for tensor parallel GPU comms protocols
+            from megatron.global_vars import _set_global_memory_buffer
         except ImportError:
             raise ImportError(
                 "\n\nPlease install megatron using the setup instructions!"
@@ -180,6 +183,7 @@ def distributed_init(cfg: MetaseqConfig):
         if torch.cuda.is_available():
             dist.all_reduce(torch.zeros(1).cuda(), group=get_model_parallel_group())
         model_parallel_cuda_manual_seed(cfg.common.seed)
+        _set_global_memory_buffer()
         model_part_number = get_model_parallel_rank()
         cfg.checkpoint.checkpoint_suffix += "-model_part-{0}".format(model_part_number)
 

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -170,9 +170,10 @@ def distributed_init(cfg: MetaseqConfig):
                 initialize_model_parallel,
                 model_parallel_cuda_manual_seed,
             )
+
             # Following initializes memory buffer in Megatron code which uses
             # buffered memory for tensor parallel GPU comms protocols
-            from megatron.global_vars import _set_global_memory_buffer
+            from megatron.global_vars import _GLOBAL_MEMORY_BUFFER, _set_global_memory_buffer
         except ImportError:
             raise ImportError(
                 "\n\nPlease install megatron using the setup instructions!"
@@ -183,7 +184,10 @@ def distributed_init(cfg: MetaseqConfig):
         if torch.cuda.is_available():
             dist.all_reduce(torch.zeros(1).cuda(), group=get_model_parallel_group())
         model_parallel_cuda_manual_seed(cfg.common.seed)
-        _set_global_memory_buffer()
+        # This check should not be usually needed as we call init only once
+        # but seems like tests are calling it multiple times.
+        if _GLOBAL_MEMORY_BUFFER is None:
+            _set_global_memory_buffer()
         model_part_number = get_model_parallel_rank()
         cfg.checkpoint.checkpoint_suffix += "-model_part-{0}".format(model_part_number)
 

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -173,7 +173,10 @@ def distributed_init(cfg: MetaseqConfig):
 
             # Following initializes memory buffer in Megatron code which uses
             # buffered memory for tensor parallel GPU comms protocols
-            from megatron.global_vars import _GLOBAL_MEMORY_BUFFER, _set_global_memory_buffer
+            from megatron.global_vars import (
+                _GLOBAL_MEMORY_BUFFER,
+                _set_global_memory_buffer,
+            )
         except ImportError:
             raise ImportError(
                 "\n\nPlease install megatron using the setup instructions!"

--- a/metaseq/model_parallel/models/transformer.py
+++ b/metaseq/model_parallel/models/transformer.py
@@ -59,16 +59,20 @@ class ModelParallelTransformerDecoder(TransformerDecoder):
                 "Model parallel training currently requires --share-decoder-input-output-embed"
             )
 
-        features = copy_to_tensor_model_parallel_region(features)
+        is_sequence_parallel = getattr(self.args, "sequence_parallel", False)
+        if is_sequence_parallel:
+            input_parallel = features
+        else:
+            input_parallel = mpu.copy_to_tensor_model_parallel_region(features)
 
         # project back to size of vocabulary
         x = mpu.LinearWithGradAccumulationAndAsyncCommunication.apply(
-            features,
+            input_parallel,
             self.output_projection.weight,
             None,
-            False,
-            False,
-            False,
+            False, # gradient_accumulation_fusion
+            False, # async_grad_allreduce
+            is_sequence_parallel, #sequence_parallel
         )
         # Gather output if model in in inference mode (i.e. evallm or generation) cause both are not yet compatible with
         # parallel vocab embeddings
@@ -82,3 +86,13 @@ class ModelParallelTransformerDecoder(TransformerDecoder):
     # This hook used as proxy for tracking state if model is in eval or generation mode.
     def make_generation_fast_(self, **unused):
         self.inference = True
+
+    def forward_embedding(
+        self,
+        *args,
+    ):
+        x, embed, positions = super().forward_embedding(*args)
+        is_sequence_parallel = getattr(self.args, "sequence_parallel", False)
+        if is_sequence_parallel:
+            x = mpu.scatter_to_sequence_parallel_region(x)
+        return x, embed, positions

--- a/metaseq/model_parallel/models/transformer.py
+++ b/metaseq/model_parallel/models/transformer.py
@@ -70,9 +70,9 @@ class ModelParallelTransformerDecoder(TransformerDecoder):
             input_parallel,
             self.output_projection.weight,
             None,
-            False, # gradient_accumulation_fusion
-            False, # async_grad_allreduce
-            is_sequence_parallel, #sequence_parallel
+            False,  # gradient_accumulation_fusion
+            False,  # async_grad_allreduce
+            is_sequence_parallel,  # sequence_parallel
         )
         # Gather output if model in in inference mode (i.e. evallm or generation) cause both are not yet compatible with
         # parallel vocab embeddings

--- a/metaseq/model_parallel/models/transformer.py
+++ b/metaseq/model_parallel/models/transformer.py
@@ -15,7 +15,6 @@ from metaseq.models.transformer_encoder import TransformerEncoder
 try:
     from megatron import mpu
     from megatron.mpu import (
-        copy_to_tensor_model_parallel_region,
         gather_from_tensor_model_parallel_region,
     )
 

--- a/metaseq/model_parallel/models/transformer_lm.py
+++ b/metaseq/model_parallel/models/transformer_lm.py
@@ -52,6 +52,18 @@ class ModelParallelTransformerLanguageModel(TransformerLanguageModel):
             args, "use_sharded_state", False
         ), "Use sharded state must be True for tensor parallel, otherwise model saving and loaded might be broken"
 
+        if getattr(args, "sequence_parallel", False):
+            assert (
+                getattr(args, "model_parallel_size", 1) > 1
+            ), "--sequence-parallel only works when --model-parallel-size is greater than 1"
+            assert (
+                getattr(args, "dropout", 0.0) == 0.0
+            ), "havent yet tested if rng states are correct for dropout with seq_parallel"
+            assert (
+                getattr(args, "activation_fn", 'gelu') == 'gelu'
+            ), "For now only supports gelu"
+
+
         decoder = ModelParallelTransformerDecoder(
             args,
             task.target_dictionary,

--- a/metaseq/model_parallel/models/transformer_lm.py
+++ b/metaseq/model_parallel/models/transformer_lm.py
@@ -60,9 +60,8 @@ class ModelParallelTransformerLanguageModel(TransformerLanguageModel):
                 getattr(args, "dropout", 0.0) == 0.0
             ), "havent yet tested if rng states are correct for dropout with seq_parallel"
             assert (
-                getattr(args, "activation_fn", 'gelu') == 'gelu'
+                getattr(args, "activation_fn", "gelu") == "gelu"
             ), "For now only supports gelu"
-
 
         decoder = ModelParallelTransformerDecoder(
             args,

--- a/metaseq/model_parallel/modules/__init__.py
+++ b/metaseq/model_parallel/modules/__init__.py
@@ -10,8 +10,11 @@ from .transformer_layer import (
     ModelParallelTransformerDecoderLayer,
 )
 
+from .sequence_parallel_transformer_layer import SequeuceParallelTransformerBlock
+
 __all__ = [
     "ModelParallelMultiheadAttention",
     "ModelParallelTransformerEncoderLayer",
     "ModelParallelTransformerDecoderLayer",
+    "SequeuceParallelTransformerBlock",
 ]

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -1,0 +1,299 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import torch
+
+import fused_layer_norm_cuda
+
+from metaseq.modules.activation_functions import gelu, gelu_back
+
+try:
+    from megatron.mpu.mappings import (
+        _reduce_scatter_along_first_dim,
+        _gather_along_first_dim
+    )
+    from megatron.mpu.utils import split_tensor_along_last_dim
+    from megatron.model.fused_softmax import scaled_upper_triang_masked_softmax_cuda
+    has_megatron_submodule = True
+except (ImportError, ModuleNotFoundError):
+    has_megatron_submodule = False
+
+
+
+class SequeuceParallelTransformerBlock(torch.autograd.Function):
+    """
+    This is custom FFN autograd function hardcoded for:
+    bias: false,
+    layernorm affine: false, ln eps: 1e-5
+    sequence_parallel: true,
+    activation: gelu,
+    gelu, layernorm: always recomputed i.e. no activation memory for these
+    """
+    @staticmethod
+    def forward_mha(q, k, v, bsz, seq_len, head_dim, embed_dim_per_partition, dtype):
+        scaling = head_dim ** -0.5
+        matmul_result = torch.empty(
+            bsz * (embed_dim_per_partition // head_dim),
+            seq_len,
+            seq_len,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+        # Scale q,k before matmul for stability see https://tinyurl.com/sudb9s96 for math
+        matmul_result = torch.baddbmm(
+            matmul_result,
+            math.sqrt(scaling) * q.transpose(0, 1),
+            math.sqrt(scaling) * k.transpose(0, 1).transpose(1, 2),
+            beta=0.0,
+        )
+        # attn_probs = matmul_result
+        scale_t = torch.tensor([1.0])
+        attn_probs = scaled_upper_triang_masked_softmax_cuda.forward(matmul_result, scale_t[0])
+        attn = torch.bmm(attn_probs, v)
+        attn = attn.transpose(0, 1).contiguous().view(seq_len, bsz, -1)
+        return attn, attn_probs
+
+
+    @staticmethod
+    def backward_mha(grad_mha_output, q, k, v, attn_probs, seq_len, bsz, head_dim):
+        scaling = head_dim ** -0.5
+        grad_mha_output= grad_mha_output.view(seq_len, -1, head_dim).transpose(0, 1)
+        grad_v = torch.bmm(attn_probs.transpose(1,2), grad_mha_output).transpose(0, 1).contiguous().view(seq_len, bsz, -1)
+        grad_attn_probs_out = torch.bmm(grad_mha_output, v.transpose(1, 2))
+
+        grad_attn_probs_in = scaled_upper_triang_masked_softmax_cuda.backward(
+            grad_attn_probs_out, attn_probs, 1.0
+        )
+        grad_q = torch.bmm(
+            math.sqrt(scaling) * grad_attn_probs_in,
+            math.sqrt(scaling) * k.transpose(0,1)
+        )
+        grad_q = grad_q.transpose(0, 1).contiguous().view(seq_len, bsz, -1)
+        grad_k = torch.bmm(
+            math.sqrt(scaling) * grad_attn_probs_in.transpose(1,2),
+            math.sqrt(scaling) * q.transpose(0,1)
+        )
+        grad_k = grad_k.transpose(0, 1).contiguous().view(seq_len, bsz, -1)
+        grad_kvq_proj_output = torch.cat([grad_k, grad_v, grad_q], dim=-1)
+        return grad_kvq_proj_output
+
+    @staticmethod
+    def forward(
+        ctx,
+        input,
+        kvq_proj_weight,
+        out_proj_weight,
+        fc1_weight,
+        fc2_weight,
+        head_dim,
+        recompute_fc1,
+    ):
+        ctx.recompute_fc1 = recompute_fc1
+
+        input = input.contiguous()
+
+        # Take out residual connection for self attention
+        residual = input
+        dtype = input.dtype
+
+        # Apply layer norm on (seq_len // #tp_size, bsz, embed_dim) tensor
+        ctx.layer_norm_normalized_shape = torch.Size((input.size(-1),))
+        ctx.eps = 1e-5
+
+        # # Self attention layer norm
+        mha_layer_norm_output, _, _ = fused_layer_norm_cuda.forward(input, ctx.layer_norm_normalized_shape, ctx.eps)
+
+        # all gather output across first dim, i.e. seq_len dim for kvq_proj
+        mha_layer_norm_output = _gather_along_first_dim(mha_layer_norm_output, cached_buffer_name='mpu')
+
+        # apply kvq, output is (seq_len, bsz, 3 * embed_dim // #tp_size)
+        kvq_out = torch.matmul(mha_layer_norm_output, kvq_proj_weight.t())
+        # the order here doesn't matter as much as long its consistent sice initialization is same.
+        # just matching the ordewr of metaseq MHA.
+        k, v, q = split_tensor_along_last_dim(kvq_out, 3, contiguous_split_chunks=True)
+        seq_len, bsz, embed_dim_per_partition = q.size()
+        q  = q.view(seq_len, -1, head_dim)
+        k  = k.view(seq_len, -1, head_dim)
+        v  = v.view(seq_len, -1, head_dim).transpose(0, 1)
+
+        attn, _ = SequeuceParallelTransformerBlock.forward_mha(q, k, v, bsz, seq_len, head_dim, embed_dim_per_partition, dtype)
+
+        out_proj_out = torch.matmul(attn, out_proj_weight.t())
+        out_proj_out = _reduce_scatter_along_first_dim(out_proj_out)
+
+        # out_proj_out = out_proj_out + residual
+        out_proj_out = out_proj_out + residual
+
+        # Take out residual connection for FFN
+        residual = out_proj_out
+        # No need to save mean and invvar cause we redo layernorm in backward
+        ffn_layer_norm_output, _, _ = fused_layer_norm_cuda.forward(out_proj_out, ctx.layer_norm_normalized_shape, ctx.eps)
+
+        # all gather output across first dim, i.e. seq_len dim
+        ffn_layer_norm_output = _gather_along_first_dim(ffn_layer_norm_output, cached_buffer_name='mpu')
+
+        # apply fc1, output is (seq_len, bsz, 4 * embed_dim // #tp_size)
+        fc1_out = torch.matmul(ffn_layer_norm_output, fc1_weight.t())
+        # apply gelu
+
+        gelu_out = gelu(fc1_out)
+        # apply fc2, output (seq_len, bsz, embed_dim) but needs to be
+        # summed across tp for real output
+        fc2_out = torch.matmul(gelu_out, fc2_weight.t())
+
+        if ctx.recompute_fc1:
+            fc1_out = None
+        ctx.save_for_backward(
+            input,
+            q,
+            k,
+            v,
+            out_proj_out,
+            kvq_proj_weight,
+            out_proj_weight,
+            fc1_out,
+            fc1_weight,
+            fc2_weight,
+        )
+        ctx.bsz, ctx.seq_len, ctx.head_dim, ctx.embed_dim_per_partition = bsz, seq_len, head_dim, embed_dim_per_partition
+
+        # apply scatter gather,
+        # input: (seq_len, bsz, embed_dim)
+        # output: (seq_len // #tp_size, bsz, embed_dim) (and embed_dim is summed across gpus)
+        fc2_out_post_scatter_gather = _reduce_scatter_along_first_dim(fc2_out)
+        final_out = fc2_out_post_scatter_gather + residual
+        return final_out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, q, k, v, out_proj_out, kvq_proj_weight, out_proj_weight, fc1_out, fc1_weight, fc2_weight = ctx.saved_tensors
+        bsz, seq_len, head_dim, embed_dim_per_partition = ctx.bsz, ctx.seq_len, ctx.head_dim, ctx.embed_dim_per_partition
+        dtype = grad_output.dtype
+
+        residual_grad = grad_output
+
+        # gatther gradients async,
+        # and we can overlap this with any recomptation.
+        grad_output, handle = _gather_along_first_dim(grad_output, async_op=True)
+
+        # Both of these operations are just recomputed from forward to save activation memory.
+        ffn_layer_norm_output, ffn_layer_norm_mean, ffn_layer_norm_invvar = fused_layer_norm_cuda.forward(out_proj_out, ctx.layer_norm_normalized_shape, ctx.eps)
+        # recompute gelu output for calculating fc2 weight gradient
+        # note, remember "gelu_out = fc2_in"
+        if not ctx.recompute_fc1:
+            assert fc1_out is not None
+            gelu_out = gelu(fc1_out)
+
+        # Now wait for reduce scatter
+        handle.wait()
+
+        ffn_layer_norm_output, handle = _gather_along_first_dim(ffn_layer_norm_output, async_op=True, cached_buffer_name='mpu')
+
+        grad_fc2_input = grad_output.matmul(fc2_weight)
+
+        if ctx.recompute_fc1:
+            handle.wait()
+            assert fc1_out is None
+            fc1_out = torch.matmul(ffn_layer_norm_output, fc1_weight.t())
+            gelu_out = gelu(fc1_out)
+
+        # calculate gelu backward
+        grad_gelu_input = gelu_back(grad_fc2_input, fc1_out)
+
+        # Reshape matrix and calculate gradient with respect to fc2 weight
+        grad_output = SequeuceParallelTransformerBlock._collapse_first_dimensions(
+            grad_output
+        )
+        gelu_out = SequeuceParallelTransformerBlock._collapse_first_dimensions(gelu_out)
+        grad_fc2_weight = grad_output.t().matmul(gelu_out)
+
+        grad_fc1_input = grad_gelu_input.matmul(fc1_weight)
+        handle.wait()
+
+        grad_gelu_input = SequeuceParallelTransformerBlock._collapse_first_dimensions(grad_gelu_input)
+        ffn_layer_norm_output = SequeuceParallelTransformerBlock._collapse_first_dimensions(ffn_layer_norm_output)
+
+        grad_fc1_input, handle = _reduce_scatter_along_first_dim(grad_fc1_input, async_op=True)
+
+        grad_fc1_weight = grad_gelu_input.t().matmul(ffn_layer_norm_output)
+
+        handle.wait()
+
+        grad_attention_output = fused_layer_norm_cuda.backward(
+            grad_fc1_input.contiguous(),
+            ffn_layer_norm_mean,
+            ffn_layer_norm_invvar,
+            out_proj_out,
+            ctx.layer_norm_normalized_shape,
+            ctx.eps,
+        )
+        grad_attention_output = grad_attention_output + residual_grad
+
+        residual_grad = grad_attention_output
+
+        grad_attention_output, handle = _gather_along_first_dim(
+            grad_attention_output,
+            async_op=True,
+        )
+
+        # recalculate attention
+        attn, attn_probs = SequeuceParallelTransformerBlock.forward_mha(q, k, v, bsz, seq_len, head_dim, embed_dim_per_partition, dtype)
+
+        handle.wait()
+
+        grad_out_proj_input = grad_attention_output.matmul(out_proj_weight)
+        grad_attention_output = SequeuceParallelTransformerBlock._collapse_first_dimensions(
+            grad_attention_output
+        )
+        attn = SequeuceParallelTransformerBlock._collapse_first_dimensions(attn)
+        grad_out_proj_weight = grad_attention_output.t().matmul(attn)
+
+        grad_kvq_proj_output = SequeuceParallelTransformerBlock.backward_mha(
+            grad_out_proj_input,
+            q,
+            k,
+            v,
+            attn_probs,
+            seq_len,
+            bsz,
+            head_dim
+        )
+
+        mha_layer_norm_output, mha_layer_norm_mean, mha_layer_norm_invvar = fused_layer_norm_cuda.forward(input, ctx.layer_norm_normalized_shape, ctx.eps)
+        mha_layer_norm_output, handle = _gather_along_first_dim(
+            mha_layer_norm_output,
+            async_op=True,
+            cached_buffer_name='mpu',
+        )
+        grad_input = grad_kvq_proj_output.matmul(kvq_proj_weight)
+        handle.wait()
+
+        grad_input, handle = _reduce_scatter_along_first_dim(
+            grad_input,
+            async_op=True
+        )
+        mha_layer_norm_output = SequeuceParallelTransformerBlock._collapse_first_dimensions(mha_layer_norm_output)
+        grad_kvq_proj_output = SequeuceParallelTransformerBlock._collapse_first_dimensions(grad_kvq_proj_output)
+        grad_kvq_weight = grad_kvq_proj_output.t().matmul(mha_layer_norm_output)
+        handle.wait()
+
+        grad_input = fused_layer_norm_cuda.backward(
+            grad_input.contiguous(),
+            mha_layer_norm_mean,
+            mha_layer_norm_invvar,
+            input,
+            ctx.layer_norm_normalized_shape,
+            ctx.eps,
+        )
+        grad_input = grad_input + residual_grad
+        return grad_input, grad_kvq_weight, grad_out_proj_weight, grad_fc1_weight, grad_fc2_weight, None, None
+
+    @staticmethod
+    def _collapse_first_dimensions(tensor):
+        return tensor.view(
+            tensor.shape[0] * tensor.shape[1],
+            tensor.shape[2],
+        )

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -3,13 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from metaseq.modules.activation_functions import gelu, gelu_back
+
 import importlib
 import math
 import torch
 
-fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
-
-from metaseq.modules.activation_functions import gelu, gelu_back
+# Not importing here cause cpu tests don't like it
+global fused_layer_norm_cuda
+fused_layer_norm_cuda = None
 
 try:
     from megatron.mpu.mappings import (
@@ -99,6 +101,11 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
         head_dim,
         recompute_fc1,
     ):
+        # import from apex
+        global fused_layer_norm_cuda
+        if fused_layer_norm_cuda is None:
+            fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
+
         ctx.recompute_fc1 = recompute_fc1
 
         input = input.contiguous()

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -3,10 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib
 import math
 import torch
 
-import fused_layer_norm_cuda
+fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
 
 from metaseq.modules.activation_functions import gelu, gelu_back
 

--- a/metaseq/models/transformer_decoder.py
+++ b/metaseq/models/transformer_decoder.py
@@ -422,6 +422,7 @@ class TransformerDecoder(IncrementalDecoder):
                 incremental_state=incremental_state,
                 self_attn_mask=self_attn_mask,
                 self_attn_padding_mask=self_attn_padding_mask,
+                recompute_fc1=(idx < getattr(self.args, "recompute_fc1_num_layers", 0)),
             )
         inner_states.append(x)
 

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -149,7 +149,6 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
     disable_affine_ln: Optional[bool] = field(
         default=False, metadata={"help": "disable weight and bias of layer norm"}
     )
-
     attn_variant: ATTN_CHOICES = field(
         default="default", metadata={"help": "variant to use for attention"}
     )
@@ -159,7 +158,12 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
             "help": "which memory efficient attention operation to use from xFormers."
         },
     )
-
+    recompute_fc1_num_layers: Optional[int] = field(
+        default=0,  metadata={
+            "help": "Num layers for which to recompute FC1 in backwards, "
+            "only applicable when --sequence-parallel option is set"
+        }
+    )
     # options from other parts of the config
     add_bos_token: bool = II("task.add_bos_token")
     tokens_per_sample: int = II("task.tokens_per_sample")

--- a/metaseq/models/transformer_lm.py
+++ b/metaseq/models/transformer_lm.py
@@ -159,10 +159,11 @@ class TransformerLanguageModelConfig(MetaseqDataclass):
         },
     )
     recompute_fc1_num_layers: Optional[int] = field(
-        default=0,  metadata={
+        default=0,
+        metadata={
             "help": "Num layers for which to recompute FC1 in backwards, "
             "only applicable when --sequence-parallel option is set"
-        }
+        },
     )
     # options from other parts of the config
     add_bos_token: bool = II("task.add_bos_token")

--- a/metaseq/modules/activation_functions.py
+++ b/metaseq/modules/activation_functions.py
@@ -16,6 +16,14 @@ def gelu(x):
 
 
 @torch.jit.script
+def gelu_back(g, x):
+    tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+    # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
+    ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (1 + tanh_out)
+    return ff*g
+
+
+@torch.jit.script
 def swiglu(x: torch.Tensor, gate: torch.Tensor):
     return F.silu(x) * gate
 

--- a/metaseq/modules/activation_functions.py
+++ b/metaseq/modules/activation_functions.py
@@ -19,8 +19,10 @@ def gelu(x):
 def gelu_back(g, x):
     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
     # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
-    ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (1 + tanh_out)
-    return ff*g
+    ff = 0.5 * x * (
+        (1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)
+    ) + 0.5 * (1 + tanh_out)
+    return ff * g
 
 
 @torch.jit.script

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -196,6 +196,7 @@ class TransformerDecoderLayer(nn.Module):
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         self_attn_mask: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[torch.Tensor] = None,
+        recompute_fc1: bool=False,
     ):
         """
         Args:
@@ -204,6 +205,18 @@ class TransformerDecoderLayer(nn.Module):
         Returns:
             encoded output of shape `(seq_len, batch, embed_dim)`
         """
+        if getattr(self.args, "sequence_parallel", False):
+            from metaseq.model_parallel.modules import SequeuceParallelTransformerBlock
+            x = SequeuceParallelTransformerBlock.apply(
+                x,
+                self.self_attn.qkv_proj.weight,
+                self.self_attn.out_proj.weight,
+                self.fc1.weight,
+                self.fc2.weight,
+                self.self_attn.head_dim,
+                recompute_fc1,
+            )
+            return x
 
         residual = x
         x = self.self_attn_layer_norm(x)

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -196,7 +196,7 @@ class TransformerDecoderLayer(nn.Module):
         incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
         self_attn_mask: Optional[torch.Tensor] = None,
         self_attn_padding_mask: Optional[torch.Tensor] = None,
-        recompute_fc1: bool=False,
+        recompute_fc1: bool = False,
     ):
         """
         Args:
@@ -207,6 +207,7 @@ class TransformerDecoderLayer(nn.Module):
         """
         if getattr(self.args, "sequence_parallel", False):
             from metaseq.model_parallel.modules import SequeuceParallelTransformerBlock
+
             x = SequeuceParallelTransformerBlock.apply(
                 x,
                 self.self_attn.qkv_proj.weight,


### PR DESCRIPTION
custom autograd function from transformer block to have more control over which ops to recompute.
I know the code is ugly and adds another codepath for model :( 

I think maybe we can just kill model parallel modules at some point? 


