### PR TITLE
Automatically evaluate checkpoints after copying to NFS

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -429,7 +429,7 @@ def _checkpoint_add_directory(basename):
     return m[1], f"checkpoint{m[3]}"
 
 
-def post_checkpoint_callback(cfg, num_updates, should_stop, filename):
+def post_checkpoint_callback(cfg, num_updates, training_finished, filename):
     if cfg.checkpoint.cloud_upload_path is not None:
         if "blob.core.windows.net" in cfg.checkpoint.cloud_upload_path:
             azcopy_logs = filename + "_azcopy_logs"
@@ -501,7 +501,7 @@ def post_checkpoint_callback(cfg, num_updates, should_stop, filename):
             nfs_evaluation(
                 cfg,
                 num_updates,
-                should_stop,
+                training_finished,
                 checkpoint_dir,
                 destination_checkpoints_dir,
             )
@@ -522,7 +522,7 @@ def post_checkpoint_callback(cfg, num_updates, should_stop, filename):
 
 
 def nfs_evaluation(
-    cfg, num_updates, should_stop, checkpoint_dir, destination_checkpoints_dir
+    cfg, num_updates, training_finished, checkpoint_dir, destination_checkpoints_dir
 ):
     if (
         cfg.checkpoint.nfs_eval_script_path is not None
@@ -532,7 +532,7 @@ def nfs_evaluation(
                 cfg.checkpoint.nfs_eval_frequency > 0
                 and num_updates % cfg.checkpoint.nfs_eval_frequency == 0
             )
-            or should_stop
+            or training_finished
         )
     ):
         for retry in range(cfg.checkpoint.nfs_eval_num_attempts):

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -512,15 +512,15 @@ def post_checkpoint_callback(cfg, filename):
                     current_checkpoint_path = os.path.join(
                         destination_checkpoints_dir, checkpoint_dir
                     )
-                    all_checkpoint_parts = os.listdir(current_checkpoint_path)
-                    num_files = len(
-                        [f for f in all_current_checkpoints if not f.startswith("_")]
+                    num_files = os.listdir(current_checkpoint_path)
+                    finished_checkpoint_parts = len(
+                        [f for f in num_files if not f.startswith("_")]
                     )
-                    if num_files == cfg.distributed_training.distributed_world_size:
+                    if finished_checkpoint_parts == cfg.distributed_training.distributed_world_size:
                         logger.info(
                             f"All checkpoint parts for {checkpoint_dir} are in NFS, will now start to run evals"
                         )
-                        logger.info(f"REMOVE checkpoints found: {num_files}")
+                        logger.info(f"REMOVE checkpoints found: {finished_checkpoint_parts}")
                         script_dir = os.path.join(
                             os.environ.get("METASEQ_SAVE_DIR"),
                             cfg.checkpoint.cloud_eval_script_path,

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -527,8 +527,13 @@ def nfs_evaluation(
     if (
         cfg.checkpoint.nfs_eval_script_path is not None
         and distributed_utils.get_global_rank() == 0
-        and ((cfg.checkpoint.nfs_eval_frequency > 0
-        and num_updates % cfg.checkpoint.nfs_eval_frequency == 0) or should_stop)
+        and (
+            (
+                cfg.checkpoint.nfs_eval_frequency > 0
+                and num_updates % cfg.checkpoint.nfs_eval_frequency == 0
+            )
+            or should_stop
+        )
     ):
         for retry in range(cfg.checkpoint.nfs_eval_num_attempts):
             time.sleep(cfg.checkpoint.nfs_eval_attempt_wait_minutes * 60)

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -462,11 +462,6 @@ def post_checkpoint_callback(cfg, filename):
             checkpoint_dir, checkpoint_file = _checkpoint_add_directory(basename)
             destination_checkpoints_dir = cfg.checkpoint.cloud_upload_path[4:]
             temporary_checkpoint_file = f"_{checkpoint_file}"
-            logger.info(
-                f"checkpoint_dir: {checkpoint_dir}, checkpoint_file: {checkpoint_file}"
-            )
-            logger.info(f"destination_checkpoints_dir: {destination_checkpoints_dir}")
-            logger.info(f"temporary_checkpoint_file: {temporary_checkpoint_file}")
             try:
                 os.mkdir(os.path.join(destination_checkpoints_dir, checkpoint_dir))
             except FileExistsError:
@@ -527,9 +522,6 @@ def post_checkpoint_callback(cfg, filename):
                         logger.info(
                             f"All checkpoint parts for {checkpoint_dir} are in NFS, will now start to run evals"
                         )
-                        logger.info(
-                            f"REMOVE checkpoints found: {finished_checkpoint_parts}"
-                        )
                         script_dir = os.path.join(
                             os.environ.get("METASEQ_SAVE_DIR"),
                             cfg.checkpoint.cloud_eval_script_path,
@@ -546,8 +538,6 @@ def post_checkpoint_callback(cfg, filename):
                         )
                         if res.returncode == 0:
                             logger.info(f"Sucessfully evaluated {checkpoint_dir}")
-                            logger.info(f"Eval script stdout = {res.stdout}")
-                            logger.info(f"Eval script stderr = {res.stderr}")
                         else:
                             logger.info(f"Error during evaluation: {res.returncode}")
                             logger.info(f"Eval script stdout = {res.stdout}")

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -10,7 +10,6 @@ Train a new model on one or across multiple GPUs.
 import argparse
 import functools
 import logging
-import importlib
 import math
 import os
 import subprocess

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -528,13 +528,8 @@ def nfs_evaluation(
     if (
         cfg.checkpoint.nfs_eval_script_path is not None
         and distributed_utils.get_global_rank() == 0
-        and (
-            (cfg.checkpoint.nfs_eval_last_checkpoint and should_stop)
-            or (
-                cfg.checkpoint.nfs_eval_frequency > 0
-                and num_updates % cfg.checkpoint.nfs_eval_frequency == 0
-            )
-        )
+        and cfg.checkpoint.nfs_eval_frequency > 0
+        and num_updates % cfg.checkpoint.nfs_eval_frequency == 0
     ):
         for retry in range(cfg.checkpoint.nfs_eval_num_retries):
             time.sleep(cfg.checkpoint.nfs_eval_retry_wait_minutes * 60)

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -526,7 +526,6 @@ def post_checkpoint_callback(cfg, filename):
                             os.environ.get("METASEQ_SAVE_DIR"),
                             cfg.checkpoint.cloud_eval_script_path,
                         )
-                        logger.info("Script Dir" + script_dir)
                         res = subprocess.run(
                             [
                                 "bash",

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -567,17 +567,17 @@ class CheckpointConfig(MetaseqDataclass):
         },
     )
     cloud_eval_num_retries: int = field(
-        default=8,
+        default=10,
         metadata={"help": "Number of retries of running evals on upload of checkpoint"},
     )
     cloud_eval_retry_wait_minutes: int = field(
-        default=1,
+        default=5,
         metadata={
             "help": "Time to wait between retries of running evals on upload of checkpoint"
         },
     )
     cloud_eval_frequency: int = field(
-        default=200,
+        default=5000,
         metadata={
             "help": (
                 "Run evaluation only on uploaded checkpoints"

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -565,10 +565,6 @@ class CheckpointConfig(MetaseqDataclass):
             ),
         },
     )
-    nfs_eval_last_checkpoint: bool = field(
-        default=False,
-        metadata={"help": "Run evaluation at the end of the training run"},
-    )
 
     # TODO(susanz): After https://github.com/fairinternal/fairseq-big-internal/issues/22 is tackled, modify this
     #  to use ComputeEnvs constant

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -548,7 +548,9 @@ class CheckpointConfig(MetaseqDataclass):
     )
     nfs_eval_num_attempts: int = field(
         default=10,
-        metadata={"help": "Number of attempts of running evals on upload of checkpoint"},
+        metadata={
+            "help": "Number of attempts of running evals on upload of checkpoint"
+        },
     )
     nfs_eval_attempt_wait_minutes: int = field(
         default=5,

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -560,6 +560,13 @@ class CheckpointConfig(MetaseqDataclass):
             "argparse_alias": "--cloud-dir",
         },
     )
+    cloud_eval_script_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Path of eval script to run on checkpoints after they were uploaded"
+        },
+    )
+
     # TODO(susanz): After https://github.com/fairinternal/fairseq-big-internal/issues/22 is tackled, modify this
     #  to use ComputeEnvs constant
     cluster_env: str = field(

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -494,26 +494,6 @@ class CheckpointConfig(MetaseqDataclass):
         default=True,
         metadata={"help": "store a last checkpoint at the end of the training run."},
     )
-    eval_module: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Python module that is dinamically imported to run evaluations. It must have an eval_fn method."
-                "Required args for eval_fn:"
-                "1. First one contains the cloud upload path."
-                "2. Second one contains the filename of the checkpoints in the cloud"
-            )
-        },
-    )
-    evaluate_interval_updates: int = field(
-        default=0, metadata={"help": "run eval_fn from eval_module every N updates"}
-    )
-    evaluate_last_checkpoint: bool = field(
-        default=False,
-        metadata={
-            "help": "run the eval_fn from eval_module at the end of the training run"
-        },
-    )
     keep_last_epochs: int = field(
         default=-1, metadata={"help": "keep only the last N epoch checkpoints"}
     )
@@ -560,23 +540,23 @@ class CheckpointConfig(MetaseqDataclass):
             "argparse_alias": "--cloud-dir",
         },
     )
-    cloud_eval_script_path: Optional[str] = field(
+    nfs_eval_script_path: Optional[str] = field(
         default=None,
         metadata={
             "help": "Path of eval script to run on checkpoints after they were uploaded"
         },
     )
-    cloud_eval_num_retries: int = field(
+    nfs_eval_num_retries: int = field(
         default=10,
         metadata={"help": "Number of retries of running evals on upload of checkpoint"},
     )
-    cloud_eval_retry_wait_minutes: int = field(
+    nfs_eval_retry_wait_minutes: int = field(
         default=5,
         metadata={
             "help": "Time to wait between retries of running evals on upload of checkpoint"
         },
     )
-    cloud_eval_frequency: int = field(
+    nfs_eval_frequency: int = field(
         default=5000,
         metadata={
             "help": (
@@ -584,6 +564,10 @@ class CheckpointConfig(MetaseqDataclass):
                 "with multiples of this frequency"
             ),
         },
+    )
+    nfs_eval_last_checkpoint: bool = field(
+        default=False,
+        metadata={"help": "Run evaluation at the end of the training run"},
     )
 
     # TODO(susanz): After https://github.com/fairinternal/fairseq-big-internal/issues/22 is tackled, modify this

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -571,9 +571,18 @@ class CheckpointConfig(MetaseqDataclass):
         metadata={"help": "Number of retries of running evals on upload of checkpoint"},
     )
     cloud_eval_retry_wait_minutes: int = field(
-        default=5,
+        default=1,
         metadata={
             "help": "Time to wait between retries of running evals on upload of checkpoint"
+        },
+    )
+    cloud_eval_frequency: int = field(
+        default=200,
+        metadata={
+            "help": (
+                "Run evaluation only on uploaded checkpoints"
+                "with multiples of this frequency"
+            ),
         },
     )
 

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -566,6 +566,16 @@ class CheckpointConfig(MetaseqDataclass):
             "help": "Path of eval script to run on checkpoints after they were uploaded"
         },
     )
+    cloud_eval_num_retries: int = field(
+        default=8,
+        metadata={"help": "Number of retries of running evals on upload of checkpoint"},
+    )
+    cloud_eval_retry_wait_minutes: int = field(
+        default=5,
+        metadata={
+            "help": "Time to wait between retries of running evals on upload of checkpoint"
+        },
+    )
 
     # TODO(susanz): After https://github.com/fairinternal/fairseq-big-internal/issues/22 is tackled, modify this
     #  to use ComputeEnvs constant

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -546,14 +546,14 @@ class CheckpointConfig(MetaseqDataclass):
             "help": "Path of eval script to run on checkpoints after they were uploaded"
         },
     )
-    nfs_eval_num_retries: int = field(
+    nfs_eval_num_attempts: int = field(
         default=10,
-        metadata={"help": "Number of retries of running evals on upload of checkpoint"},
+        metadata={"help": "Number of attempts of running evals on upload of checkpoint"},
     )
-    nfs_eval_retry_wait_minutes: int = field(
+    nfs_eval_attempt_wait_minutes: int = field(
         default=5,
         metadata={
-            "help": "Time to wait between retries of running evals on upload of checkpoint"
+            "help": "Time to wait between attempts of running evals on upload of checkpoint"
         },
     )
     nfs_eval_frequency: int = field(


### PR DESCRIPTION
This PR adds the ability to automatically evaluate checkpoints after copying to NFS.

- After the asynchronous copy of a checkpoint to NFS, we check periodically whether all checkpoint parts have finished copying.
- Once all parts are done, we run the eval script defined in `nfs_eval_script_path` for this checkpoint

Add these lines to the internal sweep script to define the eval script path:
https://www.internalfb.com/phabricator/paste/view/P576097431

Testing:
I tested this with a dummy eval script, as the Punit's real eval script should only be used for large runs. I would recommend to check first whether the eval script alone runs correctly on our frozen branch.