### PR TITLE
Fix numpy upgrade issue

### DIFF
--- a/metaseq/data/indexed_dataset.py
+++ b/metaseq/data/indexed_dataset.py
@@ -105,7 +105,7 @@ _code_to_dtype = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: np.float32,
     7: np.double,
     8: np.uint16,
     9: np.uint32,
@@ -312,7 +312,7 @@ class IndexedDatasetBuilder:
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        np.float32: 4,
         np.double: 8,
     }
 


### PR DESCRIPTION
Numpy 1.24.0 deprecated `np.float`, causing metaseq to throw errors: https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations

Given the number of bytes in the map I'm assuming we meant float32 here, even though np.float actually used 8 bytes instead of 4...