### PR TITLE
Include run id in train.log

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -271,7 +271,7 @@ def train(
             num_updates = trainer.get_num_updates()
             if num_updates % cfg.common.log_interval == 0:
                 stats = get_training_stats(metrics.get_smoothed_values("train_inner"))
-                stats["job_id"] = cfg.common.job_id
+                stats["run_id"] = cfg.common.run_id
                 progress.log(stats, tag="train_inner", step=num_updates)
 
                 # reset mid-epoch stats after each log interval

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -299,6 +299,7 @@ def train(
             num_updates = trainer.get_num_updates()
             if num_updates % cfg.common.log_interval == 0:
                 stats = get_training_stats(metrics.get_smoothed_values("train_inner"))
+                stats["job_id"] = cfg.common.job_id
                 progress.log(stats, tag="train_inner", step=num_updates)
 
                 # reset mid-epoch stats after each log interval

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -85,7 +85,7 @@ class CommonConfig(MetaseqDataclass):
     # different jobs. Please append your params to other dataclasses if they
     # were used for a particular purpose or task, such as those dedicated for
     # `distributed training`, `optimization`, etc.
-    
+
     log_interval: int = field(
         default=100,
         metadata={

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import sys
+import datetime
 from dataclasses import _MISSING_TYPE, dataclass, field
 from typing import Any, List, Optional
 
@@ -84,6 +85,7 @@ class CommonConfig(MetaseqDataclass):
     # different jobs. Please append your params to other dataclasses if they
     # were used for a particular purpose or task, such as those dedicated for
     # `distributed training`, `optimization`, etc.
+    
     log_interval: int = field(
         default=100,
         metadata={
@@ -124,6 +126,10 @@ class CommonConfig(MetaseqDataclass):
     )
     seed: int = field(
         default=1, metadata={"help": "pseudo random number generator seed"}
+    )
+    run_id: str = field(
+        default=datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S"),
+        metadata={"help": "run_id to identify the job"},
     )
     cpu: bool = field(default=False, metadata={"help": "use CPU instead of CUDA"})
     fp16: bool = field(default=False, metadata={"help": "use FP16"})

--- a/metaseq/launcher/opt_baselines.py
+++ b/metaseq/launcher/opt_baselines.py
@@ -74,6 +74,7 @@ def add_extra_options_func(parser):
     parser.add_argument(
         "--circleci", action="store_true", help="running a baseline test on circleci"
     )
+    parser.add_argument("--run-id", type=str, default=None)
 
 
 def get_grid(args):
@@ -166,6 +167,9 @@ def get_grid(args):
 
     if args.profile:
         grid += [hyperparam("--profile")]
+
+    if args.run_id is not None:
+        grid += [hyperparam("--run-id", args.run_id)]
 
     no_save_params = args.no_save_dir
     args.snapshot_code = True


### PR DESCRIPTION
Added a --run-id flag that appears in logging at each training step. As default value I added a time stamp of the beginning of training. This allows for easy identification of the specific training run.

Issue: https://github.com/facebookresearch/metaseq/issues/471