### PR TITLE
Community: Add the CTranslate2 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ enables serving OPT-175B with more flexible parallelisms on older generations of
 
 The OPT models are now supported in the [Colossal-AI](https://github.com/hpcaitech/ColossalAI#OPT), which helps users to efficiently and quickly deploy OPT models training and inference, reducing large AI model budgets and scaling down the labor cost of learning and deployment.
 
+### Using OPT with CTranslate2
+
+The OPT 125M--66B models can be executed with [CTranslate2](https://github.com/OpenNMT/CTranslate2/), which is a fast inference engine for Transformer models. The project integrates the [SmoothQuant](https://github.com/mit-han-lab/smoothquant) technique to allow 8-bit quantization of OPT models. See the [usage example](https://opennmt.net/CTranslate2/guides/transformers.html#opt) to get started.
+
 ## Getting Started in Metaseq
 Follow [setup instructions here](docs/setup.md) to get started.
 


### PR DESCRIPTION
**Patch Description**
This PR adds the [CTranslate2](https://github.com/OpenNMT/CTranslate2/) integration in the README. CTranslate2 is a fast inference engine for Transformer models, including OPT models.

**Testing steps**
No tests are needed.