### PR TITLE
Fixing the last step of the decoding process

### DIFF
--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -210,7 +210,7 @@ class SequenceGenerator(nn.Module):
 
         eos_mask = torch.zeros(lprobs.size(0), dtype=torch.bool, device=lprobs.device)
 
-        for step in range(start_step, max_len + 1):
+        for step in range(start_step, max_len):
             if step < min_len:
                 # minimum length constraint (does not apply if using prefix_tokens)
                 lprobs[:, self.eos] = -math.inf
@@ -221,7 +221,7 @@ class SequenceGenerator(nn.Module):
             lprobs[:, self.pad] = -math.inf  # never select pad
 
             # handle max length constraint
-            if step >= max_len:
+            if step >= max_len - 1:
                 lprobs[:, : self.eos] = -math.inf
                 lprobs[:, self.eos + 1 :] = -math.inf
 


### PR DESCRIPTION
**Patch Description**
Fix the last step of the decoding process. Specifically in the previous loop using `for step in range(start_step, max_len + 1):`,  when `step = max_len` and iterating to L250 where
```
model_out = self.model.decoder(
                tokens[:, : step + 1],
                incremental_state=incremental_states,
            )
```
error will throw from forward of multihead_attention because tokens is of shape `(bsz * beam_size, max_len)` and when `step=max_len`, `tokens[:, : step + 1]` is of the same shape as `tokens[:, : step]`. This is not usually observed as `max_len` is usually not reached but it’s more easily reached when the input is longer, e.g. in cases when adding long debiasing prefixes. Hence, the loop should be changed to `for step in range(start_step, max_len):` instead.

Specifically errors are
```
ERROR - Encountered an exception!! 
Traceback (most recent call last):
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/models.py", line 258, in _load_lm_and_run_func
    retval = func(model=generator, **kwargs)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/gpt3_eval.py", line 628, in run_evaluations
    for metric, score in run_evaluation(
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/gpt3_eval.py", line 1163, in run_evaluation
    eval_predictions, metrics_scores = predictor.predict(eval_samples)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/predictors.py", line 1257, in predict
    return self.predict_without_calibration(samples)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/predictors.py", line 1327, in predict_without_calibration
    predictions = self.predict_outputs(samples)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/predictors.py", line 1251, in predict_outputs
    return self.generate(samples)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/predictors.py", line 1199, in generate
    generation_traces = self.sample_with_adaptative_max_tokens(sentences=prompts)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/predictors.py", line 483, in sample_with_adaptative_max_tokens
    batched_hypos = self._batched_generate(request_object)
  File "/private/home/ellenxtan/metaseq-internal/metaseq_internal/eval/predictors.py", line 837, in _batched_generate
    hypotheses_batch = self.model.generate(**request_object)
  File "/private/home/ellenxtan/metaseq/metaseq/hub_utils.py", line 350, in generate
    translations = self.task.inference_step(generator, self.models, batch)
  File "/private/home/ellenxtan/metaseq/metaseq/tasks/base_task.py", line 426, in inference_step
    return generator.generate(models, sample, prefix_tokens=prefix_tokens)
  File "/private/home/ellenxtan/.local/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 28, in decorate_context
    return func(*args, **kwargs)
  File "/private/home/ellenxtan/metaseq/metaseq/sequence_generator.py", line 297, in generate
    return self._generate(sample, **kwargs)
  File "/private/home/ellenxtan/metaseq/metaseq/sequence_generator.py", line 515, in _generate
    model_out = self.model.decoder(
  File "/private/home/ellenxtan/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/private/home/ellenxtan/metaseq/metaseq/models/transformer_decoder.py", line 374, in forward
    x, extra = self.extract_features(
  File "/private/home/ellenxtan/metaseq/metaseq/models/transformer_decoder.py", line 422, in extract_features
    x = layer(
  File "/private/home/ellenxtan/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/private/home/ellenxtan/metaseq/metaseq/modules/transformer_decoder_layer.py", line 227, in forward
    x = self.forward_attention(
  File "/private/home/ellenxtan/metaseq/metaseq/model_parallel/modules/transformer_decoder_layer.py", line 159, in forward_attention
    attn_output, attn_bias = self.self_attn(
  File "/private/home/ellenxtan/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/private/home/ellenxtan/metaseq/metaseq/model_parallel/modules/multihead_attention.py", line 499, in forward
    assert key_padding_mask.size(1) == src_len
AssertionError
```

