### PR TITLE
barrierless rendezvous for faster init

### DIFF
--- a/metaseq/distributed/rendezvous.py
+++ b/metaseq/distributed/rendezvous.py
@@ -120,43 +120,13 @@ def meet_at_rendezvous(url, **kwargs):
 
 
 def _tcp_retry_barrierless_rendezvous_handler(url: str, timeout=default_pg_timeout, **kwargs):
-    def _error(msg):
-        return ValueError("barrierlesstcpr:// rendezvous: " + msg)
-
+    assert url.startswith("barrierlesstcpr://")
+    url = url.replace("barrierlesstcpr://", "tcpr://")
+    rendezvous_iterator = rendezvous(url)
+    store, rank, world_size = next(rendezvous_iterator)
     global STORE
-
-    result = urlparse(url)
-    if not result.port:
-        raise _error("port number missing")
-    query_dict = _query_to_dict(result.query)
-    if "rank" not in query_dict:
-        raise _error("rank parameter missing")
-    if "world_size" not in query_dict:
-        raise _error("world size parameter missing")
-
-    rank = int(query_dict["rank"])
-    world_size = int(query_dict["world_size"])
-    assert result.hostname is not None
-
-    for tries in range(1, RETRIES + 1):
-        try:
-            store = _create_c10d_store(
-                result.hostname, result.port, rank, world_size, timeout
-            )
-            logger.warning(
-                f"Successfully connected to primary node on attempt {tries}/{RETRIES}"
-            )
-            STORE = ComplicitStore(store, world_size)
-            yield (STORE, rank, world_size)
-            break
-        except RuntimeError as re:
-            logger.error(
-                f"Failed to connect to primary node on attempt {tries}/{RETRIES}: {re}"
-            )
-            time.sleep(COOLDOWN * (2**tries))
-
-    # If this configuration is invalidated, there is nothing we can do about it
-    raise RuntimeError("Unable to perform re-rendezvous using barrierlesstcpr:// method")
+    STORE = ComplicitStore(store, world_size)
+    return iter([(STORE, rank, world_size)])
 
 register_rendezvous_handler("barrierlessenv", meet_at_rendezvous)
 register_rendezvous_handler("tcpr", _tcp_retry_rendezvous_handler)

--- a/metaseq/distributed/rendezvous.py
+++ b/metaseq/distributed/rendezvous.py
@@ -6,7 +6,7 @@ from typing import Dict
 from urllib.parse import urlparse
 
 from torch.distributed.constants import default_pg_timeout
-from torch.distributed import register_rendezvous_handler, Store, TCPStore
+from torch.distributed import register_rendezvous_handler, Store, TCPStore, rendezvous
 
 
 RETRIES = 5
@@ -73,8 +73,8 @@ def _tcp_retry_rendezvous_handler(url: str, timeout=default_pg_timeout, **kwargs
 STORE_BASED_BARRIER_MARKER = "store_based_barrier_key:"
 
 
-class ComplicitStore(torch.distributed.Store):
-    def __init__(self, store: torch.distributed.Store, world_size: int):
+class ComplicitStore(Store):
+    def __init__(self, store: Store, world_size: int):
         super().__init__()
         self.store = store
         self.world_size = world_size
@@ -112,7 +112,7 @@ STORE = None
 
 def meet_at_rendezvous(url, **kwargs):
     assert url == "barrierlessenv://"
-    rendezvous_iterator = torch.distributed.rendezvous("env://")
+    rendezvous_iterator = rendezvous("env://")
     store, rank, world_size = next(rendezvous_iterator)
     global STORE
     STORE = ComplicitStore(store, world_size)

--- a/metaseq/distributed/rendezvous.py
+++ b/metaseq/distributed/rendezvous.py
@@ -70,4 +70,60 @@ def _tcp_retry_rendezvous_handler(url: str, timeout=default_pg_timeout, **kwargs
     raise RuntimeError("Unable to perform re-rendezvous using tcpr:// method")
 
 
+STORE_BASED_BARRIER_MARKER = "store_based_barrier_key:"
+
+
+class ComplicitStore(torch.distributed.Store):
+    def __init__(self, store: torch.distributed.Store, world_size: int):
+        super().__init__()
+        self.store = store
+        self.world_size = world_size
+
+    def set(self, *args, **kwargs):
+        return self.store.set(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self.store.get(*args, **kwargs)
+
+    def add(self, key: str, *args, **kwargs):
+        # The marker isn't always a prefix: it's sometimes prefixed with default_pg/.
+        if STORE_BASED_BARRIER_MARKER in key:
+            return self.world_size
+        return self.store.add(key, *args, **kwargs)
+
+    def compare_set(self, *args, **kwargs):
+        return self.store.compare_set(*args, **kwargs)
+
+    def delete_key(self, *args, **kwargs):
+        return self.store.delete_key(*args, **kwargs)
+
+    def num_keys(self, *args, **kwargs):
+        return self.store.num_keys(*args, **kwargs)
+
+    def set_timeout(self, *args, **kwargs):
+        return self.store.set_timeout(*args, **kwargs)
+
+    def wait(self, *args, **kwargs):
+        return self.store.wait(*args, **kwargs)
+
+
+# There seems to be some lifetime issue where if we don't keep this object alive
+# then stuff will fail down the line. In particular we saw that these calls:
+#   >>> torch.distributed.init_process_group("nccl", init_method="barrierlessenv://")
+#   >>> torch.distributed.new_group(ranks=[0])
+# led to this error:
+#   RuntimeError: fn INTERNAL ASSERT FAILED at "/opt/conda/conda-bld/pytorch_1659484809662/work/torch/csrc/distributed/c10d/init.cpp":155, please report a bug to PyTorch.
+STORE = None
+
+
+def meet_at_rendezvous(url, **kwargs):
+    assert url == "barrierlessenv://"
+    rendezvous_iterator = torch.distributed.rendezvous("env://")
+    store, rank, world_size = next(rendezvous_iterator)
+    global STORE
+    STORE = ComplicitStore(store, world_size)
+    return iter([(STORE, rank, world_size)])
+
+
+register_rendezvous_handler("barrierlessenv", meet_at_rendezvous)
 register_rendezvous_handler("tcpr", _tcp_retry_rendezvous_handler)

--- a/metaseq/distributed/rendezvous.py
+++ b/metaseq/distributed/rendezvous.py
@@ -106,9 +106,13 @@ class ComplicitStore(Store):
     def wait(self, *args, **kwargs):
         return self.store.wait(*args, **kwargs)
 
+
 STORE = None
 
-def _tcp_retry_barrierless_rendezvous_handler(url: str, timeout=default_pg_timeout, **kwargs):
+
+def _tcp_retry_barrierless_rendezvous_handler(
+    url: str, timeout=default_pg_timeout, **kwargs
+):
     assert url.startswith("barrierlesstcpr://")
     url = url.replace("barrierlesstcpr://", "tcpr://")
     rendezvous_iterator = rendezvous(url, timeout=timeout)
@@ -117,5 +121,8 @@ def _tcp_retry_barrierless_rendezvous_handler(url: str, timeout=default_pg_timeo
     STORE = ComplicitStore(store, world_size)
     return iter([(STORE, rank, world_size)])
 
+
 register_rendezvous_handler("tcpr", _tcp_retry_rendezvous_handler)
-register_rendezvous_handler("barrierlesstcpr", _tcp_retry_barrierless_rendezvous_handler)
+register_rendezvous_handler(
+    "barrierlesstcpr", _tcp_retry_barrierless_rendezvous_handler
+)

--- a/metaseq/distributed/rendezvous.py
+++ b/metaseq/distributed/rendezvous.py
@@ -106,28 +106,16 @@ class ComplicitStore(Store):
     def wait(self, *args, **kwargs):
         return self.store.wait(*args, **kwargs)
 
-
 STORE = None
-
-
-def meet_at_rendezvous(url, **kwargs):
-    assert url == "barrierlessenv://"
-    rendezvous_iterator = rendezvous("env://")
-    store, rank, world_size = next(rendezvous_iterator)
-    global STORE
-    STORE = ComplicitStore(store, world_size)
-    return iter([(STORE, rank, world_size)])
-
 
 def _tcp_retry_barrierless_rendezvous_handler(url: str, timeout=default_pg_timeout, **kwargs):
     assert url.startswith("barrierlesstcpr://")
     url = url.replace("barrierlesstcpr://", "tcpr://")
-    rendezvous_iterator = rendezvous(url)
+    rendezvous_iterator = rendezvous(url, timeout=timeout)
     store, rank, world_size = next(rendezvous_iterator)
     global STORE
     STORE = ComplicitStore(store, world_size)
     return iter([(STORE, rank, world_size)])
 
-register_rendezvous_handler("barrierlessenv", meet_at_rendezvous)
 register_rendezvous_handler("tcpr", _tcp_retry_rendezvous_handler)
 register_rendezvous_handler("barrierlesstcpr", _tcp_retry_barrierless_rendezvous_handler)

--- a/metaseq/distributed/rendezvous.py
+++ b/metaseq/distributed/rendezvous.py
@@ -107,12 +107,6 @@ class ComplicitStore(torch.distributed.Store):
         return self.store.wait(*args, **kwargs)
 
 
-# There seems to be some lifetime issue where if we don't keep this object alive
-# then stuff will fail down the line. In particular we saw that these calls:
-#   >>> torch.distributed.init_process_group("nccl", init_method="barrierlessenv://")
-#   >>> torch.distributed.new_group(ranks=[0])
-# led to this error:
-#   RuntimeError: fn INTERNAL ASSERT FAILED at "/opt/conda/conda-bld/pytorch_1659484809662/work/torch/csrc/distributed/c10d/init.cpp":155, please report a bug to PyTorch.
 STORE = None
 
 

--- a/metaseq/distributed/utils.py
+++ b/metaseq/distributed/utils.py
@@ -84,7 +84,7 @@ def _infer_slurm_init(cfg: DistributedTrainingConfig):
             host = os.environ.get("MASTER_ADDR", None)
         if host is None:
             return
-        cfg.distributed_init_method = "tcpr://{host}:{port}".format(
+        cfg.distributed_init_method = "barrierlesstcpr://{host}:{port}".format(
             host=host, port=cfg.distributed_port
         )
         nnodes = int(os.environ.get("SLURM_NNODES"))


### PR DESCRIPTION
**Patch Description**
Added a barrierlessenv init_method for pytorch distributed method init_process_group. This is done for faster initialization of the process group

**Testing steps**
Run with --distributed_init_method barrierlessenv://

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
