### PR TITLE
remove zero_sharding code

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -14,7 +14,6 @@ from metaseq.dataclass.constants import (
     DATASET_IMPL_CHOICES,
     DDP_BACKEND_CHOICES,
     LOG_FORMAT_CHOICES,
-    ZERO_SHARDING_CHOICES,
     CLIP_GRAD_NORM_TYPE_CHOICES,
 )
 
@@ -268,9 +267,7 @@ class DistributedTrainingConfig(MetaseqDataclass):
             "batchnorm population statistics"
         },
     )
-    zero_sharding: ZERO_SHARDING_CHOICES = field(
-        default="none", metadata={"help": "ZeRO sharding"}
-    )
+
     fp16: bool = II("common.fp16")
     memory_efficient_fp16: bool = II("common.memory_efficient_fp16")
     bf16: bool = II("common.bf16")

--- a/metaseq/dataclass/constants.py
+++ b/metaseq/dataclass/constants.py
@@ -43,7 +43,6 @@ DDP_BACKEND_CHOICES = ChoiceEnum(
     ]
 )
 DATASET_IMPL_CHOICES = ChoiceEnum(["raw", "lazy", "cached", "mmap", "fasta"])
-ZERO_SHARDING_CHOICES = ChoiceEnum(["none", "os"])
 CLIP_GRAD_NORM_TYPE_CHOICES = ChoiceEnum(["l2", "inf"])
 
 # Default document attention separator

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -74,11 +74,6 @@ class Trainer(object):
         if self.is_fsdp:
             import fairscale
 
-            if self.cfg.distributed_training.zero_sharding != "none":
-                raise ValueError(
-                    "FullyShardedDataParallel is not compatible with --zero-sharding "
-                    "option (it's already built in)"
-                )
             if (
                 max(self.cfg.optimization.update_freq) > 1
                 and fairscale.__version__ < "0.4.0"
@@ -299,18 +294,6 @@ class Trainer(object):
                 "using non-pointwise optimizers (e.g., Adagrad, Adafactor, LAMB)"
             )
 
-        if self.cfg.distributed_training.zero_sharding == "os":
-            if (
-                self.cfg.common.fp16
-                and not self.cfg.common.memory_efficient_fp16
-                and not self.cfg.common.fp16_no_flatten_grads
-            ):
-                raise ValueError(
-                    "ZeRO is incompatible with fp16 and flattened grads. "
-                    "Please use --fp16-no-flatten-grads"
-                )
-            else:
-                optim.shard_(self._optimizer, self.data_parallel_process_group)
 
         # We should initialize the learning rate scheduler immediately after
         # building the optimizer, so that the initial learning rate is set.
@@ -467,16 +450,6 @@ class Trainer(object):
 
                 logger.info(f"Loaded state for {filename}")
 
-                # If doing zero_sharding, do not broadcast global optimizer
-                # state. Later we will broadcast sharded states to each rank
-                # to avoid memory exploding.
-                if (
-                    not load_on_all_ranks
-                    and self.cfg.distributed_training.zero_sharding == "os"
-                    and "last_optimizer_state" in state
-                    and is_distributed
-                ):
-                    state["last_optimizer_state"] = "SHARDED"
             else:
                 last_optim_state = None
                 state = None

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -294,7 +294,6 @@ class Trainer(object):
                 "using non-pointwise optimizers (e.g., Adagrad, Adafactor, LAMB)"
             )
 
-
         # We should initialize the learning rate scheduler immediately after
         # building the optimizer, so that the initial learning rate is set.
         self._lr_scheduler = lr_scheduler.build_lr_scheduler(


### PR DESCRIPTION
**Patch Description**
We've switched to FSDP, so we need to remove the "zero_sharding" code which was predecessor to FSDP. Solving issue #641. 

**Testing steps**
# Test running the code
RN=NB000
python -m PROJECT_NAME.projects.MODEL_NAME.sweep_baseline -g 4 -n 1 --rsc --model-size 8m --tokenizer rsc --prefix $RN --local --data /checkpoint/TEAM_NAME/datasets/consolidated/v4.0

# Test running evaluations