### PR TITLE
load-checkpoint-on-more-gpus

### DIFF
--- a/gpu_tests/test_checkpoint_loading_on_more_gpus.py
+++ b/gpu_tests/test_checkpoint_loading_on_more_gpus.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import subprocess
+import json
+import multiprocessing
+from functools import partial, partialmethod
+import unittest
+from unittest.mock import patch
+import torch
+from metaseq.dataclass.configs import DistributedTrainingConfig
+from metaseq.launcher.opt_baselines import cli_main as sweep_cli_main
+from metaseq.cli.train import cli_main as train_cli_main
+from metaseq.launcher.opt_job_constants import Size, M
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "test requires 4 GPUs, none found")
+@unittest.skipIf(
+    DistributedTrainingConfig.distributed_world_size != 4,
+    "test requires 4 GPUs",
+)
+class TestModelParallelMP1(unittest.TestCase):
+    """
+    The test will verify that the model can started with more GPUs
+    from a checkpoint created with less GPUs. We test the first
+    run with 2 GPUs and the second run is started with 4 GPUs
+    from the previous checkpoint with 2GPUs.
+    """
+
+    def test_load_checkpoint(self):
+        argv_injection = (
+            "python3 metaseq/launcher/opt_baselines.py   "
+            "--prefix train.8m    --model-size 8m    --checkpoints-dir ./test-checkpoint    "
+            "--tensorboard-logdir ./test-checkpoint    --num-trials 1    --azure   "
+            "--num-gpus 2 --num-nodes 1   --seed 1   "
+            "--local --disable-validation    --max-epoch 5    --max-update 5 --benchmark    "
+        )
+        max_update_first_run = 20
+        size_patch_dict = {"8m": Size(4, 128, 2, 64, int(0.03125 * M), 1.0e-3, 2)}
+
+        training_log_events_first_run = self._helper(
+            max_update=max_update_first_run,
+            argv_injection=argv_injection,
+            size_patch_dict=size_patch_dict,
+        )
+
+        # check that training ran correctly
+        # check that the number of updates was correct
+        self.assertNotEqual(training_log_events_first_run, [])
+        self.assertIsNotNone(training_log_events_first_run[-1]["num_updates"])
+        self.assertEqual(
+            int(training_log_events_first_run[-1]["num_updates"]), max_update_first_run
+        )
+
+        first_run_checkpoints = subprocess.Popen(
+            "ls -1 ./test-checkpoint/*.ngpu2",
+            shell=True,  # this enables the * to be interpreted as a wildcard pattern
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        stdout_first, stderr_first = first_run_checkpoints.communicate()
+        files_first = stdout_first.split("\n")
+        # check that there are only 2 checkpoint files after running on 2 GPUs
+        # ['checkpoint_18-model_part-0-shard0.pt', 'checkpoint_18-model_part-1-shard0.pt']
+        checkpoints_first_num = len(
+            [
+                filename
+                for filename in files_first
+                if filename.startswith("checkpoint_18")
+            ]
+        )
+        self.assertEqual(
+            checkpoints_first_num,
+            2,
+            f"Expected 2 checkpoint files got {checkpoints_first_num}. List all files in the dir: {files_first}",
+        )
+
+        # start second run with 4 gpus from a previously created checkpoint
+        # with 2 gpus from a "*.ngpu2/checkpoint_18.pt"
+        argv_injection = (
+            "python3 metaseq/launcher/opt_baselines.py   "
+            "--prefix train.8m    --model-size 8m    --checkpoints-dir ./test-checkpoint    "
+            "--tensorboard-logdir ./test-checkpoint    --num-trials 1    --azure   "
+            "--num-gpus 4 --num-nodes 1   --seed 1   "
+            "--local --disable-validation    --max-epoch 5    --max-update 5 --benchmark    "
+            "--restore-file ./test-checkpoint/train.8m.dummy_lm.me_fp16.fsdp.zero2.relu."
+            "transformer_lm_megatron.nlay4.emb128.lrnpos.0emb_scale.tps2048.adam.b2_0.95."
+            "eps1e-08.cl1.0.lr0.001.endlr0.0001.wu50.dr0.1.atdr0.1.0emb_dr.wd0.1.ms16.uf1."
+            "mu50.s1.me5.ngpu2/checkpoint_18.pt"
+        )
+
+        max_update_second_run = 40
+
+        training_log_events_second_run = self._helper(
+            max_update=max_update_second_run,
+            argv_injection=argv_injection,
+            size_patch_dict=size_patch_dict,
+        )
+
+        second_run_checkpoints = subprocess.Popen(
+            "ls -1 ./test-checkpoint/*.ngpu4",
+            shell=True,  # this enables the * to be interpreted as a wildcard pattern
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        stdout_second, _ = second_run_checkpoints.communicate()
+        files_second = stdout_second.split("\n")
+
+        # check that there are now 4 checkpoint files after running on 4 GPUs
+        # and starting from the checkpoint folder with 2 checkpoints
+        # ['checkpoint_36-model_part-0-shard0.pt', 'checkpoint_36-model_part-0-shard1.pt',
+        # 'checkpoint_36-model_part-1-shard0.pt', 'checkpoint_36-model_part-1-shard1.pt'
+        checkpoints_second_num = len(
+            [
+                filename
+                for filename in files_second
+                if filename.startswith("checkpoint_36")
+            ]
+        )
+        self.assertEqual(
+            checkpoints_second_num,
+            4,
+            f"Expected 4 checkpoint files got {checkpoints_second_num}. List all files in the dir: {files_second}",
+        )
+
+        # cleanup of the checkpoints files
+        cleanup_checkpoints = subprocess.Popen(
+            "rm -r ./test-checkpoint",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        _, _ = cleanup_checkpoints.communicate()
+
+    def _helper(self, max_update, argv_injection, size_patch_dict):
+        """
+        Helper function to run the test
+        """
+        # start the process for the model run
+        multiprocessing.set_start_method("spawn", force=True)
+        with torch.multiprocessing.Manager() as manager:
+            events = manager.list()
+            p = multiprocessing.Process(
+                target=run_training,
+                args=(max_update, events, argv_injection, size_patch_dict),
+            )
+            p.start()
+            p.join()
+            events_first_run = list(events)
+
+        # parse the log events from the log_to_events()
+        training_log_events = [
+            json.loads(event["message"])
+            for event in events_first_run
+            if event["type"] == "log" and event["message"].startswith('{"epoch"')
+        ]
+
+        return training_log_events
+
+
+def run_training(max_update, events, argv_injection, size_patch_dict):
+    # clean any unused cach to reduce CUDA OOM
+    torch.cuda.empty_cache()
+    # main arguments to run the training script
+    # both patches are aneeded to run the job of the circleci GPUs
+    with patch("sys.argv", argv_injection.split()[1:]), patch(
+        "metaseq.launcher.slurm.local_run",
+        partial(local_run_mock, max_update=max_update, events=events),
+    ), patch.dict(
+        "metaseq.launcher.opt_job_constants.MODEL_SIZES",
+        # reduce the batch size for CUDA memory optimization
+        size_patch_dict,
+    ):
+        sweep_cli_main()
+
+
+def local_run_mock(args, env, train_cmd, dry_run, max_update, events):
+    """
+    The function introduces several pathces for the argumets of the
+    model training. These patches are needed to pass gpu tests on
+    circleci GPUs (empirical knowledge)
+    """
+    train_cmd[train_cmd.index("--max-update") + 1] = str(max_update)
+    train_cmd[train_cmd.index("--num-workers") + 1] = "1"
+    train_cmd[train_cmd.index("--save-interval-updates") + 1] = "18"
+
+    with patch("logging.Logger._log", partialmethod(log_to_events, events=events)):
+        with patch.dict("os.environ", env, clear=True):
+            with patch("sys.argv", train_cmd[1:]):
+                train_cli_main()
+
+
+def log_to_events(self, info, message, args, events, **kwargs):
+    """
+    The function is used to collect logging info from the subprocesses
+    and store it in the 'events' variable, which is then passed over
+    to the main process for asserting that the model ran correctly
+    """
+    print(self, message)
+    if isinstance(message, str):
+        events.append(
+            {
+                "type": "log",
+                "message": message,
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gpu_tests/test_checkpoint_loading_on_more_gpus.py
+++ b/gpu_tests/test_checkpoint_loading_on_more_gpus.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
     DistributedTrainingConfig.distributed_world_size != 4,
     "test requires 4 GPUs",
 )
-class TestModelParallelMP1(unittest.TestCase):
+class TestLoadOnMoreGPUs(unittest.TestCase):
     """
     The test will verify that the model can started with more GPUs
     from a checkpoint created with less GPUs. We test the first
@@ -56,6 +56,8 @@ class TestModelParallelMP1(unittest.TestCase):
             int(training_log_events_first_run[-1]["num_updates"]), max_update_first_run
         )
 
+        # get the list of files from the chekpoint folder
+        # from the 2 GPUs run: ./test-checkpoint/*.ngpu2
         first_run_checkpoints = subprocess.Popen(
             "ls -1 ./test-checkpoint/*.ngpu2",
             shell=True,  # this enables the * to be interpreted as a wildcard pattern
@@ -103,9 +105,10 @@ class TestModelParallelMP1(unittest.TestCase):
         )
 
         # check that training ran correctly
-        # check that the number of updates was correct
         self.assertNotEqual(training_log_events_second_run, [])
 
+        # get the list of files from the chekpoint folder
+        # from the 4 GPUs run: ./test-checkpoint/*.ngpu4
         second_run_checkpoints = subprocess.Popen(
             "ls -1 ./test-checkpoint/*.ngpu4",
             shell=True,  # this enables the * to be interpreted as a wildcard pattern

--- a/gpu_tests/test_checkpoint_loading_on_more_gpus.py
+++ b/gpu_tests/test_checkpoint_loading_on_more_gpus.py
@@ -102,6 +102,10 @@ class TestModelParallelMP1(unittest.TestCase):
             size_patch_dict=size_patch_dict,
         )
 
+        # check that training ran correctly
+        # check that the number of updates was correct
+        self.assertNotEqual(training_log_events_second_run, [])
+
         second_run_checkpoints = subprocess.Popen(
             "ls -1 ./test-checkpoint/*.ngpu4",
             shell=True,  # this enables the * to be interpreted as a wildcard pattern

--- a/gpu_tests/test_checkpoint_loading_on_more_gpus.py
+++ b/gpu_tests/test_checkpoint_loading_on_more_gpus.py
@@ -55,6 +55,9 @@ class TestLoadOnMoreGPUs(unittest.TestCase):
         self.assertEqual(
             int(training_log_events_first_run[-1]["num_updates"]), max_update_first_run
         )
+        # check the achieved loss is correct
+        loss_val = float(training_log_events_first_run[-1]["loss"])
+        self.assertAlmostEqual(loss_val, 14.744, 1)  # 1 digit precision
 
         # get the list of files from the chekpoint folder
         # from the 2 GPUs run: ./test-checkpoint/*.ngpu2
@@ -106,6 +109,15 @@ class TestLoadOnMoreGPUs(unittest.TestCase):
 
         # check that training ran correctly
         self.assertNotEqual(training_log_events_second_run, [])
+
+        # check the achieved loss is correct
+        # check that loss is same as with 2 GPUs after reloading on 4 GPUs
+        loss_val_start = float(training_log_events_second_run[0]["loss"])
+        self.assertAlmostEqual(loss_val_start, 14.744, 1)  # 1 digit precision
+
+        # check that loss improved during training on 4 GPUs
+        loss_val_end = float(training_log_events_second_run[-1]["loss"])
+        self.assertAlmostEqual(loss_val_end, 12.165, 1)  # 1 digit precision
 
         # get the list of files from the chekpoint folder
         # from the 4 GPUs run: ./test-checkpoint/*.ngpu4

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -10,7 +10,6 @@ import os
 import re
 import socket
 from typing import Any, Dict, List, Optional, Tuple
-import shutil
 import math
 import torch
 from omegaconf import OmegaConf

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -11,7 +11,7 @@ import re
 import socket
 from typing import Any, Dict, List, Optional, Tuple
 import shutil
-
+import math
 import torch
 from omegaconf import OmegaConf
 
@@ -220,13 +220,8 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
                     )
             else:
                 filename = cfg.restore_file.replace(".pt", suffix + ".pt")
-            if filename is not None:
-                logger.info(
-                    f"Copying checkpoint from nfs {filename} -> {checkpoint_path_to_load}"
-                )
-                shutil.copyfile(filename, checkpoint_path_to_load)
-            else:
-                logger.info(f"No NFS checkpoints found")
+
+            checkpoint_path_to_load = filename
 
         elif cfg.cluster_env == ComputeEnvs.AZURE.value and has_metaseq_internal:
             if (
@@ -278,13 +273,15 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
     # make sure everyone is done downloading their checkpoints before we load
     distributed_utils.global_barrier()
 
-    extra_state = trainer.load_checkpoint(
-        checkpoint_path_to_load,
-        reset_optimizer,
-        reset_lr_scheduler,
-        optimizer_overrides,
-        reset_meters=reset_meters,
-    )
+    extra_state = None
+    if checkpoint_path_to_load is not None:
+        extra_state = trainer.load_checkpoint(
+            checkpoint_path_to_load,
+            reset_optimizer,
+            reset_lr_scheduler,
+            optimizer_overrides,
+            reset_meters=reset_meters,
+        )
 
     if reset_dataloader and int(os.environ.get("SLURM_RESTART_COUNT", 0)) > 0:
         logger.info(
@@ -375,31 +372,79 @@ def get_paths_to_load(path, suffix="rank-"):
 
     # Check if this looks like a sharded checkpoint
     if not _is_checkpoint_sharded(checkpoint_files):
-        return [local_path]
+        return [local_path], 1
 
     # Check if we need to merge shards
     world_size = distributed_utils.get_data_parallel_world_size()
-    if world_size >= checkpoint_files_count:
-        return [local_path]
+    if world_size == checkpoint_files_count:
+        return [local_path], checkpoint_files_count
+    elif world_size > checkpoint_files_count:
+        # For now only support the case when new world size is multipe of previous
+        rank = distributed_utils.get_data_parallel_rank()
+        if world_size % checkpoint_files_count == 0:
+            n_new_shards_per_file = int(world_size / checkpoint_files_count)
+            rank_to_load = rank // n_new_shards_per_file
+            fname = re.sub(
+                f"{suffix}[0-9]+",
+                f"{suffix}{rank_to_load}",
+                checkpoint_files[0],
+            )
+            return [fname], checkpoint_files_count
+        else:
+            n_new_shards_per_file = world_size / checkpoint_files_count
+            n_files_per_shard = checkpoint_files_count / world_size
+            start_rank = (rank / n_new_shards_per_file)
+            end_rank = start_rank + n_files_per_shard
 
-    # Assign an equal number of shards
-    assert checkpoint_files_count % world_size == 0
-    n_local_files = int(checkpoint_files_count / world_size)
-    rank = distributed_utils.get_data_parallel_rank()
-    start_rank = n_local_files * rank
-    fnames = []
-    for rank_to_load in range(start_rank, start_rank + n_local_files):
-        fname = re.sub(
-            f"{suffix}[0-9]+",
-            f"{suffix}{rank_to_load}",
-            checkpoint_files[0],
+            ranks_to_load = list(set((int(start_rank), int(math.ceil(end_rank) - 1 ))))
+            fnames = []
+
+            for rank_to_load in ranks_to_load:
+                fname = re.sub(
+                    f"{suffix}[0-9]+",
+                    f"{suffix}{rank_to_load}",
+                    checkpoint_files[0],
+                )
+                fnames.append(fname)
+            return fnames, checkpoint_files_count
+    else:
+        # Assign an equal number of shards
+        assert checkpoint_files_count % world_size == 0
+        n_local_files = int(checkpoint_files_count / world_size)
+        rank = distributed_utils.get_data_parallel_rank()
+        start_rank = n_local_files * rank
+        fnames = []
+        for rank_to_load in range(start_rank, start_rank + n_local_files):
+            fname = re.sub(
+                f"{suffix}[0-9]+",
+                f"{suffix}{rank_to_load}",
+                checkpoint_files[0],
+            )
+            fnames.append(fname)
+        logger.info(
+            f"Loading {checkpoint_files_count} on {world_size} DDP workers: {n_local_files} files per worker."
         )
-        fnames.append(fname)
-    logger.info(
-        f"Loading {checkpoint_files_count} on {world_size} DDP workers: {n_local_files} files per worker."
-    )
 
-    return fnames
+        return fnames, checkpoint_files_count
+
+    # # Assign an equal number of shards
+    # assert checkpoint_files_count % world_size == 0
+    # n_local_files = int(checkpoint_files_count / world_size)
+    # rank = distributed_utils.get_data_parallel_rank()
+    # start_rank = n_local_files * rank
+    # fnames = []
+    # for rank_to_load in range(start_rank, start_rank + n_local_files):
+    #     fname = re.sub(
+    #         f"{suffix}[0-9]+",
+    #         f"{suffix}{rank_to_load}",
+    #         checkpoint_files[0],
+    #     )
+    #     fnames.append(fname)
+    # logger.info(
+    #     f"Loading {checkpoint_files_count} on {world_size} DDP workers: {n_local_files} files per worker."
+    # )
+
+    # return fnames
 
 
 def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False) -> dict:
@@ -420,13 +465,25 @@ def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False) ->
     """
 
     # Expand multi-part checkpoints like "checkpoint_last-shard0.pt"
-    paths_to_load = get_paths_to_load(path, suffix="shard")
-
+    paths_to_load, ddp_checkpoint_files_count = get_paths_to_load(path, suffix="shard")
+    world_size = distributed_utils.get_data_parallel_world_size()
     try:
-        if len(paths_to_load) > 1:
+        if world_size < ddp_checkpoint_files_count:
+            assert len(paths_to_load) > 1
             state = _merge_flat_fsdp_shards([torch_load_cpu(f) for f in paths_to_load])
-        else:
+        elif world_size == ddp_checkpoint_files_count:
             state = torch_load_cpu(paths_to_load[0])
+        else:
+            shard_ids = []
+            states = []
+            for path_to_load in paths_to_load:
+                assert "shard" in path_to_load
+                match = re.search(r"-shard(\d+)\.pt", path_to_load)
+                assert match
+                shard_ids.append(int(match.group(1)))
+                states.append(torch_load_cpu(path_to_load))
+
+            state = _split_flat_fsdp_shards(states, previous_shard_counts=ddp_checkpoint_files_count, shard_ids=shard_ids)
     except Exception as error:
         logger.error(
             f"Got Exception While Trying To Load {path} with Paths to Load {paths_to_load}."
@@ -693,3 +750,96 @@ def _get_pad_info(state_dict: Dict) -> Dict[str, int]:
             assert full_key not in res, f"collision: {full_key} already in {res}"
             res[full_key] = v["padding"]
     return res
+
+
+def _split_flat_fsdp_shards(states: List[Dict], previous_shard_counts: int, shard_ids: List[int]) -> Dict:
+    """
+    This function basically takes multiple FSDP states, merges and then finds the new state
+    in the new FSDP shard.
+    i.e.
+    lets say previous training was with data prallel size = 2 and
+    new training run is with data parallel size = 3.
+    Then it will take [state1, state2] and based on the current data parallel rank,
+    return the new state, which in the case of
+    a) rank0: first 2/3rd of state1
+    b) rank1: last 1/3rd of state1, first 1/3rd of state2
+    c) rank2: last 2/3rd of state2
+    """
+    # First copy all keys apart from model and opt stats to the
+    # final state dict from zero'th loaded state
+    splitted_state = {k: v for k, v in states[0].items() if k not in ('model', 'opt_stats')}
+    splitted_model_state = {}
+    ddp_world_size = distributed_utils.get_data_parallel_world_size()
+
+    for k in states[0]["model"].keys():
+        dtype = states[0]["model"][k].dtype
+        if "flat_param" not in k:
+            # I think usually its just decoder.version that comes here.
+            splitted_model_state[k] = states[0]["model"][k]
+            continue
+
+        values = [state['model'][k] for state in states]
+
+        assert all(len(value.shape) == 1 for value in values), "Flat param should have only one dimensional tensor"
+        assert all(value.size(0) == values[0].size(0) for value in values), "all shards should have same sized tensor"
+
+        full_param_shape = values[0].size(0) * previous_shard_counts
+
+        # TODO: [namangoyal] double check this
+        new_shard_size = math.ceil(full_param_shape / ddp_world_size)
+        new_start_offset = new_shard_size * distributed_utils.get_data_parallel_rank()
+
+        current_start_offset = values[0].size(0) * shard_ids[0]
+        start_offset = new_start_offset-current_start_offset
+
+        concatted_value = torch.cat(values)
+        new_v = concatted_value[start_offset: start_offset+new_shard_size]
+
+        if new_v.size(0) != new_shard_size:
+            assert distributed_utils.get_data_parallel_rank() == ddp_world_size - 1
+            num_to_pad = new_shard_size - new_v.size(0)
+            new_v = torch.nn.functional.pad(new_v, [0, num_to_pad])
+        splitted_model_state[k] = new_v
+
+    splitted_state['model'] = splitted_model_state
+    # TODO(susanz): Not removing decoder.version due to HF compatibility.
+    if "decoder.version" not in splitted_state['model']:
+        splitted_state['model']["decoder.version"] = torch.tensor([3.0], dtype=dtype)
+
+    if OPT_KEY in states[0]:
+        splitted_state[OPT_KEY] = _split_flat_fsdp_opt_state(states, previous_shard_counts, shard_ids)
+
+    return splitted_state
+
+
+def _split_flat_fsdp_opt_state(states: List[Dict], previous_shard_counts: int, shard_ids: List[int]) -> Dict:
+    splitted_opt_state = states[0][OPT_KEY]
+    ddp_world_size = distributed_utils.get_data_parallel_world_size()
+    for k in states[0][OPT_KEY]["state"].keys():
+        # 0,1,2,3... if each layer wrapped, else 0
+        for k2 in states[0][OPT_KEY]["state"][k].keys():
+            values = [state[OPT_KEY]["state"][k][k2] for state in states]
+
+            if not torch.is_tensor(values[0]) or is_singleton_tensor(values[0]):
+                assert all(value == values[0] for value in values)
+                splitted_opt_state["state"][k][k2] = values[0]
+            else:
+                assert all(len(value.shape) == 1 for value in values), "Flat param should have only one dimensional tensor"
+                full_param_shape = values[0].size(0) * previous_shard_counts
+
+                # TODO: [namangoyal] double check this
+                new_shard_size = math.ceil(full_param_shape / ddp_world_size)
+                new_start_offset = new_shard_size * distributed_utils.get_data_parallel_rank()
+
+                current_start_offset = values[0].size(0) * shard_ids[0]
+                start_offset = new_start_offset-current_start_offset
+
+                concatted_value = torch.cat(values)
+                splitted_value = concatted_value[start_offset: start_offset+new_shard_size]
+
+                if splitted_value.size(0) != new_shard_size:
+                    assert distributed_utils.get_data_parallel_rank() == ddp_world_size - 1
+                    num_to_pad = new_shard_size - splitted_value.size(0)
+                    splitted_value = torch.nn.functional.pad(splitted_value, [0, num_to_pad])
+                splitted_opt_state["state"][k][k2] = splitted_value
+    return splitted_opt_state

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -517,13 +517,6 @@ class CheckpointConfig(MetaseqDataclass):
             "the checkpoint"
         },
     )
-    load_checkpoint_on_all_dp_ranks: bool = field(
-        default=False,
-        metadata={
-            "help": "load checkpoints on all data parallel devices "
-            "(default: only load on rank 0 and broadcast to other devices)"
-        },
-    )
     # TODO: remove write_checkpoints_asynchronously flag; metaseq-internal has dependency here so keeping for now.
     write_checkpoints_asynchronously: bool = field(
         default=True,

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -17,7 +17,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from itertools import chain
 from typing import Any, Dict, List
-
+import os
 import torch
 import torch.distributed as dist
 from omegaconf import OmegaConf

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -437,10 +437,13 @@ class Trainer(object):
             # to a real file, we convert it to multiple files to be loaded later.
             # so here we just check if there are some files existing in the dir.
             files_in_local_dir = os.listdir(os.path.dirname(filename))
-            filename_prefix = os.path.splitext(os.path.basename(filename))[0].replace(self.checkpoint_suffix, '')
-            matched_files = [f for f in files_in_local_dir if f.startswith(filename_prefix)]
+            filename_prefix = os.path.splitext(os.path.basename(filename))[0].replace(
+                self.checkpoint_suffix, ""
+            )
+            matched_files = [
+                f for f in files_in_local_dir if f.startswith(filename_prefix)
+            ]
             bexists = len(matched_files) > 0
-
 
         if bexists:
             logger.info(f"Preparing to load checkpoint {filename}")

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -426,19 +426,30 @@ class Trainer(object):
         extra_state, self._optim_history, last_optim_state = None, [], None
 
         is_distributed = self.data_parallel_world_size > 1
-        bexists = PathManager.isfile(filename)
+        bexists = False
+
+        logger.info(f"attempting to load checkpoint from: {filename}")
+
+        if PathManager.isfile(filename):
+            bexists = True
+        else:
+            # this is a big hacky as when we increase the world size, then filename doesn't really point
+            # to a real file, we convert it to multiple files to be loaded later.
+            # so here we just check if there are some files existing in the dir.
+            files_in_local_dir = os.listdir(os.path.dirname(filename))
+            filename_prefix = os.path.splitext(os.path.basename(filename))[0].replace(self.checkpoint_suffix, '')
+            matched_files = [f for f in files_in_local_dir if f.startswith(filename_prefix)]
+            bexists = len(matched_files) > 0
+
+
         if bexists:
             logger.info(f"Preparing to load checkpoint {filename}")
-            load_on_all_ranks = (
-                self.cfg.checkpoint.load_checkpoint_on_all_dp_ranks
-                # FSDP requires loading checkpoint shards on all ranks
-                or self.is_fsdp
-            )
+            # FSDP requires loading checkpoint shards on all ranks
+            load_on_all_ranks = self.is_fsdp
 
             if load_on_all_ranks or self.is_data_parallel_master:
                 state = checkpoint_utils.load_checkpoint_to_cpu(
                     filename,
-                    load_on_all_ranks=load_on_all_ranks,
                 )
                 last_optim_state = state.get("last_optimizer_state", None)
                 if last_optim_state == -1:


### PR DESCRIPTION
**Patch Description**
Enabling checkpoint loading on larger amount of GPUs (following logic from @ngoyal2707 PR #620). Adding test to check if loading from checkpoint created from 2 GPUs possible to start a run on 4 GPUs. Currently we support the case when new number of GPUs is multiple of the previous number of GPUs.

**Testing steps**
`cd ~/rsc/metaseq`
first run on 2 GPUs and save checkpoint:
`python3 metaseq/launcher/opt_baselines.py --prefix train.8m --model-size 8m --checkpoints-dir ./gpu_tests/test-checkpoint --tensorboard-logdir ./gpu_teststest-checkpoint --num-trials 1    --azure --num-gpus 2 --num-nodes 1 --seed 1 --local --disable-validation --max-epoch 5    --max-update 5 --benchmark`

second run with 4 GPUs and --restore-file from the previous checkpoints:
`python3 metaseq/launcher/opt_baselines.py --prefix train.8m --model-size 8m --checkpoints-dir ./gpu_tests/test-checkpoint --tensorboard-logdir ./gpu_teststest-checkpoint --num-trials 1    --azure --num-gpus 4 --num-nodes 1 --seed 1 --local --disable-validation --max-epoch 5    --max-update 5 --benchmark --restore-file ./gpu_tests/test-checkpoint/train.8m.dummy_lm.me_fp16.fsdp.zero2.relu.transformer_lm_megatron.nlay4.emb128.lrnpos.0emb_scale.tps2048.adam.b2_0.95.eps1e-08.cl1.0.lr0.001.endlr0.0001.wu50.dr0.1.atdr0.1.0emb_dr.wd0.1.ms16.uf1.mu50.s1.me5.ngpu2/checkpoint_18.pt`

<img width="1193" alt="2GPUs_run" src="https://user-images.githubusercontent.com/17045099/218806479-d9537c2d-382e-43cb-bd66-e1a980482b94.png">
<img width="1179" alt="4GPUs_run_from_previous" src="https://user-images.githubusercontent.com/17045099/218806492-d7456a44-61e7-45b3-85bd-22197ba3d960.png">

