### PR TITLE
Adding flash attention for sequence parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ install_fairscale: &install_fairscale
             cd ~/
         fi
 
-
 install_xformers: &install_xformers
   - run:
       name: Install xFormers from Source
@@ -171,7 +170,6 @@ commands:
     steps:
       - <<: *install_dep_common
       - <<: *install_fairscale
-      - <<: *install_xformers
       - <<: *install_dep_fused_ops
       - <<: *install_repo
       - <<: *download_and_configure_125m_with_hf_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,22 @@ install_fairscale: &install_fairscale
             cd ~/
         fi
 
+
+install_xformers: &install_xformers
+  - run:
+      name: Install xFormers from Source
+      working_directory: ~/
+      command: |
+        source activate metaseq
+        if ! python -c 'import xformers'; then
+            git clone https://github.com/facebookresearch/xformers.git
+            cd xformers
+            git checkout 4c06c79095ba8073dc870ee820e36a83302ae30c
+            git submodule update --init --recursive
+            pip install .
+            cd ~/
+        fi
+
 install_dep_pt19: &install_dep_pt19
   - run:
       name: Install Pytorch Dependencies
@@ -155,6 +171,7 @@ commands:
     steps:
       - <<: *install_dep_common
       - <<: *install_fairscale
+      - <<: *install_xformers
       - <<: *install_dep_fused_ops
       - <<: *install_repo
       - <<: *download_and_configure_125m_with_hf_dependencies

--- a/gpu_tests/test_sequence_parallel_transformer_layer.py
+++ b/gpu_tests/test_sequence_parallel_transformer_layer.py
@@ -20,13 +20,12 @@ def _distributed_init():
     device = 0
     torch.cuda.set_device(device)
 
-
     # Call the init process.
     init_method = "tcp://"
     master_ip = os.getenv("MASTER_ADDR", "localhost")
     master_port = os.getenv("MASTER_PORT", "6000")
     init_method += master_ip + ":" + master_port
-    init_method="file:///d:/tmp/some_file"
+    init_method = "file:///d:/tmp/some_file"
     torch.distributed.init_process_group(
         backend=backend, world_size=world_size, rank=rank, init_method=init_method
     )
@@ -69,9 +68,9 @@ class TestParity(unittest.TestCase):
         # std attn
         args.attn_variant = std_attn_variant
         reset_seeds()
-        decoder = ModelParallelTransformerDecoderLayer((args).cuda()
+        decoder = ModelParallelTransformerDecoderLayer(args).cuda()
         result = decoder(x_)
-        
+
         torch.distributed.barrier()
 
         assert torch.allclose(xf_result, result)
@@ -90,7 +89,7 @@ class TestParity(unittest.TestCase):
 
         torch.distributed.barrier()
         if torch.distributed.get_rank() == 0:
-            print('>> passed the test :-)')
+            print(">> passed the test :-)")
 
 
 if __name__ == "__main__":

--- a/gpu_tests/test_sequence_parallel_transformer_layer.py
+++ b/gpu_tests/test_sequence_parallel_transformer_layer.py
@@ -50,7 +50,7 @@ class TestParity(unittest.TestCase):
             memory_efficient_fp16=True,
             bf16=False,
         )
-        S, B, E = 128, 1, 64
+        S, B, E = 64, 128, 64
         x = torch.rand(
             (S, B, E), device="cuda", dtype=torch.float16, requires_grad=False
         )

--- a/gpu_tests/test_sequence_parallel_transformer_layer.py
+++ b/gpu_tests/test_sequence_parallel_transformer_layer.py
@@ -47,8 +47,10 @@ class TestParity(unittest.TestCase):
             decoder_ffn_embed_dim=64,
             decoder_layers=1,
             attention_dropout=0.0,
+            memory_efficient_fp16=True,
+            bf16=False,
         )
-        S, B, E = 128, 2, 64
+        S, B, E = 128, 1, 64
         x = torch.rand(
             (S, B, E), device="cuda", dtype=torch.float16, requires_grad=False
         )

--- a/gpu_tests/test_sequence_parallel_transformer_layer.py
+++ b/gpu_tests/test_sequence_parallel_transformer_layer.py
@@ -22,16 +22,14 @@ def _distributed_init():
 
     # Call the init process.
     init_method = "tcp://"
-    master_ip = os.getenv("MASTER_ADDR", "localhost")
-    master_port = os.getenv("MASTER_PORT", "6000")
+    master_ip = "localhost"
+    master_port = "6000"
     init_method += master_ip + ":" + master_port
-    init_method = "file:///d:/tmp/some_file"
     torch.distributed.init_process_group(
         backend=backend, world_size=world_size, rank=rank, init_method=init_method
     )
 
 
-# TODO: add dtype
 class TestParity(unittest.TestCase):
     def test_xformers_parity(self):
         if not torch.cuda.is_available():
@@ -51,7 +49,9 @@ class TestParity(unittest.TestCase):
             attention_dropout=0.0,
         )
         S, B, E = 128, 2, 64
-        x = torch.rand((S, B, E), device="cuda", requires_grad=False)
+        x = torch.rand(
+            (S, B, E), device="cuda", dtype=torch.float16, requires_grad=False
+        )
         x_ = x.clone()
         x.requires_grad = True
         x_.requires_grad = True

--- a/gpu_tests/test_sequence_parallel_transformer_layer.py
+++ b/gpu_tests/test_sequence_parallel_transformer_layer.py
@@ -63,7 +63,7 @@ class TestParity(unittest.TestCase):
             sequence_parallel=True,
             decoder_embed_dim=64,
             dropout=0.0,
-            decoder_attention_heads=1,
+            decoder_attention_heads=2,
             decoder_ffn_embed_dim=64,
             decoder_layers=1,
             attention_dropout=0.0,
@@ -85,19 +85,23 @@ class TestParity(unittest.TestCase):
         args.attn_variant = xf_attn_variant
         reset_seeds()
         xf_decoder = ModelParallelTransformerDecoderLayer(args).cuda()
+        reset_seeds()
         xf_result = xf_decoder(x)
 
         # std attn
         args.attn_variant = std_attn_variant
         reset_seeds()
         decoder = ModelParallelTransformerDecoderLayer(args).cuda()
+        reset_seeds()
         result = decoder(x_)
 
         torch.distributed.barrier()
         _assert_allclose(xf_result, result, atol=atol, rtol=rtol)
 
         # Test Backwards
+        reset_seeds()
         xf_result.backward(torch.ones_like(x))
+        reset_seeds()
         result.backward(torch.ones_like(x_))
 
         torch.distributed.barrier()

--- a/gpu_tests/test_sequence_parallel_transformer_layer.py
+++ b/gpu_tests/test_sequence_parallel_transformer_layer.py
@@ -3,7 +3,7 @@ import unittest
 import random
 import torch
 from types import SimpleNamespace
-from megatron.mpu import initialize_model_parallel
+from megatron.mpu import destroy_model_parallel, initialize_model_parallel
 from metaseq.model_parallel.modules import ModelParallelTransformerDecoderLayer
 
 
@@ -85,7 +85,7 @@ class TestParity(unittest.TestCase):
         assert torch.allclose(x.grad, x_.grad)
 
         # Reset groups
-        mpu.destroy_model_parallel()
+        destroy_model_parallel()
 
         torch.distributed.barrier()
         if torch.distributed.get_rank() == 0:

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -183,12 +183,13 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
             k = k.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
             v = v.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
 
-            # bmhk -> m, b*h, k
-            attn = xf_op.forward_no_grad(
-                q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0, scale=None
-            )  # .permute((0, 2, 1, 3)).view(-1, seq_len, head_dim).transpose(0, 1)
-            attn = attn.transpose(0, 1).view(seq_len, -1, head_dim)
-            # OR transpose 0/1, then view
+            attn = (
+                xf_op.forward_no_grad(
+                    q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0, scale=None
+                )
+                .transpose(0, 1)
+                .view(seq_len, -1, head_dim)
+            )
         else:
             q = q.view(seq_len, -1, head_dim)
             k = k.view(seq_len, -1, head_dim)

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -6,6 +6,7 @@
 from metaseq.modules.activation_functions import gelu, gelu_back, relu, relu_back
 
 import importlib
+import logging
 import math
 import torch
 from types import SimpleNamespace

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -242,12 +242,16 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
             ctx.head_dim,
             ctx.embed_dim_per_partition,
             ctx.activation_fn_name,
+            ctx.xf_eff_attn,
+            ctx.xf_op,
         ) = (
             bsz,
             seq_len,
             head_dim,
             embed_dim_per_partition,
             activation_fn_name,
+            xf_eff_attn,
+            xf_op,
         )
 
         # apply scatter gather,
@@ -271,12 +275,22 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
             fc1_weight,
             fc2_weight,
         ) = ctx.saved_tensors
-        bsz, seq_len, head_dim, embed_dim_per_partition, activation_fn_name = (
+        (
+            bsz,
+            seq_len,
+            head_dim,
+            embed_dim_per_partition,
+            activation_fn_name,
+            xf_eff_attn,
+            xf_op,
+        ) = (
             ctx.bsz,
             ctx.seq_len,
             ctx.head_dim,
             ctx.embed_dim_per_partition,
             ctx.activation_fn_name,
+            ctx.xf_eff_attn,
+            ctx.xf_op,
         )
         dtype = grad_output.dtype
 

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -195,7 +195,7 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
                     op=xf_op[0],
                 )
                 .transpose(0, 1)
-                .reshape(seq_len, bsz, num_heads*head_dim)
+                .reshape(seq_len, bsz, num_heads * head_dim)
             )
             # TODO: Reshape q/k/v back to original?
         else:
@@ -413,7 +413,11 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
                 op=xf_op[0],
             )
             out = attn
-            attn = attn.transpose(0, 1).reshape(seq_len, bsz, num_heads*head_dim).contiguous()
+            attn = (
+                attn.transpose(0, 1)
+                .reshape(seq_len, bsz, num_heads * head_dim)
+                .contiguous()
+            )
         else:
             attn, attn_probs = SequeuceParallelTransformerBlock.forward_mha(
                 q, k, v, bsz, seq_len, head_dim, embed_dim_per_partition, dtype

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -182,8 +182,8 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
             k = k.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
             v = v.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
 
-            attn = xf_op.forward(
-                None, q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0
+            attn = xf_op.forward_no_grad(
+                q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0, scale=None
             ).view(seq_len, bsz, -1)
         else:
             q = q.view(seq_len, -1, head_dim)
@@ -385,7 +385,13 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
         if xf_eff_attn:
             fake_ctx = _FakeContext()
             attn = xf_op.forward(
-                fake_ctx, q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0
+                fake_ctx,
+                q,
+                k,
+                v,
+                attn_bias=xops.LowerTriangularMask(),
+                p=0.0,
+                scale=None,
             ).view(seq_len, bsz, -1)
         else:
             attn, attn_probs = SequeuceParallelTransformerBlock.forward_mha(

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -108,7 +108,7 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
         k = k.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
         v = v.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
 
-        attn = xops.MemoryEfficientAttentionFlashAttentionOp.forward(
+        attn = xops.MemoryEfficientAttentionCutlassFwdFlashBwOp.forward(
             None, q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0
         ).view(seq_len, bsz, -1)
 
@@ -287,7 +287,7 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
 
         # recalculate attention
         fake_ctx = _FakeContext()
-        attn = xops.MemoryEfficientAttentionFlashAttentionOp.forward(
+        attn = xops.MemoryEfficientAttentionCutlassFwdFlashBwOp.forward(
             fake_ctx, q, k, v, attn_bias=xops.LowerTriangularMask(), p=0.0
         ).view(seq_len, bsz, -1)
 
@@ -302,7 +302,7 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
         attn = SequeuceParallelTransformerBlock._collapse_first_dimensions(attn)
         grad_out_proj_weight = grad_attention_output.t().matmul(attn)
 
-        d_q, d_k, d_v, _, _ = xops.MemoryEfficientAttentionFlashAttentionOp.backward(
+        d_q, d_k, d_v, _, _ = xops.MemoryEfficientAttentionCutlassFwdFlashBwOp.backward(
             fake_ctx, grad_out_proj_input
         )
         d_q = d_q.transpose(0, 1).view(seq_len, bsz, -1)

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -30,7 +30,6 @@ try:
     )
     from megatron.mpu.utils import split_tensor_along_last_dim
     from megatron.model.fused_softmax import scaled_upper_triang_masked_softmax_cuda
-    from megatron.mpu import get_tensor_model_parallel_world_size
 
     has_megatron_submodule = True
 except (ImportError, ModuleNotFoundError):
@@ -434,7 +433,7 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
         if xf_eff_attn:
             grad_out_proj_input = grad_out_proj_input.reshape(
                 seq_len, bsz, -1, head_dim
-            ).transpose(0,1)
+            ).transpose(0, 1)
             d_q, d_k, d_v = xops.memory_efficient_attention_backward(
                 grad=grad_out_proj_input,
                 output=out,
@@ -456,7 +455,6 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
             grad_kvq_proj_output = SequeuceParallelTransformerBlock.backward_mha(
                 grad_out_proj_input, q, k, v, attn_probs, seq_len, bsz, head_dim
             )
-
 
         (
             mha_layer_norm_output,

--- a/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
+++ b/metaseq/model_parallel/modules/sequence_parallel_transformer_layer.py
@@ -197,7 +197,6 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
                 .transpose(0, 1)
                 .reshape(seq_len, bsz, num_heads * head_dim)
             )
-            # TODO: Reshape q/k/v back to original?
         else:
             q = q.view(seq_len, -1, head_dim)
             k = k.view(seq_len, -1, head_dim)
@@ -396,11 +395,6 @@ class SequeuceParallelTransformerBlock(torch.autograd.Function):
 
         # recalculate attention
         if xf_eff_attn:
-            # TODO: reshape q/k/v?
-            # q = q.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
-            # k = k.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
-            # v = v.view(seq_len, bsz, -1, head_dim).transpose(0, 1)
-
             num_heads = embed_dim_per_partition // head_dim
 
             attn, lse = xops.memory_efficient_attention_forward_requires_grad(

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -71,7 +71,7 @@ class TransformerDecoderLayer(nn.Module):
         self.skip_bias_add = (self.activation_fn_name == "gelu") and has_fused_bias_gelu
 
         self.attn_variant = getattr(args, "attn_variant", "default")
-        sefl.xf_attn_op = getattr(args, "xf_attn_op", None)
+        self.xf_attn_op = getattr(args, "xf_attn_op", None)
 
         # TODO[Susan]: Clean up these kwargs when unifying method signatures between model & non-model parallel.
         fc1_kwargs = {

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -70,6 +70,9 @@ class TransformerDecoderLayer(nn.Module):
         self.activation_fn_name = getattr(args, "activation_fn", "relu") or "relu"
         self.skip_bias_add = (self.activation_fn_name == "gelu") and has_fused_bias_gelu
 
+        self.attn_variant = getattr(args, "attn_variant", "default")
+        sefl.xf_attn_op = getattr(args, "xf_attn_op", None)
+
         # TODO[Susan]: Clean up these kwargs when unifying method signatures between model & non-model parallel.
         fc1_kwargs = {
             "initialize_params_on_gpu": initialize_params_on_gpu,
@@ -219,8 +222,8 @@ class TransformerDecoderLayer(nn.Module):
                 self.self_attn.head_dim,
                 recompute_fc1,
                 self.activation_fn_name,
-                attn_variant=getattr(args, "attn_variant", "default")
-                xf_attn_op=getattr(args, "xf_attn_op", None)
+                self.attn_variant,
+                self.xf_attn_op,
             )
             return x
 

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -219,6 +219,8 @@ class TransformerDecoderLayer(nn.Module):
                 self.self_attn.head_dim,
                 recompute_fc1,
                 self.activation_fn_name,
+                attn_variant=getattr(args, "attn_variant", "default")
+                xf_attn_op=getattr(args, "xf_attn_op", None)
             )
             return x
 

--- a/tests/test_sequence_parallel_transformer_layer.py
+++ b/tests/test_sequence_parallel_transformer_layer.py
@@ -1,0 +1,87 @@
+import os
+import unittest
+import random
+import tempfile
+import torch
+from types import SimpleNamespace
+from megatron.mpu import initialize_model_parallel
+from metaseq.model_parallel.modules import ModelParallelTransformerDecoderLayer
+
+
+def reset_seeds():
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+    random.seed(42)
+
+
+def _distributed_init():
+    backend = "nccl"
+    local_rank = None
+    rank = 0
+    world_size = 1
+    device = 0
+    torch.cuda.set_device(device)
+
+    # Call the init process.
+    init_method = "tcp://"
+    master_ip = os.getenv("MASTER_ADDR", "localhost")
+    master_port = os.getenv("MASTER_PORT", "6000")
+    init_method += master_ip + ":" + master_port
+    torch.distributed.init_process_group(
+        backend=backend, world_size=world_size, rank=rank, init_method=init_method
+    )
+
+
+# TODO: add dtype
+class TestParity(unittest.TestCase):
+    def test_xformers_parity(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available, skipping test")
+
+        _distributed_init()
+        tensor_model_parallel_size_ = 1
+        initialize_model_parallel(tensor_model_parallel_size_)
+
+        args = SimpleNamespace(
+            sequence_parallel=True,
+            decoder_embed_dim=64,
+            dropout=0.0,
+            decoder_attention_heads=1,
+            decoder_ffn_embed_dim=64,
+            decoder_layers=1,
+            attention_dropout=0.0,
+        )
+        S, B, E = 128, 2, 64
+        x = torch.rand((S, B, E), device="cuda", requires_grad=False)
+        x_ = x.clone()
+        x.requires_grad = True
+        x_.requires_grad = True
+
+        xf_attn_variant = "xformers_default"
+        std_attn_variant = "default"
+
+        # xformers
+        args.attn_variant = xf_attn_variant
+        reset_seeds()
+        xf_decoder = ModelParallelTransformerDecoderLayer(args).cuda()
+        xf_result = xf_decoder(x)
+
+        # std attn
+        args.attn_variant = std_attn_variant
+        reset_seeds()
+        decoder = TransformerDecoderLayer(args).cuda()
+        result = decoder(x_)
+
+        assert torch.allclose(xf_result, result)
+
+        loss_xf = torch.norm(xf_result)
+        loss_xf.backward()
+
+        loss = torch.norm(result)
+        loss.backward()
+
+        assert torch.allclose(x.grad, x_.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Patch Description**
Creating this PR off of #511, so it can be reviewed by @stephenroller 

The last commit (3d709dba5c4be713fd821dc4e0f6b6f90f5ead40) removes some changes from the sequence parallel code which enabled testing with world size of 1. CI is not currently running the test anyway because CI needs to be updated for the test to run. 

The forward and backward tests are passing right now. However in some cases, about .2% of the elements fail

**Testing steps**
Unit Test `gpu_tests/test_sequence_parallel_transformer_layer.py`

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
