### PR TITLE
Support overriding sequence parallelism in the API

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -18,7 +18,11 @@ from omegaconf import OmegaConf
 from metaseq.dataclass.configs import CheckpointConfig
 from metaseq.dataclass.utils import overwrite_args_by_name
 from metaseq.distributed import utils as distributed_utils
-from metaseq.file_io import PathManager, torch_load_cpu
+from metaseq.file_io import (
+    PathManager,
+    torch_load_cpu,
+    load_and_pop_last_optimizer_state,
+)
 from metaseq.launcher.opt_job_constants import ComputeEnvs
 
 logger = logging.getLogger(__name__)
@@ -316,7 +320,8 @@ def _is_checkpoint_sharded(checkpoint_files) -> bool:
             "--model-parallel. If you are working on a new script, it may also mean "
             "you failed to fsdp_wrap or you have an unnecessary fsdp_wrap."
         )
-    sd = torch_load_cpu(checkpoint_files[0])
+    # We don't need the optimizer state here, since we're just loading the model for the config.
+    sd = load_and_pop_last_optimizer_state(checkpoint_files[0])
     return sd["cfg"]["distributed_training"]["use_sharded_state"]
 
 

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -18,11 +18,7 @@ from omegaconf import OmegaConf
 from metaseq.dataclass.configs import CheckpointConfig
 from metaseq.dataclass.utils import overwrite_args_by_name
 from metaseq.distributed import utils as distributed_utils
-from metaseq.file_io import (
-    PathManager,
-    torch_load_cpu,
-    load_and_pop_last_optimizer_state,
-)
+from metaseq.file_io import PathManager, torch_load_cpu
 from metaseq.launcher.opt_job_constants import ComputeEnvs
 
 logger = logging.getLogger(__name__)
@@ -320,8 +316,7 @@ def _is_checkpoint_sharded(checkpoint_files) -> bool:
             "--model-parallel. If you are working on a new script, it may also mean "
             "you failed to fsdp_wrap or you have an unnecessary fsdp_wrap."
         )
-    # We don't need the optimizer state here, since we're just loading the model for the config.
-    sd = load_and_pop_last_optimizer_state(checkpoint_files[0])
+    sd = torch_load_cpu(checkpoint_files[0])
     return sd["cfg"]["distributed_training"]["use_sharded_state"]
 
 

--- a/metaseq/cli/interactive_cli.py
+++ b/metaseq/cli/interactive_cli.py
@@ -12,6 +12,7 @@ See docs/api.md for more information.
 """
 
 import os
+import ast
 import random
 import sys
 import logging
@@ -35,6 +36,7 @@ else:
     )
 TOTAL_WORLD_SIZE = constants_module.TOTAL_WORLD_SIZE
 LAUNCH_ARGS = constants_module.LAUNCH_ARGS
+ARG_OVERRIDES = constants_module.ARG_OVERRIDES
 
 logger = build_logger()
 
@@ -115,6 +117,11 @@ def cli_main():
     args.data = os.path.dirname(args.path)  # hardcode the data arg
     cfg = convert_namespace_to_omegaconf(args)
     cfg.distributed_training.distributed_world_size = TOTAL_WORLD_SIZE
+
+    model_overrides = ast.literal_eval(cfg.common_eval.model_overrides)
+    model_overrides.update(ARG_OVERRIDES)
+    cfg.common_eval.model_overrides = str(model_overrides)
+
     distributed_utils.call_main(cfg, worker_main, namespace_args=args)
 
 

--- a/metaseq/cli/interactive_cli.py
+++ b/metaseq/cli/interactive_cli.py
@@ -36,7 +36,7 @@ else:
     )
 TOTAL_WORLD_SIZE = constants_module.TOTAL_WORLD_SIZE
 LAUNCH_ARGS = constants_module.LAUNCH_ARGS
-ARG_OVERRIDES = constants_module.ARG_OVERRIDES
+INFERENCE_ARG_OVERRIDES = constants_module.INFERENCE_ARG_OVERRIDES
 
 logger = build_logger()
 
@@ -119,7 +119,7 @@ def cli_main():
     cfg.distributed_training.distributed_world_size = TOTAL_WORLD_SIZE
 
     model_overrides = ast.literal_eval(cfg.common_eval.model_overrides)
-    model_overrides.update(ARG_OVERRIDES)
+    model_overrides.update(INFERENCE_ARG_OVERRIDES)
     cfg.common_eval.model_overrides = str(model_overrides)
 
     distributed_utils.call_main(cfg, worker_main, namespace_args=args)

--- a/metaseq/cli/interactive_hosted.py
+++ b/metaseq/cli/interactive_hosted.py
@@ -12,6 +12,7 @@ See docs/api.md for more information.
 """
 
 import os
+import ast
 import queue
 import pkg_resources
 import random
@@ -50,6 +51,7 @@ MAX_BEAM = constants_module.MAX_BEAM
 DEFAULT_PORT = constants_module.DEFAULT_PORT
 TOTAL_WORLD_SIZE = constants_module.TOTAL_WORLD_SIZE
 LAUNCH_ARGS = constants_module.LAUNCH_ARGS
+ARG_OVERRIDES = constants_module.ARG_OVERRIDES
 
 app = Flask(__name__)
 
@@ -377,6 +379,11 @@ def cli_main():
     port = DEFAULT_PORT
     cfg = convert_namespace_to_omegaconf(args)
     cfg.distributed_training.distributed_world_size = TOTAL_WORLD_SIZE
+
+    model_overrides = ast.literal_eval(cfg.common_eval.model_overrides)
+    model_overrides.update(ARG_OVERRIDES)
+    cfg.common_eval.model_overrides = str(model_overrides)
+
     distributed_utils.call_main(cfg, worker_main, namespace_args=args)
 
 

--- a/metaseq/cli/interactive_hosted.py
+++ b/metaseq/cli/interactive_hosted.py
@@ -51,7 +51,7 @@ MAX_BEAM = constants_module.MAX_BEAM
 DEFAULT_PORT = constants_module.DEFAULT_PORT
 TOTAL_WORLD_SIZE = constants_module.TOTAL_WORLD_SIZE
 LAUNCH_ARGS = constants_module.LAUNCH_ARGS
-ARG_OVERRIDES = constants_module.ARG_OVERRIDES
+INFERENCE_ARG_OVERRIDES = constants_module.INFERENCE_ARG_OVERRIDES
 
 app = Flask(__name__)
 
@@ -381,7 +381,7 @@ def cli_main():
     cfg.distributed_training.distributed_world_size = TOTAL_WORLD_SIZE
 
     model_overrides = ast.literal_eval(cfg.common_eval.model_overrides)
-    model_overrides.update(ARG_OVERRIDES)
+    model_overrides.update(INFERENCE_ARG_OVERRIDES)
     cfg.common_eval.model_overrides = str(model_overrides)
 
     distributed_utils.call_main(cfg, worker_main, namespace_args=args)

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -7,6 +7,7 @@ import argparse
 import ast
 import logging
 import os
+import re
 import time
 from argparse import Namespace
 from typing import List, Optional
@@ -16,12 +17,13 @@ import numpy as np
 import torch
 
 from metaseq import checkpoint_utils, tasks
-from metaseq import utils
+from metaseq import utils, distributed_utils
 from metaseq.data import encoders
 from metaseq.dataclass.configs import MetaseqConfig
 from metaseq.dataclass.utils import convert_namespace_to_omegaconf
 from metaseq.distributed import fsdp_enable_wrap, fsdp_wrap
 from metaseq.service.utils import normalize_newlines
+from metaseq.file_io import PathManager
 
 
 logger = logging.getLogger(__name__)
@@ -106,6 +108,24 @@ class GeneratorInterface:
         return self.bpe.bpe.decode(x)
 
     def load_model(self):
+        if self.cfg.common.model_parallel_size == 1:
+            r = distributed_utils.get_global_rank()
+        else:
+            r = distributed_utils.get_data_parallel_rank()
+
+        suffix = self.cfg.checkpoint.checkpoint_suffix
+
+        sharded_files = PathManager.ls(
+            re.sub(".pt$", f"{suffix}*", self.cfg.common_eval.path)
+        )
+        if len(sharded_files) > 0 and "-shard" in sharded_files[0]:
+            # We are loading a sharded checkpoint
+            suffix += f"-shard{r}"
+        else:
+            suffix += ""
+
+        self.cfg.checkpoint.checkpoint_suffix = suffix
+
         utils.import_user_module(self.cfg.common)
 
         # Fix seed for stochastic decoding
@@ -120,6 +140,7 @@ class GeneratorInterface:
         task = tasks.setup_task(self.cfg.task)
 
         def _build_model(cfg, task):
+            cfg.model.distribute_checkpointed_activations = False
             model = task.build_model(cfg.model).cuda()
             model.make_generation_fast_()
             return fsdp_wrap(model)

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -140,7 +140,6 @@ class GeneratorInterface:
         task = tasks.setup_task(self.cfg.task)
 
         def _build_model(cfg, task):
-            cfg.model.distribute_checkpointed_activations = False
             model = task.build_model(cfg.model).cuda()
             model.make_generation_fast_()
             return fsdp_wrap(model)

--- a/metaseq/service/constants.py
+++ b/metaseq/service/constants.py
@@ -58,4 +58,4 @@ LAUNCH_ARGS = [
 ]
 
 # Optional arg overrides which influence model loading during inference
-ARG_OVERRIDES = {}
+INFERENCE_ARG_OVERRIDES = {}

--- a/metaseq/service/constants.py
+++ b/metaseq/service/constants.py
@@ -58,5 +58,4 @@ LAUNCH_ARGS = [
 ]
 
 # Optional arg overrides which influence model loading during inference
-ARG_OVERRIDES = {
-}
+ARG_OVERRIDES = {}

--- a/metaseq/service/constants.py
+++ b/metaseq/service/constants.py
@@ -56,3 +56,7 @@ LAUNCH_ARGS = [
     f"--max-tokens {BATCH_SIZE * MAX_SEQ_LEN}",
     "/tmp",  # required "data" argument.
 ]
+
+# Optional arg overrides which influence model loading during inference
+ARG_OVERRIDES = {
+}


### PR DESCRIPTION
**Patch Description**
1. Support overriding sequence parallelism in the API
2. Support loading FSDP sharded models through the API

**Testing steps**

1. Take a sequence parallel checkpoint, and create a constants module file (custom_constants_module.py)

```
# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
#
# This source code is licensed under the MIT license found in the
# LICENSE file in the root directory of this source tree.

import os

MAX_SEQ_LEN = 2048
BATCH_SIZE = 2048  # silly high bc we dynamically batch by MAX_BATCH_TOKENS
MAX_BATCH_TOKENS = 3072
DEFAULT_PORT = 6010
MODEL_PARALLEL = <REPLACE_MODEL_PARALLEL_SIZE_HERE>
TOTAL_WORLD_SIZE = <REPLACE_WORLD_SIZE_HERE>
MAX_BEAM = 16

CHECKPOINT_FOLDER = <INSERT_MODEL_CHECKPOINT_FOLDER_HERE>

# tokenizer files
HF_TOKENIZER = <INSERT_TOKENIZER_FILE_HERE>
MODEL_FILE = os.path.join(CHECKPOINT_FOLDER, "reshard.pt")


LAUNCH_ARGS = [
    f"--model-parallel-size {MODEL_PARALLEL}",
    f"--distributed-world-size {TOTAL_WORLD_SIZE}",
    "--ddp-backend fully_sharded",
    "--task language_modeling",
    "--bpe hf_byte_bpe",
    f"--hf-tokenizer {HF_TOKENIZER}",
    f"--path {MODEL_FILE}",
    "--beam 1 --nbest 1",
    "--distributed-port 13000",
    "--checkpoint-shard-count 1",
    "--use-sharded-state",
    f"--batch-size {BATCH_SIZE}",
    f"--buffer-size {BATCH_SIZE * MAX_SEQ_LEN}",
    f"--max-tokens {BATCH_SIZE * MAX_SEQ_LEN}",
    "/tmp",  # required "data" argument.
]

# Optional arg overrides which influence model loading during inference
INFERENCE_ARG_OVERRIDES = {"sequence_parallel": False}

```


2. Export the constants module for it to be visible to interactive_hosted.py

```
export PYTHONPATH=$PYTHONPATH:/path/to/custom_constants_module METASEQ_SERVICE_CONSTANTS_MODULE=custom_constants_module
```


3. Run interactive_hosted.py
```
srun --exclusive -N <NUMBER_OF_NODES> --gpus-per-node <NUMBER_OF_GPUS_PER_NODE> --tasks 1 -c 96 --partition <PUT_PARTITION_NAME_HERE> --time "1-00:00:00" --qos high  --pty python metaseq/cli/interactive_hosted.py
```
NUMBER_OF_NODES*NUMBER_OF_GPUS_PER_NODE should be equal to MODEL_PARALLEL_SIZE


4. Prompt the model
```
curl -k http://<ip>:<port>/completions -H "Authorization: Bearer Punit" -H "Content-Type: application/json" \
-d '{
"prompt": [16853, 16947, 19678, 16709, 16647, 19493, 17495, 16688, 16397],
"temperature": 0.0,
"max_tokens": 0, "min_tokens": 0,
"top_p": 1.0, "n": 1, "best_of": 1,
"echo": true, "logprobs": 1, "seed": 1
}'
```

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
