### PR TITLE
Default to always skip last batch

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -212,9 +212,7 @@ def train(
         itr = iterators.GroupedIterator(
             itr,
             update_freq,
-            skip_remainder_batch=(
-                not cfg.optimization.train_with_epoch_remainder_batch
-            ),
+            skip_remainder_batch=True,
         )
 
     progress = progress_bar.get_progress_bar(

--- a/metaseq/data/document_to_sequence.py
+++ b/metaseq/data/document_to_sequence.py
@@ -146,7 +146,7 @@ class DocumentToSequenceDataset(torch.utils.data.IterableDataset):
         break_mode (str, optional): Mode used for breaking tokens. Values can
             be one of:
             - 'none': break tokens into equally sized blocks (up to block_size)
-        drop_last (bool, optional): drop the last item (default: False)
+        drop_last (bool, optional): drop the last item (default: True)
         padding_idx (int, optional): index to use for padding symbols
             (required if *drop_last* is ``False``)
         shuffle_buffer_size (int, optional): buffer this many items and shuffle
@@ -164,7 +164,7 @@ class DocumentToSequenceDataset(torch.utils.data.IterableDataset):
         dataset: torch.utils.data.IterableDataset,
         block_size: int,
         break_mode: str = "none",
-        drop_last: Optional[bool] = False,
+        drop_last: Optional[bool] = True,
         padding_idx: Optional[int] = None,
         shuffle_buffer_size: int = 1,
         seed: Optional[int] = None,

--- a/metaseq/data/iterators.py
+++ b/metaseq/data/iterators.py
@@ -437,7 +437,7 @@ class EpochBatchIterator(EpochBatchIterating):
             (default: ``False``).
         skip_remainder_batch (bool, optional): if set, discard the last batch in an epoch
             for the sake of training stability, as the last batch is usually smaller than
-                local_batch_size * distributed_word_size (default: ``False``).
+                local_batch_size * distributed_word_size (default: ``True``).
     """
 
     def __init__(
@@ -453,7 +453,7 @@ class EpochBatchIterator(EpochBatchIterating):
         buffer_size=0,
         timeout=0,
         disable_shuffling=False,
-        skip_remainder_batch=False,
+        skip_remainder_batch=True,
     ):
         assert isinstance(dataset, torch.utils.data.Dataset)
         self.dataset = dataset
@@ -674,12 +674,12 @@ class GroupedIterator(CountingIterator):
         chunk_size (int): size of each chunk
         skip_remainder_batch (bool, optional): if set, discard the last grouped batch in
           each training epoch, as the last grouped batch is usually smaller than
-                local_batch_size * distributed_word_size * chunk_size (default: ``False``).
+                local_batch_size * distributed_word_size * chunk_size (default: ``True``).
     Attributes:
         n (int): number of elements consumed from this iterator
     """
 
-    def __init__(self, iterable, chunk_size, skip_remainder_batch=False):
+    def __init__(self, iterable, chunk_size, skip_remainder_batch=True):
         if skip_remainder_batch:
             total_num_itrs = int(math.floor(len(iterable) / float(chunk_size)))
             logger.info(
@@ -705,7 +705,7 @@ class GroupedIterator(CountingIterator):
             iterable.take(total_num_itrs * chunk_size)
 
 
-def _chunk_iterator(itr, chunk_size, skip_remainder_batch=False):
+def _chunk_iterator(itr, chunk_size, skip_remainder_batch=True):
     chunk = []
     for x in itr:
         chunk.append(x)

--- a/metaseq/data/partitioned_streaming_dataset.py
+++ b/metaseq/data/partitioned_streaming_dataset.py
@@ -16,7 +16,7 @@ class PartitionedStreamingDataset(torch.utils.data.IterableDataset):
         dataset (~torch.utils.data.IterableDataset): dataset to partition
         num_shards (int): number of ways to partition the dataset
         shard_id (int): shard index to iterate over
-        drop_last (bool, optional): drop the last item (default: False)
+        drop_last (bool, optional): drop the last item (default: True)
     """
 
     def __init__(
@@ -24,7 +24,7 @@ class PartitionedStreamingDataset(torch.utils.data.IterableDataset):
         dataset: torch.utils.data.IterableDataset,
         num_shards: int,
         shard_id: int,
-        drop_last: bool = False,
+        drop_last: bool = True,
     ):
         super().__init__()
         self.dataset = dataset

--- a/metaseq/data/streaming_src_tgt_dataset.py
+++ b/metaseq/data/streaming_src_tgt_dataset.py
@@ -21,7 +21,7 @@ class StreamingSrcTgtDataset(torch.utils.data.IterableDataset):
         break_mode (str, optional): Mode used for breaking tokens. Values can
             be one of:
             - 'none': break tokens into equally sized blocks (up to block_size)
-        drop_last (bool, optional): drop the last item (default: False)
+        drop_last (bool, optional): drop the last item (default: True)
         padding_idx (int, optional): index to use for padding symbols
             (required if *drop_last* is ``False``)
         shuffle_buffer_size (int, optional): buffer this many items and shuffle
@@ -36,7 +36,7 @@ class StreamingSrcTgtDataset(torch.utils.data.IterableDataset):
         dataset: torch.utils.data.IterableDataset,
         block_size: int,
         break_mode: str = "none",
-        drop_last: Optional[bool] = False,
+        drop_last: Optional[bool] = True,
         padding_idx: Optional[int] = None,
         shuffle_buffer_size: int = 1,
         seed: Optional[int] = None,

--- a/metaseq/data/streaming_token_block_dataset.py
+++ b/metaseq/data/streaming_token_block_dataset.py
@@ -23,7 +23,7 @@ class StreamingTokenBlockDataset(torch.utils.data.IterableDataset):
             - 'none': break tokens into equally sized blocks (up to block_size)
         drop_last (bool, optional): drop the last item (default: False)
         padding_idx (int, optional): index to use for padding symbols
-            (required if *drop_last* is ``False``)
+            (required if *drop_last* is ``True``)
         shuffle_buffer_size (int, optional): buffer this many items and shuffle
             using the provided *seed*; default value is 1, so no shuffling is
             performed. This can be adjusted dynamically after initialization,
@@ -36,7 +36,7 @@ class StreamingTokenBlockDataset(torch.utils.data.IterableDataset):
         dataset: torch.utils.data.IterableDataset,
         block_size: int,
         break_mode: str = "none",
-        drop_last: Optional[bool] = False,
+        drop_last: Optional[bool] = True,
         padding_idx: Optional[int] = None,
         shuffle_buffer_size: int = 1,
         seed: Optional[int] = None,

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -426,13 +426,6 @@ class OptimizationConfig(MetaseqDataclass):
             " (note: this may be interpreted differently depending on --lr-scheduler)"
         },
     )
-    train_with_epoch_remainder_batch: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "if set, include the last (partial) batch of each epoch in training"
-            " (default is to skip it)."
-        },
-    )
 
 
 @dataclass

--- a/metaseq/logging/progress_bar/tensorboard_progress_bar.py
+++ b/metaseq/logging/progress_bar/tensorboard_progress_bar.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-import string
 import sys
 from numbers import Number
 import atexit

--- a/metaseq/tasks/base_task.py
+++ b/metaseq/tasks/base_task.py
@@ -212,7 +212,7 @@ class BaseTask(object):
         data_buffer_size=0,
         disable_iterator_cache=False,
         batch_by_size=True,
-        skip_remainder_batch=False,
+        skip_remainder_batch=True,
     ):
         """
         Get an iterator that yields batches of data from the given dataset.

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -398,7 +398,7 @@ class StreamingLanguageModelingTask(LegacyTask):
         data_buffer_size=0,
         disable_iterator_cache=False,
         batch_by_size=True,
-        skip_remainder_batch=False,
+        skip_remainder_batch=True,
     ):
         """
         Get an iterator that yields batches of data from the given dataset.

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -599,9 +599,7 @@ class Trainer(object):
             epoch=epoch,
             data_buffer_size=self.cfg.dataset.data_buffer_size,
             disable_iterator_cache=disable_iterator_cache,
-            skip_remainder_batch=(
-                not self.cfg.optimization.train_with_epoch_remainder_batch
-            ),
+            skip_remainder_batch=True,
         )
         logger.info("finished creating batch iterator")
         self.reset_dummy_batch(batch_iterator.first_batch)


### PR DESCRIPTION
At the moment, we never toggle `train_with_epoch_remainder_batch` anyway - removing this flag for now to reduce surface area here.