### PR TITLE
Add optional type conversion to FSDP resharding script

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,8 +19,8 @@ Complete all of the setup as mentioned in [the Setup doc](setup.md).
   ```bash
   for j in {0..7}; do
       python -m metaseq.scripts.reshard_fsdp \
-      --input-glob-pattern "/path/to/raw/checkpoints/checkpoint_last-model_part-$j-shard*.pt" \
-      --output-shard-name "/path/to/resharded/checkpoints/reshard-model_part-$j.pt" \
+      --input "/path/to/raw/checkpoints/checkpoint_last-model_part-$j-shard*.pt" \
+      --output "/path/to/resharded/checkpoints/reshard-model_part-$j.pt" \
       --num-output-shards 1 --skip-optimizer-state True --unflatten-weights True
   done
   ```

--- a/metaseq/scripts/reshard_mp.py
+++ b/metaseq/scripts/reshard_mp.py
@@ -103,7 +103,7 @@ def reshard_model_parallel_parts(
         state_dict = {"model": sharded_dict}
         # Copy other values from rank 0
         for key in ["cfg", "extra_state", "optimizer_history", "args"]:
-            state_dict[key] = rank0_state_dict[key]
+            state_dict[key] = rank0_state_dict.get(key, None)
         state_dict["cfg"]["model"].model_parallel_size = M
 
         output_file = output.format(i=i)

--- a/projects/OPT/download_opt175b.md
+++ b/projects/OPT/download_opt175b.md
@@ -36,8 +36,8 @@ To consolidate the 992 shards into 8 files model-parallel evaluation, run the `m
 ```bash
 for j in {0..7}; do
     python -m metaseq.scripts.reshard_fsdp \
-    --input-glob-pattern "/path/to/raw/checkpoints/checkpoint_last-model_part-$j-shard*.pt" \
-    --output-shard-name "/path/to/resharded/checkpoints/reshard-model_part-$j.pt" \
+    --input "/path/to/raw/checkpoints/checkpoint_last-model_part-$j-shard*.pt" \
+    --output "/path/to/resharded/checkpoints/reshard-model_part-$j.pt" \
     --num-output-shards 1 --skip-optimizer-state True --unflatten-weights True
 done
 ```


### PR DESCRIPTION
### Summary of Changes
We add an option to convert weights into a new `dtype` while resharding FSDP checkpoints. This helps reduce checkpoint sizes and avoids issues under RAM constraints when we attempt to load checkpoints. For example, model weights might be saved in full precision but one only needs half precision at inference time.

We also rename some options (e.g. `input-glob-pattern` → `input` and `output-shard-name` → `output`) for succinctness.

### Test Plan
* Reshard and convert the OPT-125M checkpoint into various dtypes and make sure we can do inference correctly in the new dtypes:
```
seq 0 1 | parallel --line-buffer 'python metaseq/scripts/reshard_fsdp.py --input "/data/checkpoints/opt-125m/raw/checkpoint_last-model_part-{}-shard*.pt" --output "/data/checkpoints/opt-125m/reshard-no-os/reshard-model_part-{}.pt" --skip-optimizer-state True --unflatten-weights True --output-dtype fp16'
```
