### PR TITLE
Current flake8 no longer accepts comments on config lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 extend-ignore =
-    # E203 whitespace with black
+    # E203: whitespace with black
     E203
     # E741: "l" is ambiguous
     E741

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,10 @@
 [flake8]
 extend-ignore =
-    F541  # f-string is missing placeholders
-    E203  # whitespace with black
-    E741  # "l" is ambiguous
+    # E203 whitespace with black
+    E203
+    # E741: "l" is ambiguous
+    E741
+    # F541: f-string is missing placeholders
+    F541
 # github size
 max-line-length=127

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ def do_setup(package_data):
         ),
         extras_require={
             "dev": [
-                "flake8==6.0.0",
+                "flake8",
                 "black==22.3.0",
                 # test deps
                 "iopath",

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ def do_setup(package_data):
         ),
         extras_require={
             "dev": [
-                "flake8==3.9.2",
+                "flake8==6.0.0",
                 "black==22.3.0",
                 # test deps
                 "iopath",


### PR DESCRIPTION
https://github.com/PyCQA/flake8/tags 

`ValueError: Error code '#' supplied to 'extend-ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'`

**Patch Description**
Describe your changes

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
