### PR TITLE
Fix config.yml dump in training runs.

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -67,11 +67,15 @@ def main(cfg: DictConfig) -> None:
 
     checkpoint_utils.verify_checkpoint_directory(cfg.checkpoint.save_dir)
 
-    if distributed_utils.is_master(cfg.distributed_training):
+    if distributed_utils.is_master(cfg.distributed_training) and os.environ.get(
+        "METASEQ_SAVE_DIR"
+    ):
         # save a (vaguely human readable) copy of the training config
+        # TODO(roller): only works when launched with a sweep script
+        # should fix that
         OmegaConf.save(
             config=_flatten_config(cfg),
-            f=os.path.join(cfg.checkpoint.save_dir, "config.yml"),
+            f=os.path.join(os.environ["METASEQ_SAVE_DIR"], "config.yml"),
         )
 
     if (


### PR DESCRIPTION
**Patch Description**
Due to changes of logic around NFS handling, config.yml is no longer being saved along with training runs. Small hack to fix that.

**Testing steps**
Launched a 1 node run, validated config.yml exists.