### PR TITLE
fix argument passing for consolidated model

### DIFF
--- a/metaseq/modules/multihead_attention.py
+++ b/metaseq/modules/multihead_attention.py
@@ -97,9 +97,10 @@ class MultiheadAttention(nn.Module):
 
     def reset_parameters(self):
         def _init_method_bias(weight, bias):
-            fan_in, _ = nn.init._calculate_fan_in_and_fan_out(weight)
-            bound = 1 / math.sqrt(fan_in)
-            nn.init.uniform_(bias, -bound, bound)
+            if bias is not None:
+                fan_in, _ = nn.init._calculate_fan_in_and_fan_out(weight)
+                bound = 1 / math.sqrt(fan_in)
+                nn.init.uniform_(bias, -bound, bound)
 
         if self.qkv_same_dim:
             # Empirically observed the convergence to be much better with

--- a/metaseq/modules/transformer_decoder_layer.py
+++ b/metaseq/modules/transformer_decoder_layer.py
@@ -157,6 +157,7 @@ class TransformerDecoderLayer(nn.Module):
             input_dim,
             output_dim,
             initialize_params_on_gpu=initialize_params_on_gpu,
+            bias=not disable_bias,
             dtype=utils.get_model_init_dtype(self.args),
         )
 


### PR DESCRIPTION
Model is not correctly initialized if it is consolidated and MP was stitched. 