### PR TITLE
[tboard] Don't run out of letters

### DIFF
--- a/metaseq/logging/progress_bar/tensorboard_progress_bar.py
+++ b/metaseq/logging/progress_bar/tensorboard_progress_bar.py
@@ -53,7 +53,7 @@ class TensorboardProgressBarWrapper(BaseProgressBar):
         if key not in _writers:
             # tensorboard doesn't play well when we clobber it with reruns
             # find an acceptable suffix
-            for suffix in [""] + list(string.ascii_uppercase):
+            for suffix in (f"{i:04d}" for i in range(10000)):
                 logdir = os.path.join(self.tensorboard_logdir + suffix, key)
                 if not os.path.exists(logdir):
                     logger.info(f"Setting tensorboard directory to {logdir}")


### PR DESCRIPTION
**Patch Description**
Our restart logic is too good these days. Make sure tboard doesn't ever run out of suffixes.

**Testing steps**
quick job test created the correct tboard folder.