### PR TITLE
Return on all matching checkpoint files when caching

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -365,10 +365,12 @@ def _cache_checkpoint_files(path: str, suffix: str) -> Tuple[str, List[str]]:
             continue
         src_name = os.path.basename(filepath)
         if src_name == local_name:
-            continue
-        src_path = os.path.join(os.path.dirname(path), src_name)
-        tgt_path = PathManager.get_local_path(src_path, force=True)
-        local_paths.append(tgt_path)
+            # Target path is already cached
+            local_paths.append(local_path)
+        else:
+            src_path = os.path.join(os.path.dirname(path), src_name)
+            tgt_path = PathManager.get_local_path(src_path, force=True)
+            local_paths.append(tgt_path)
 
     return local_path, local_paths
 


### PR DESCRIPTION
**Patch Description**
I didn't re-run all testing steps from https://github.com/facebookresearch/metaseq/pull/452 and I just caught one case regressed.

**Testing steps**
Multiple eval runs on OPT 125M:

* remote path + consolidated
* remote path + DP>1
* local path + consolidated
* local path + DP>1
