### PR TITLE
Automatically detect and skip loss spikes

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -416,7 +416,7 @@ class OptimizationConfig(MetaseqDataclass):
         },
     )
     ewm_ratio_to_skip_batch: float = field(
-        default=1.25,
+        default=-1,
         metadata={
             "help": "Skip current batch if the loss to loss ewm ratio is "
             "higher than this value. Turned off at -1"

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -415,10 +415,11 @@ class OptimizationConfig(MetaseqDataclass):
             "help": "Skip gradient update if gnorm is higher than --clip-norm value"
         },
     )
-    max_loss_to_skip_batch: float = field(
-        default=-1,
+    ewm_ratio_to_skip_batch: float = field(
+        default=1.25,
         metadata={
-            "help": "Skip current batch if loss is higher than this value. Turned off at -1"
+            "help": "Skip current batch if the loss to loss ewm ratio is "
+            "higher than this value. Turned off at -1"
         },
     )
 

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -415,6 +415,13 @@ class OptimizationConfig(MetaseqDataclass):
             "help": "Skip gradient update if gnorm is higher than --clip-norm value"
         },
     )
+    max_loss_to_skip_batch: float = field(
+        default=-1,
+        metadata={
+            "help": "Skip current batch if loss is higher than this value. Turned off at -1"
+        },
+    )
+
     update_freq: List[int] = field(
         default_factory=lambda: [1],
         metadata={"help": "update parameters every N_i batches, when in epoch i"},

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -979,8 +979,6 @@ class Trainer(object):
         )
 
     def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch, span=9):
-        if ewm_ratio_to_skip_batch == -1:
-            return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
         loss_t = float(loss_sum / sample_size / math.log(2))
@@ -993,7 +991,7 @@ class Trainer(object):
         ewm_t = (1 - alpha) * ewm_t_1 + alpha * loss_t
         ewm_ratio = loss_t / ewm_t
 
-        if ewm_ratio > ewm_ratio_to_skip_batch:
+        if ewm_ratio_to_skip_batch != -1 and ewm_ratio > ewm_ratio_to_skip_batch:
             self._skipped_loss_spikes += 1
             raise SpikeError(
                 f"Skip batch as we encountered a loss spike. In "

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -141,6 +141,8 @@ class Trainer(object):
         self._previous_training_time = 0
         self._cumulative_training_time = None
 
+        self.real_steps = 0
+
     def reinitialize(self):
         """Reinitialize the Trainer, typically after model params change."""
         self._lr_scheduler = None
@@ -981,11 +983,16 @@ class Trainer(object):
         )
 
     def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch):
+        self.real_steps += 1
         if ewm_ratio_to_skip_batch == -1:
             return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
         loss_t = float(loss_sum / sample_size / math.log(2))
+
+        if self.real_steps % 10 == 0:
+            loss_t *= 10
+            logger.info("Increased loss by 10x")
 
         if self._ewm_loss is None:
             self._ewm_loss = loss_t

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -358,7 +358,7 @@ class Trainer(object):
                 "extra_state": {
                     "metrics": metrics.state_dict(),
                     "previous_training_time": self.cumulative_training_time(),
-                    "ewm_loss": self._ewm_loss
+                    "ewm_loss": self._ewm_loss,
                 },
             }
 
@@ -544,7 +544,9 @@ class Trainer(object):
 
             if "ewm_loss" in extra_state:
                 self._ewm_loss = extra_state["ewm_loss"]
-                logger.info(f"loaded ewm loss from checkpoint with value {self._ewm_loss}")
+                logger.info(
+                    f"loaded ewm loss from checkpoint with value {self._ewm_loss}"
+                )
 
             self.lr_step(epoch)
 
@@ -987,12 +989,16 @@ class Trainer(object):
 
         if self._ewm_loss is None:
             self._ewm_loss = loss_t
-            logger.info("ewm loss was None at this point, so it was initilialized to loss_t")
+            logger.info(
+                "ewm loss was None at this point, so it was initilialized to loss_t"
+            )
 
         ewm_t_1 = self._ewm_loss
-        ewm_t = ewm(loss_t, ewm_t_1, span = 9)
+        ewm_t = ewm(loss_t, ewm_t_1, span=9)
         ewm_ratio = loss_t / ewm_t
-        logger.info(f"Step {self.get_num_updates()}: ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}")
+        logger.info(
+            f"Step {self.get_num_updates()}: loss_t: {loss_t:.2f}, ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}"
+        )
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
@@ -1289,6 +1295,7 @@ def _set_module_by_path(module, path, value):
 def ewm(loss_t, ewm_t_1, span):
     alpha = 2 / (span + 1)
     return (1 - alpha) * ewm_t_1 + alpha * loss_t
+
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -978,9 +978,11 @@ class Trainer(object):
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
         loss = float(loss_sum / sample_size / math.log(2))
         if loss > max_loss_to_skip_batch:
-            raise SpikeError(f"Skip batch as we encountered a loss spike. In "
-            f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
-            f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}")
+            raise SpikeError(
+                f"Skip batch as we encountered a loss spike. In "
+                f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
+                f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}"
+            )
 
     def cumulative_training_time(self):
         if self._cumulative_training_time is None:
@@ -1261,6 +1263,7 @@ def _set_module_by_path(module, path, value):
     for name in path[:-1]:
         module = getattr(module, name)
     setattr(module, path[-1], value)
+
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -15,7 +15,6 @@ import time
 import math
 from itertools import chain
 from typing import Any, Dict, List
-import random
 
 import torch
 from omegaconf import OmegaConf
@@ -977,16 +976,8 @@ class Trainer(object):
             return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
-
         loss = float(loss_sum / sample_size / math.log(2))
-
-        if random.randint(0, 15) == 10:
-            loss = loss * 100
-            logger.info("increased loss")
-            logger.info(str(loss))
-        logger.info(str(loss))
         if loss > max_loss_to_skip_batch:
-            logger.info("doing skip")
             raise SpikeError(f"Skip batch as we encountered a loss spike. In "
             f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
             f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}")

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -1187,7 +1187,9 @@ class Trainer(object):
                     + "-" * 80
                 )
 
-    def _reduce_and_log_stats(self, logging_outputs, sample_size, grad_norm=None, ewm_loss_ratio=0):
+    def _reduce_and_log_stats(
+        self, logging_outputs, sample_size, grad_norm=None, ewm_loss_ratio=0
+    ):
         # standard code
         if grad_norm is not None and (
             not torch.is_tensor(grad_norm) or torch.isfinite(grad_norm)
@@ -1196,7 +1198,9 @@ class Trainer(object):
             metrics.log_scalar("gnorm", grad_norm, priority=400, round=3)
             metrics.log_scalar("ewm_loss", self._ewm_loss, priority=700, round=2)
             metrics.log_scalar("ewm_loss_ratio", ewm_loss_ratio, priority=710, round=4)
-            metrics.log_scalar("skipped_loss_spikes", self._skipped_loss_spikes, priority=720)
+            metrics.log_scalar(
+                "skipped_loss_spikes", self._skipped_loss_spikes, priority=720
+            )
             self._skipped_loss_spikes = 0
             if self.cfg.optimization.clip_norm > 0:
                 metrics.log_scalar(

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -773,13 +773,12 @@ class Trainer(object):
                 self.cfg.optimization.clip_norm_type,
                 self.cfg.optimization.skip_gradient_update_on_clip_norm,
             )
-
             # check that grad norms are consistent across workers
             self._check_grad_norms(grad_norm)
             if not torch.isfinite(grad_norm).all():
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
-
+            self.skip_spike(logging_outputs)
             # take an optimization step
             self.task.optimizer_step(
                 self.optimizer, model=self.model, update_num=self.get_num_updates()
@@ -808,6 +807,12 @@ class Trainer(object):
                 f"NOTE: gradient overflow detected, ignoring gradient, {str(e)}"
             )
             grad_norm = torch.tensor(0.0).cuda()
+            self.zero_grad()
+        except SpikeError as e:
+            overflow = True
+            logger.info(
+                f"Skipped Spike: {str(e)}"
+            )
             self.zero_grad()
         except RuntimeError as e:
             if "out of memory" in str(e):
@@ -965,6 +970,10 @@ class Trainer(object):
             aggregate_norm_fn=None,
             skip_gradient_update_on_clip_norm=skip_gradient_update_on_clip_norm,
         )
+
+    def skip_spike(self):
+        logger.info(str(logging_outputs))
+        raise SpikeError(f"Skip because spike, in num_update {self.get_num_updates()}")
 
     def cumulative_training_time(self):
         if self._cumulative_training_time is None:
@@ -1245,3 +1254,6 @@ def _set_module_by_path(module, path, value):
     for name in path[:-1]:
         module = getattr(module, name)
     setattr(module, path[-1], value)
+
+class SpikeError(Exception):
+    pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -779,7 +779,9 @@ class Trainer(object):
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
             # skip optimizer step if there is a loss spike
-            self.skip_spike(logging_outputs, self.cfg.optimization.max_loss_to_skip_batch)
+            self.skip_spike(
+                logging_outputs, self.cfg.optimization.max_loss_to_skip_batch
+            )
             # take an optimization step
             self.task.optimizer_step(
                 self.optimizer, model=self.model, update_num=self.get_num_updates()

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -1010,7 +1010,7 @@ class Trainer(object):
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
                 f"Skip batch as we encountered a loss spike. In "
-                f"num_update: {self.get_num_updates()} the loss is {loss:.2f}. "
+                f"num_update: {self.get_num_updates()} the loss is {loss_t:.2f}. "
                 f"The ewm for the loss was only at {ewm_t:.2f} . "
                 f"The loss to ewm loss ratio is {ewm_ratio:.2f}, which is higher than "
                 f"ewm_ratio_to_skip_batch of {ewm_ratio_to_skip_batch} ."

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -992,6 +992,7 @@ class Trainer(object):
         ewm_t_1 = self._ewm_loss
         ewm_t = ewm(loss_t, ewm_t_1, span = 9)
         ewm_ratio = loss_t / ewm_t
+        logger.info(f"Step {self.get_num_updates()}: ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}")
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
@@ -1287,7 +1288,7 @@ def _set_module_by_path(module, path, value):
 
 def ewm(loss_t, ewm_t_1, span):
     alpha = 2 / (span + 1)
-    return (1 - alpha) * ewm_1 + alpha * loss_t
+    return (1 - alpha) * ewm_t_1 + alpha * loss_t
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -977,7 +977,7 @@ class Trainer(object):
             skip_gradient_update_on_clip_norm=skip_gradient_update_on_clip_norm,
         )
 
-    def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch):
+    def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch, span=9):
         if ewm_ratio_to_skip_batch == -1:
             return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
@@ -988,7 +988,8 @@ class Trainer(object):
             self._ewm_loss = loss_t
 
         ewm_t_1 = self._ewm_loss
-        ewm_t = ewm(loss_t, ewm_t_1, span=9)
+        alpha = 2 / (span + 1)
+        ewm_t = (1 - alpha) * ewm_t_1 + alpha * loss_t
         ewm_ratio = loss_t / ewm_t
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
@@ -999,7 +1000,7 @@ class Trainer(object):
                 f"The loss to ewm loss ratio is {ewm_ratio:.2f}, which is higher than "
                 f"ewm_ratio_to_skip_batch of {ewm_ratio_to_skip_batch} ."
             )
-
+        # the current loss is only included in ewm if the current batch is not skipped
         self._ewm_loss = ewm_t
 
     def cumulative_training_time(self):
@@ -1281,11 +1282,6 @@ def _set_module_by_path(module, path, value):
     for name in path[:-1]:
         module = getattr(module, name)
     setattr(module, path[-1], value)
-
-
-def ewm(loss_t, ewm_t_1, span):
-    alpha = 2 / (span + 1)
-    return (1 - alpha) * ewm_t_1 + alpha * loss_t
 
 
 class SpikeError(Exception):

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -15,7 +15,6 @@ import time
 import math
 from itertools import chain
 from typing import Any, Dict, List
-
 import torch
 from omegaconf import OmegaConf
 
@@ -780,7 +779,7 @@ class Trainer(object):
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
             # skip optimizer step if there is a loss spike
-            self.skip_spike(logging_outputs, max_loss_to_skip_batch=100)
+            self.skip_spike(logging_outputs, self.cfg.optimization.max_loss_to_skip_batch)
             # take an optimization step
             self.task.optimizer_step(
                 self.optimizer, model=self.model, update_num=self.get_num_updates()

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -12,8 +12,10 @@ import logging
 import re
 import sys
 import time
+import math
 from itertools import chain
 from typing import Any, Dict, List
+import random
 
 import torch
 from omegaconf import OmegaConf
@@ -778,7 +780,8 @@ class Trainer(object):
             if not torch.isfinite(grad_norm).all():
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
-            self.skip_spike(logging_outputs)
+            # skip optimizer step if there is a loss spike
+            self.skip_spike(logging_outputs, max_loss_to_skip_batch=100)
             # take an optimization step
             self.task.optimizer_step(
                 self.optimizer, model=self.model, update_num=self.get_num_updates()
@@ -810,9 +813,7 @@ class Trainer(object):
             self.zero_grad()
         except SpikeError as e:
             overflow = True
-            logger.info(
-                f"Skipped Spike: {str(e)}"
-            )
+            logger.info(str(e))
             self.zero_grad()
         except RuntimeError as e:
             if "out of memory" in str(e):
@@ -971,9 +972,24 @@ class Trainer(object):
             skip_gradient_update_on_clip_norm=skip_gradient_update_on_clip_norm,
         )
 
-    def skip_spike(self):
-        logger.info(str(logging_outputs))
-        raise SpikeError(f"Skip because spike, in num_update {self.get_num_updates()}")
+    def skip_spike(self, logging_outputs, max_loss_to_skip_batch):
+        if max_loss_to_skip_batch == -1:
+            return
+        loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
+        sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
+
+        loss = float(loss_sum / sample_size / math.log(2))
+
+        if random.randint(0, 15) == 10:
+            loss = loss * 100
+            logger.info("increased loss")
+            logger.info(str(loss))
+        logger.info(str(loss))
+        if loss > max_loss_to_skip_batch:
+            logger.info("doing skip")
+            raise SpikeError(f"Skip batch as we encountered a loss spike. In "
+            f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
+            f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}")
 
     def cumulative_training_time(self):
         if self._cumulative_training_time is None:


### PR DESCRIPTION
**Patch Description**
Added a new flag `max_loss_to_skip_batch` that, if set to some maximum acceptable loss will abort the iteration before doing an optimizer step.
The loss value to compare to is the same one used in the logs. It might be or not different to the one in tensorboard.
The logic is similar to our `skip_gradient_update_on_clip_norm` flag which also skips batches, whenever the gradient norm is above the clip value, and also how we handle overflows.

**Testing steps**
Tested this with our small sweep script. I think our disks are full so I couldn't test this with a longer run.
For testing I increased the loss and checked whether we are skipping correctly