### PR TITLE
Add backslash to the script in projects/OPT/download_opt175b.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,7 @@ Complete all of the setup as mentioned in [the Setup doc](setup.md).
 - Reshard the FSDP checkpoints using the script `metaseq/scripts/reshard_fsdp.py`. For example, we can merge all FSDP shards within each of the 8 model parallel parts of OPT-175B using the following command:
   ```bash
   for j in {0..7}; do
-      python -m metaseq.scripts.reshard_fsdp
+      python -m metaseq.scripts.reshard_fsdp \
       --input-glob-pattern "/path/to/raw/checkpoints/checkpoint_last-model_part-$j-shard*.pt" \
       --output-shard-name "/path/to/resharded/checkpoints/reshard-model_part-$j.pt" \
       --num-output-shards 1 --skip-optimizer-state True --unflatten-weights True

--- a/projects/OPT/download_opt175b.md
+++ b/projects/OPT/download_opt175b.md
@@ -35,7 +35,7 @@ md5sum *
 To consolidate the 992 shards into 8 files model-parallel evaluation, run the `metaseq.scripts.reshard_fsdp` script:
 ```bash
 for j in {0..7}; do
-    python -m metaseq.scripts.reshard_fsdp
+    python -m metaseq.scripts.reshard_fsdp \
     --input-glob-pattern "/path/to/raw/checkpoints/checkpoint_last-model_part-$j-shard*.pt" \
     --output-shard-name "/path/to/resharded/checkpoints/reshard-model_part-$j.pt" \
     --num-output-shards 1 --skip-optimizer-state True --unflatten-weights True


### PR DESCRIPTION
**Patch Description**
I got an email from Meta to download OPT175B weights, and tried to run it by following projects/OPT/download_opt175b.md.
When resharding the shards, I got an error as follows:
```bash
ERROR: The function received no value for the required argument: input_glob_pattern
Usage: reshard_fsdp.py INPUT_GLOB_PATTERN OUTPUT_SHARD_NAME <flags>
  optional flags:        --num_output_shards | --unflatten_weights |
  --skip_optimizer_state
```
The main reason of this error is lacking the backslash in the scripts. I added it to the scripts as follows:
```bash
for j in {0..7}; do
    python -m metaseq.scripts.reshard_fsdp \ # <- I added this backslash
        --input-glob-pattern "/groups/gcb50205/actx/opt_175b/checkpoint_last-model_part-$j-shard*.pt" \
        --output-shard-name "/groups/gcb50205/actx/opt_175b_parallel/checkpoints/reshard-model_part-$j.pt" \
        --num-output-shards 1 --skip-optimizer-state True --unflatten-weights True
done
```

**Testing steps**
After adding it to the scripts, the error was solved and I could run the script.

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
