### PR TITLE
update sklearn package name in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ def do_setup(package_data):
             "pytest",
             "pytest-regressions",
             "regex",
-            "sklearn",  # for evals
+            "scikit-learn",  # for evals
             "sacrebleu",  # for evals
             "tensorboard==2.8.0",
             "timeout-decorator",


### PR DESCRIPTION
**Patch Description**
https://pypi.org/project/sklearn/
deprecated sklearn package, use scikit-learn instead

**Testing steps**
create new env, pip install scikit-learn, create python, import sklearn

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
