### PR TITLE
Only validate at validate_interval_updates and end of training

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -394,8 +394,7 @@ def validate_and_save(
         or should_stop
     )
     do_validate = (
-        (not end_of_epoch and do_save)  # validate during mid-epoch saves
-        or should_stop
+        should_stop
         or (
             cfg.dataset.validate_interval_updates > 0
             and num_updates > 0


### PR DESCRIPTION
Removed previous condition that ensured that we validate everytime we save.