### PR TITLE
Fixes to generation code (n and best_of params)

### DIFF
--- a/metaseq/cli/README.md
+++ b/metaseq/cli/README.md
@@ -47,7 +47,7 @@ LAUNCH_ARGS = [
     f"--merges-filename {BPE_MERGES}",
     f"--vocab-filename {BPE_VOCAB}",
     f"--path {MODEL_FILE}",
-    "--beam 1 --nbest 1",
+    "--beam 1",
     "--distributed-port 13000",
     "--checkpoint-shard-count 1",
     f"--batch-size {BATCH_SIZE}",

--- a/metaseq/cli/interactive_hosted.py
+++ b/metaseq/cli/interactive_hosted.py
@@ -305,15 +305,17 @@ def completions(engine=None):
         generation_args["top_p"] = round(float(generation_args["top_p"]), 1)
     else:
         generation_args["top_p"] = 1.0
-    # beam search top n
-    if "n" in generation_args:
-        if int(generation_args["n"]) > MAX_BEAM:
-            logger.warning(
-                f'beam size/sampling size of {int(generation_args["n"])} too large, using {MAX_BEAM} to avoid OOM'
-            )
-        generation_args["n"] = min(MAX_BEAM, max(1, int(generation_args["n"])))
-    else:
+    if "n" not in generation_args:
         generation_args["n"] = 1
+    if "best_of" not in generation_args:
+        generation_args["best_of"] = generation_args["n"]    
+    # beam search
+    if int(generation_args["best_of"]) > MAX_BEAM:
+        logger.warning(
+            f'beam size/sampling size of {int(generation_args["best_of"])} too large, using {MAX_BEAM} to avoid OOM'
+        )
+        generation_args["best_of"] = MAX_BEAM
+        generation_args["n"] = min(MAX_BEAM, int(generation_args["n"]))
 
     ret_queue = queue.Queue()
     for i, prompt in enumerate(prompts):

--- a/metaseq/cli/interactive_hosted.py
+++ b/metaseq/cli/interactive_hosted.py
@@ -308,7 +308,7 @@ def completions(engine=None):
     if "n" not in generation_args:
         generation_args["n"] = 1
     if "best_of" not in generation_args:
-        generation_args["best_of"] = generation_args["n"]    
+        generation_args["best_of"] = generation_args["n"]
     # beam search
     if int(generation_args["best_of"]) > MAX_BEAM:
         logger.warning(

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -574,10 +574,6 @@ class GenerationConfig(MetaseqDataclass):
         default=5,
         metadata={"help": "beam size"},
     )
-    nbest: int = field(
-        default=1,
-        metadata={"help": "number of hypotheses to output"},
-    )
     max_len_a: float = field(
         default=0,
         metadata={

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -197,8 +197,8 @@ class GeneratorInterface:
         temperature: softmax temperature
         top_p: nucleus probability
         log_probs: return this cutoff of the probability distribution
-        n: beam size
-        best_of: number of beams to return. must be <= n
+        best_of: beam size
+        n: number of beams to return. must be <= best_of
         echo: if true, returned text/tokens/scores includes the prompt.
             This is useful for getting PPL evaluations.
         stop: a list of terminating tokens
@@ -217,6 +217,7 @@ class GeneratorInterface:
         self.cfg.generation.sampling_topp = top_p if top_p > 0 else -1
         self.cfg.generation.sampling = top_p > 0.0
         self.cfg.generation.beam = best_of
+        self.cfg.generation.nbest = n
         if temperature > 0:
             self.cfg.generation.temperature = temperature
         elif temperature == 0:
@@ -289,7 +290,7 @@ class GeneratorInterface:
             # actually turn everything into strings
             for i in range(all_tokens.size(0)):
                 beams = []
-                for j in range(best_of):
+                for j in range(n):
                     # first beam is always the highest scoring
                     tokens = all_tokens[i, j].tolist()
                     scores = all_scores[i, j].tolist()

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -217,7 +217,6 @@ class GeneratorInterface:
         self.cfg.generation.sampling_topp = top_p if top_p > 0 else -1
         self.cfg.generation.sampling = top_p > 0.0
         self.cfg.generation.beam = best_of
-        self.cfg.generation.nbest = n
         if temperature > 0:
             self.cfg.generation.temperature = temperature
         elif temperature == 0:


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/metaseq/issues/529, where the problem is very well documented. 

1/ `best_of` should control beam size, while `n` controls number of generations to be returned.
2/ `nbest` doesn't do anything, the number of generations returned is controlled in hub_utils.