### PR TITLE
numpy.float has been replaced by numpy.single

### DIFF
--- a/metaseq/data/indexed_dataset.py
+++ b/metaseq/data/indexed_dataset.py
@@ -105,7 +105,7 @@ _code_to_dtype = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: np.single,
     7: np.double,
     8: np.uint16,
     9: np.uint32,
@@ -312,7 +312,7 @@ class IndexedDatasetBuilder:
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        np.single: 4,
         np.double: 8,
     }
 


### PR DESCRIPTION
https://numpy.org/doc/stable/user/basics.types.html
https://github.com/numpy/numpy/releases/tag/v1.24.0
This should allow [the GitHub Actions](https://github.com/facebookresearch/metaseq/actions) to pass ✅ 

**Patch Description**
Describe your changes

**Testing steps**
Describe how you tested your changes

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
