### PR TITLE
Automatically detect and skip loss spikes

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -416,7 +416,7 @@ class OptimizationConfig(MetaseqDataclass):
         },
     )
     ewm_ratio_to_skip_batch: float = field(
-        default=1.25,
+        default=-1,
         metadata={
             "help": "Skip current batch if the loss to loss ewm ratio is "
             "higher than this value. Turned off at -1"

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -415,10 +415,11 @@ class OptimizationConfig(MetaseqDataclass):
             "help": "Skip gradient update if gnorm is higher than --clip-norm value"
         },
     )
-    max_loss_to_skip_batch: float = field(
-        default=-1,
+    ewm_ratio_to_skip_batch: float = field(
+        default=1.25,
         metadata={
-            "help": "Skip current batch if loss is higher than this value. Turned off at -1"
+            "help": "Skip current batch if the loss to loss ewm ratio is "
+            "higher than this value. Turned off at -1"
         },
     )
 

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -415,6 +415,13 @@ class OptimizationConfig(MetaseqDataclass):
             "help": "Skip gradient update if gnorm is higher than --clip-norm value"
         },
     )
+    max_loss_to_skip_batch: float = field(
+        default=-1,
+        metadata={
+            "help": "Skip current batch if loss is higher than this value. Turned off at -1"
+        },
+    )
+
     update_freq: List[int] = field(
         default_factory=lambda: [1],
         metadata={"help": "update parameters every N_i batches, when in epoch i"},

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -765,7 +765,9 @@ class Trainer(object):
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
             # skip optimizer step if there is a loss spike
-            self.skip_spike(logging_outputs, self.cfg.optimization.max_loss_to_skip_batch)
+            self.skip_spike(
+                logging_outputs, self.cfg.optimization.max_loss_to_skip_batch
+            )
             # take an optimization step
             self.task.optimizer_step(
                 self.optimizer, model=self.model, update_num=self.get_num_updates()

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -996,7 +996,7 @@ class Trainer(object):
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
                 f"Skip batch as we encountered a loss spike. In "
-                f"num_update: {self.get_num_updates()} the loss is {loss:.2f}. "
+                f"num_update: {self.get_num_updates()} the loss is {loss_t:.2f}. "
                 f"The ewm for the loss was only at {ewm_t:.2f} . "
                 f"The loss to ewm loss ratio is {ewm_ratio:.2f}, which is higher than "
                 f"ewm_ratio_to_skip_batch of {ewm_ratio_to_skip_batch} ."

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -978,6 +978,7 @@ class Trainer(object):
         ewm_t_1 = self._ewm_loss
         ewm_t = ewm(loss_t, ewm_t_1, span = 9)
         ewm_ratio = loss_t / ewm_t
+        logger.info(f"Step {self.get_num_updates()}: ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}")
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
@@ -1273,7 +1274,7 @@ def _set_module_by_path(module, path, value):
 
 def ewm(loss_t, ewm_t_1, span):
     alpha = 2 / (span + 1)
-    return (1 - alpha) * ewm_1 + alpha * loss_t
+    return (1 - alpha) * ewm_t_1 + alpha * loss_t
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -15,7 +15,6 @@ import time
 import math
 from itertools import chain
 from typing import Any, Dict, List
-import random
 
 import torch
 from omegaconf import OmegaConf
@@ -963,16 +962,8 @@ class Trainer(object):
             return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
-
         loss = float(loss_sum / sample_size / math.log(2))
-
-        if random.randint(0, 15) == 10:
-            loss = loss * 100
-            logger.info("increased loss")
-            logger.info(str(loss))
-        logger.info(str(loss))
         if loss > max_loss_to_skip_batch:
-            logger.info("doing skip")
             raise SpikeError(f"Skip batch as we encountered a loss spike. In "
             f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
             f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}")

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -113,6 +113,7 @@ class Trainer(object):
         self._wrapped_criterion = None
         self._wrapped_model = None
         self._ewm_loss = None
+        self._skipped_loss_spikes = 0
 
         # TODO(myleott): support tpu
         if self.cuda and self.data_parallel_world_size > 1:
@@ -770,7 +771,7 @@ class Trainer(object):
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
             # skip optimizer step if there is a loss spike
-            self.skip_spike(
+            ewm_loss_ratio = self.skip_spike(
                 logging_outputs, self.cfg.optimization.ewm_ratio_to_skip_batch
             )
             # take an optimization step
@@ -822,7 +823,7 @@ class Trainer(object):
 
             # log stats
             logging_output = self._reduce_and_log_stats(
-                logging_outputs, sample_size, grad_norm
+                logging_outputs, sample_size, grad_norm, ewm_loss_ratio
             )
 
             # clear CUDA cache to reduce memory fragmentation
@@ -979,6 +980,7 @@ class Trainer(object):
         ewm_ratio = loss_t / ewm_t
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
+            self._skipped_loss_spikes += 1
             raise SpikeError(
                 f"Skip batch as we encountered a loss spike. In "
                 f"num_update: {self.get_num_updates()} the loss is {loss_t:.2f}. "
@@ -988,6 +990,8 @@ class Trainer(object):
             )
         # the current loss is only included in ewm if the current batch is not skipped
         self._ewm_loss = ewm_t
+
+        return ewm_ratio
 
     def cumulative_training_time(self):
         if self._cumulative_training_time is None:
@@ -1171,13 +1175,17 @@ class Trainer(object):
                     + "-" * 80
                 )
 
-    def _reduce_and_log_stats(self, logging_outputs, sample_size, grad_norm=None):
+    def _reduce_and_log_stats(self, logging_outputs, sample_size, grad_norm=None, ewm_loss_ratio=0):
         # standard code
         if grad_norm is not None and (
             not torch.is_tensor(grad_norm) or torch.isfinite(grad_norm)
         ):
             metrics.log_speed("ups", 1.0, priority=100, round=2)
             metrics.log_scalar("gnorm", grad_norm, priority=400, round=3)
+            metrics.log_scalar("ewm_loss", self._ewm_loss, priority=700, round=2)
+            metrics.log_scalar("ewm_loss_ratio", ewm_loss_ratio, priority=710, round=4)
+            metrics.log_scalar("skipped_loss_spikes", self._skipped_loss_spikes, priority=720)
+            self._skipped_loss_spikes = 0
             if self.cfg.optimization.clip_norm > 0:
                 metrics.log_scalar(
                     "clip",

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -15,7 +15,6 @@ import time
 import math
 from itertools import chain
 from typing import Any, Dict, List
-
 import torch
 from omegaconf import OmegaConf
 
@@ -766,7 +765,7 @@ class Trainer(object):
                 # check local gradnorm single GPU case, trigger NanDetector
                 raise FloatingPointError("gradients are Nan/Inf")
             # skip optimizer step if there is a loss spike
-            self.skip_spike(logging_outputs, max_loss_to_skip_batch=100)
+            self.skip_spike(logging_outputs, self.cfg.optimization.max_loss_to_skip_batch)
             # take an optimization step
             self.task.optimizer_step(
                 self.optimizer, model=self.model, update_num=self.get_num_updates()

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -112,6 +112,7 @@ class Trainer(object):
         self._warn_once = set()
         self._wrapped_criterion = None
         self._wrapped_model = None
+        self._ewm_loss = None
 
         # TODO(myleott): support tpu
         if self.cuda and self.data_parallel_world_size > 1:
@@ -357,6 +358,7 @@ class Trainer(object):
                 "extra_state": {
                     "metrics": metrics.state_dict(),
                     "previous_training_time": self.cumulative_training_time(),
+                    "ewm_loss": self._ewm_loss
                 },
             }
 
@@ -527,6 +529,10 @@ class Trainer(object):
             if "previous_training_time" in extra_state:
                 self._previous_training_time = extra_state["previous_training_time"]
                 self._start_time = time.time()
+
+            if "ewm_loss" in extra_state:
+                self._ewm_loss = extra_state["ewm_loss"]
+                logger.info(f"loaded ewm loss from checkpoint with value {self._ewm_loss}")
 
             self.lr_step(epoch)
 
@@ -766,7 +772,7 @@ class Trainer(object):
                 raise FloatingPointError("gradients are Nan/Inf")
             # skip optimizer step if there is a loss spike
             self.skip_spike(
-                logging_outputs, self.cfg.optimization.max_loss_to_skip_batch
+                logging_outputs, self.cfg.optimization.ewm_ratio_to_skip_batch
             )
             # take an optimization step
             self.task.optimizer_step(
@@ -958,18 +964,31 @@ class Trainer(object):
             skip_gradient_update_on_clip_norm=skip_gradient_update_on_clip_norm,
         )
 
-    def skip_spike(self, logging_outputs, max_loss_to_skip_batch):
-        if max_loss_to_skip_batch == -1:
+    def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch):
+        if ewm_ratio_to_skip_batch == -1:
             return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
-        loss = float(loss_sum / sample_size / math.log(2))
-        if loss > max_loss_to_skip_batch:
+        loss_t = float(loss_sum / sample_size / math.log(2))
+
+        if self._ewm_loss is None:
+            self._ewm_loss = loss_t
+            logger.info("ewm loss was None at this point, so it was initilialized to loss_t")
+
+        ewm_t_1 = self._ewm_loss
+        ewm_t = ewm(loss_t, ewm_t_1, span = 9)
+        ewm_ratio = loss_t / ewm_t
+
+        if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
                 f"Skip batch as we encountered a loss spike. In "
-                f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
-                f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}"
+                f"num_update: {self.get_num_updates()} the loss is {loss:.2f}. "
+                f"The ewm for the loss was only at {ewm_t:.2f} . "
+                f"The loss to ewm loss ratio is {ewm_ratio:.2f}, which is higher than "
+                f"ewm_ratio_to_skip_batch of {ewm_ratio_to_skip_batch} ."
             )
+
+        self._ewm_loss = ewm_t
 
     def cumulative_training_time(self):
         if self._cumulative_training_time is None:
@@ -1251,6 +1270,10 @@ def _set_module_by_path(module, path, value):
         module = getattr(module, name)
     setattr(module, path[-1], value)
 
+
+def ewm(loss_t, ewm_t_1, span):
+    alpha = 2 / (span + 1)
+    return (1 - alpha) * ewm_1 + alpha * loss_t
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -358,7 +358,7 @@ class Trainer(object):
                 "extra_state": {
                     "metrics": metrics.state_dict(),
                     "previous_training_time": self.cumulative_training_time(),
-                    "ewm_loss": self._ewm_loss
+                    "ewm_loss": self._ewm_loss,
                 },
             }
 
@@ -532,7 +532,9 @@ class Trainer(object):
 
             if "ewm_loss" in extra_state:
                 self._ewm_loss = extra_state["ewm_loss"]
-                logger.info(f"loaded ewm loss from checkpoint with value {self._ewm_loss}")
+                logger.info(
+                    f"loaded ewm loss from checkpoint with value {self._ewm_loss}"
+                )
 
             self.lr_step(epoch)
 
@@ -973,12 +975,16 @@ class Trainer(object):
 
         if self._ewm_loss is None:
             self._ewm_loss = loss_t
-            logger.info("ewm loss was None at this point, so it was initilialized to loss_t")
+            logger.info(
+                "ewm loss was None at this point, so it was initilialized to loss_t"
+            )
 
         ewm_t_1 = self._ewm_loss
-        ewm_t = ewm(loss_t, ewm_t_1, span = 9)
+        ewm_t = ewm(loss_t, ewm_t_1, span=9)
         ewm_ratio = loss_t / ewm_t
-        logger.info(f"Step {self.get_num_updates()}: ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}")
+        logger.info(
+            f"Step {self.get_num_updates()}: loss_t: {loss_t:.2f}, ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}"
+        )
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(
@@ -1275,6 +1281,7 @@ def _set_module_by_path(module, path, value):
 def ewm(loss_t, ewm_t_1, span):
     alpha = 2 / (span + 1)
     return (1 - alpha) * ewm_t_1 + alpha * loss_t
+
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -141,8 +141,6 @@ class Trainer(object):
         self._previous_training_time = 0
         self._cumulative_training_time = None
 
-        self.real_steps = 0
-
     def reinitialize(self):
         """Reinitialize the Trainer, typically after model params change."""
         self._lr_scheduler = None
@@ -534,9 +532,6 @@ class Trainer(object):
 
             if "ewm_loss" in extra_state:
                 self._ewm_loss = extra_state["ewm_loss"]
-                logger.info(
-                    f"loaded ewm loss from checkpoint with value {self._ewm_loss}"
-                )
 
             self.lr_step(epoch)
 
@@ -969,29 +964,18 @@ class Trainer(object):
         )
 
     def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch):
-        self.real_steps += 1
         if ewm_ratio_to_skip_batch == -1:
             return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
         loss_t = float(loss_sum / sample_size / math.log(2))
 
-        if self.real_steps % 10 == 0:
-            loss_t *= 10
-            logger.info("Increased loss by 10x")
-
         if self._ewm_loss is None:
             self._ewm_loss = loss_t
-            logger.info(
-                "ewm loss was None at this point, so it was initilialized to loss_t"
-            )
 
         ewm_t_1 = self._ewm_loss
         ewm_t = ewm(loss_t, ewm_t_1, span=9)
         ewm_ratio = loss_t / ewm_t
-        logger.info(
-            f"Step {self.get_num_updates()}: loss_t: {loss_t:.2f}, ewm_t_1: {ewm_t_1:.2f}, ewm_t: {ewm_t:.2f}, ewm ratio: {ewm_ratio:.2f}"
-        )
 
         if ewm_ratio > ewm_ratio_to_skip_batch:
             raise SpikeError(

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -964,9 +964,11 @@ class Trainer(object):
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
         loss = float(loss_sum / sample_size / math.log(2))
         if loss > max_loss_to_skip_batch:
-            raise SpikeError(f"Skip batch as we encountered a loss spike. In "
-            f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
-            f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}")
+            raise SpikeError(
+                f"Skip batch as we encountered a loss spike. In "
+                f"num_update: {self.get_num_updates()} the loss is {loss:.2f}, "
+                f"which is higher than max_loss_to_skip_batch: {max_loss_to_skip_batch:.2f}"
+            )
 
     def cumulative_training_time(self):
         if self._cumulative_training_time is None:
@@ -1247,6 +1249,7 @@ def _set_module_by_path(module, path, value):
     for name in path[:-1]:
         module = getattr(module, name)
     setattr(module, path[-1], value)
+
 
 class SpikeError(Exception):
     pass

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -1173,7 +1173,9 @@ class Trainer(object):
                     + "-" * 80
                 )
 
-    def _reduce_and_log_stats(self, logging_outputs, sample_size, grad_norm=None, ewm_loss_ratio=0):
+    def _reduce_and_log_stats(
+        self, logging_outputs, sample_size, grad_norm=None, ewm_loss_ratio=0
+    ):
         # standard code
         if grad_norm is not None and (
             not torch.is_tensor(grad_norm) or torch.isfinite(grad_norm)
@@ -1182,7 +1184,9 @@ class Trainer(object):
             metrics.log_scalar("gnorm", grad_norm, priority=400, round=3)
             metrics.log_scalar("ewm_loss", self._ewm_loss, priority=700, round=2)
             metrics.log_scalar("ewm_loss_ratio", ewm_loss_ratio, priority=710, round=4)
-            metrics.log_scalar("skipped_loss_spikes", self._skipped_loss_spikes, priority=720)
+            metrics.log_scalar(
+                "skipped_loss_spikes", self._skipped_loss_spikes, priority=720
+            )
             self._skipped_loss_spikes = 0
             if self.cfg.optimization.clip_norm > 0:
                 metrics.log_scalar(

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -965,8 +965,6 @@ class Trainer(object):
         )
 
     def skip_spike(self, logging_outputs, ewm_ratio_to_skip_batch, span=9):
-        if ewm_ratio_to_skip_batch == -1:
-            return
         loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
         sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
         loss_t = float(loss_sum / sample_size / math.log(2))
@@ -979,7 +977,7 @@ class Trainer(object):
         ewm_t = (1 - alpha) * ewm_t_1 + alpha * loss_t
         ewm_ratio = loss_t / ewm_t
 
-        if ewm_ratio > ewm_ratio_to_skip_batch:
+        if ewm_ratio_to_skip_batch != -1 and ewm_ratio > ewm_ratio_to_skip_batch:
             self._skipped_loss_spikes += 1
             raise SpikeError(
                 f"Skip batch as we encountered a loss spike. In "


### PR DESCRIPTION
Allows to set a threshold for loss to ewa loss ratio, on which to skip a batch. This is useful for skipping loss spikes.
Here are more details: https://github.com/facebookresearch/metaseq/pull/521