### PR TITLE
Add support for relative position embeddings

### DIFF
--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -216,6 +216,7 @@ class TransformerDecoderLayer(nn.Module):
                 self.self_attn.out_proj.weight,
                 self.fc1.weight,
                 self.fc2.weight,
+                self_attn_mask,
                 self.self_attn.head_dim,
                 recompute_fc1,
                 self.activation_fn_name,


### PR DESCRIPTION
**Patch Description**
Leaving mostly for record keeping, as experiments here were unsuccessful. Adds support for learned alibi embeddings, and in a previous version, simple offset lookups. Includes necessary changes to propagate gradients through learned positional offsets.

**Testing steps**
Ran a 7B run with `--alibi`.