### PR TITLE
Debug logging for end_of_epoch

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -275,7 +275,7 @@ def train(
 
         end_of_epoch = not itr.has_next()
         if end_of_epoch:
-            end_of_epoch = distributed_utils.get_global_rank()
+            grank = distributed_utils.get_global_rank()
             dataset = epoch_itr.dataset
             while not hasattr(dataset, 'len_cache'):
                 dataset = dataset.dataset

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -274,6 +274,16 @@ def train(
                 metrics.reset_meters("train_inner")
 
         end_of_epoch = not itr.has_next()
+        if end_of_epoch:
+            end_of_epoch = distributed_utils.get_global_rank()
+            dataset = epoch_itr.dataset
+            while not hasattr(dataset, 'len_cache'):
+                dataset = dataset.dataset
+            len_cache = tuple(dataset.len_cache.data)
+            cache_hash = hash(len_cache)
+            contains_zero = any([x == 0 for x in len_cache])
+            logger.warn(f"End of Epoch on rank {grank}: sequences_consumed={itr.sequences_consumed} n={itr.n} len_cache_hash={cache_hash} len_cache_has_zeros={contains_zero}")
+
         valid_losses, should_stop = validate_and_save(
             cfg,
             trainer,


### PR DESCRIPTION
In larger runs some dataloaders appear to end early. Adding some debug logging when they reach an end_of_epoch state to try to spot the difference in these instances vs others.

