### PR TITLE
Auto-delete checkpoints

### DIFF
--- a/gpu_tests/test_checkpoint_saving.py
+++ b/gpu_tests/test_checkpoint_saving.py
@@ -254,7 +254,12 @@ def subprocess_run_mock(cmd, stdout, stderr, events):
 
 
 def save_checkpoint_mock(
-    self, filename, extra_state, training_finished=False, async_callback_fn=None
+    self,
+    filename,
+    extra_state,
+    training_finished=False,
+    async_callback_fn=None,
+    files_to_symlink_to=None,
 ):
     logger = logging.getLogger("metaseq.trainer")
     """Save all training state in a checkpoint file."""

--- a/gpu_tests/test_checkpoint_saving.py
+++ b/gpu_tests/test_checkpoint_saving.py
@@ -90,7 +90,9 @@ class TestCheckpointSavingAndUploading(unittest.TestCase):
                     "96.0",
                 ],
             )
-            self.assertTrue(os.path.basename(worker_cmd["command"][-1]) in expected_file_names)
+            self.assertTrue(
+                os.path.basename(worker_cmd["command"][-1]) in expected_file_names
+            )
             self.assertEqual(
                 worker_cmd["checkpoint_model_dir"], common_checkpoint_model_dir
             )

--- a/gpu_tests/test_checkpoint_saving.py
+++ b/gpu_tests/test_checkpoint_saving.py
@@ -12,6 +12,7 @@ import multiprocessing
 from functools import partial, partialmethod
 import unittest
 from unittest.mock import patch, Mock, MagicMock
+from urllib.parse import urlparse
 import torch
 from metaseq.dataclass.configs import DistributedTrainingConfig
 from metaseq.launcher.opt_baselines import cli_main as sweep_cli_main
@@ -81,15 +82,15 @@ class TestCheckpointSavingAndUploading(unittest.TestCase):
         self.assertEqual(file_names_saved_azure, expected_file_names)
         for worker_cmd in upload_events:
             self.assertEqual(
-                worker_cmd["command"],
+                worker_cmd["command"][:4],
                 [
                     "azcopy",
                     "copy",
                     "--cap-mbps",
                     "96.0",
-                    "https://myaccount.blob.core.windows.net/test",
                 ],
             )
+            self.assertTrue(os.path.basename(worker_cmd["command"][-1]) in expected_file_names)
             self.assertEqual(
                 worker_cmd["checkpoint_model_dir"], common_checkpoint_model_dir
             )
@@ -235,18 +236,22 @@ def download_checkpoint_mock(blob_url, checkpoint_path, suffix, events):
 
 
 def subprocess_run_mock(cmd, stdout, stderr, events):
-    # replaces subprocess.run azcopy command that uploads to azure
-    _, checkpoint_dir, checkpoint_model_dir, checkpoint_file = cmd[4].split("/")
-    events.append(
-        {
-            "type": "upload",
-            "command": cmd[:4] + cmd[5:],
-            "checkpoint_dir": checkpoint_dir,
-            "checkpoint_model_dir": checkpoint_model_dir,
-            "checkpoint_file": checkpoint_file,
-            "file_saved_locally": os.path.exists(cmd[4]),
-        }
-    )
+    source = cmd[4]
+    dest = cmd[5]
+
+    # Only interested in local -> remote transfers (not asserting remote copies/aliases)
+    if urlparse(source).scheme == "" and urlparse(dest).scheme == "https":
+        _, checkpoint_dir, checkpoint_model_dir, checkpoint_file = source.split("/")
+        events.append(
+            {
+                "type": "upload",
+                "command": cmd[:4] + cmd[5:],
+                "checkpoint_dir": checkpoint_dir,
+                "checkpoint_model_dir": checkpoint_model_dir,
+                "checkpoint_file": checkpoint_file,
+                "file_saved_locally": os.path.exists(source),
+            }
+        )
 
     res = Mock()
     res.returncode = 0
@@ -283,7 +288,7 @@ def save_checkpoint_mock(
                     logger.info(f"Beginning asynchronous torch.save to {filename}")
                     torch.save(state_dict, filename)
                     if async_callback_fn is not None:
-                        async_callback_fn(filename)
+                        async_callback_fn(filename, files_to_symlink_to)
                     logger.info(f"Asynchronous torch.save to {filename} complete.")
                 except Exception as e:
                     logger.exception(f"Asynchronous save failed: {e}")

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -97,14 +97,14 @@ def save_checkpoint(
             async_callback_fn=async_callback_fn if save_to_NFS else None,
         )
 
-        if len(checkpoints) > 1:
-            # Create symlink between identical checkpoints (differing in naming for epoch/update/last).
-            for other_checkpoint in checkpoints[1:]:
-                if PathManager.islink(other_checkpoint):
-                    PathManager.rm(other_checkpoint)
-                assert PathManager.symlink(
-                    checkpoints[0], other_checkpoint
-                ), f"Failed to symlink {checkpoints[0]} to {other_checkpoint}"
+        # if len(checkpoints) > 1:
+        #     # Create symlink between identical checkpoints (differing in naming for epoch/update/last).
+        #     for other_checkpoint in checkpoints[1:]:
+        #         if PathManager.islink(other_checkpoint):
+        #             PathManager.rm(other_checkpoint)
+        #         assert PathManager.symlink(
+        #             checkpoints[0], other_checkpoint
+        #         ), f"Failed to symlink {checkpoints[0]} to {other_checkpoint}"
 
         write_timer.stop()
         logger.info(

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -95,16 +95,8 @@ def save_checkpoint(
             extra_state,
             training_finished=training_finished,
             async_callback_fn=async_callback_fn if save_to_NFS else None,
+            files_to_symlink_to=checkpoints[1:] if len(checkpoints) > 1 else None,
         )
-
-        # if len(checkpoints) > 1:
-        #     # Create symlink between identical checkpoints (differing in naming for epoch/update/last).
-        #     for other_checkpoint in checkpoints[1:]:
-        #         if PathManager.islink(other_checkpoint):
-        #             PathManager.rm(other_checkpoint)
-        #         assert PathManager.symlink(
-        #             checkpoints[0], other_checkpoint
-        #         ), f"Failed to symlink {checkpoints[0]} to {other_checkpoint}"
 
         write_timer.stop()
         logger.info(

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -110,6 +110,50 @@ def save_checkpoint(
             f"(writing took {write_timer.sum} seconds)"
         )
 
+        # See if there's any older checkpoints to delete after saving a new one.
+        # Only deletes if keep_last_updates > 0 or keep_last_epochs > 0 (default -1 for both).
+        delete_old_checkpoint_files(cfg, end_of_epoch, suffix)
+
+
+def delete_old_checkpoint_files(cfg: CheckpointConfig, end_of_epoch: bool, suffix: str):
+    if not end_of_epoch and cfg.keep_last_updates > 0:
+        # remove old checkpoints; checkpoints are sorted in descending order
+        checkpoints = checkpoint_paths(
+            cfg.save_dir, pattern=r"checkpoint_\d+_(\d+){}\.pt".format(suffix)
+        )
+        for old_chk in checkpoints[cfg.keep_last_updates :]:
+            if os.path.lexists(old_chk):
+                os.remove(old_chk)
+
+    if cfg.keep_last_epochs > 0:
+        # remove old epoch checkpoints; checkpoints are sorted in descending order
+        checkpoints = checkpoint_paths(
+            cfg.save_dir, pattern=r"checkpoint(\d+){}\.pt".format(suffix)
+        )
+        for old_chk in checkpoints[cfg.keep_last_epochs :]:
+            if os.path.lexists(old_chk):
+                os.remove(old_chk)
+
+
+# Reference:
+# https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/checkpoint_utils.py#L538
+def checkpoint_paths(path, pattern=r"checkpoint(\d+)\.pt"):
+    """Retrieves all checkpoints found in `path` directory.
+    Checkpoints are identified by matching filename to the specified pattern. If
+    the pattern contains groups, the result will be sorted by the first group in
+    descending order.
+    """
+    pt_regexp = re.compile(pattern)
+    files = os.listdir(path)
+
+    entries = []
+    for i, f in enumerate(files):
+        m = pt_regexp.fullmatch(f)
+        if m is not None:
+            idx = float(m.group(1)) if len(m.groups()) > 0 else i
+            entries.append((idx, m.group(0)))
+    return [os.path.join(path, x[1]) for x in sorted(entries, reverse=True)]
+
 
 def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
     """

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -97,6 +97,13 @@ def save_checkpoint(
             async_callback_fn=async_callback_fn if save_to_NFS else None,
         )
 
+        if len(checkpoints) > 1:
+            # Create symlink between identical checkpoints (differing in naming for epoch/update/last).
+            for other_checkpoint in checkpoints[1:]:
+                assert PathManager.symlink(
+                    checkpoints[0], other_checkpoint, overwrite=True
+                ), f"Failed to symlink {checkpoints[0]} to {other_checkpoint}"
+
         write_timer.stop()
         logger.info(
             f"Saved checkpoint {checkpoints[0]} (epoch {epoch} @ {updates} updates) "

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -100,8 +100,10 @@ def save_checkpoint(
         if len(checkpoints) > 1:
             # Create symlink between identical checkpoints (differing in naming for epoch/update/last).
             for other_checkpoint in checkpoints[1:]:
+                if PathManager.islink(other_checkpoint):
+                    PathManager.rm(other_checkpoint)
                 assert PathManager.symlink(
-                    checkpoints[0], other_checkpoint, overwrite=True
+                    checkpoints[0], other_checkpoint
                 ), f"Failed to symlink {checkpoints[0]} to {other_checkpoint}"
 
         write_timer.stop()

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -539,20 +539,22 @@ def post_checkpoint_callback(
     if cfg.checkpoint.cloud_upload_path is not None:
         if "blob.core.windows.net" in cfg.checkpoint.cloud_upload_path:
             azcopy_log_dir = os.path.dirname(filename)
-            _copy_to_azure(filename, cfg.checkpoint.cloud_upload_path, azcopy_log_dir)
+            final_path = _get_destination_path(
+                filename, cfg.checkpoint.cloud_upload_path
+            )
+            _copy_to_azure(filename, final_path, azcopy_log_dir)
 
             # Delete original checkpoint on local storage
             # TODO make this configurable
             os.remove(filename)
 
             # Azure Blob doesn't support symlinks so make full copies
-            source = _get_destination_path(filename, cfg.checkpoint.cloud_upload_path)
             if files_to_symlink_to:
                 for other_checkpoint in files_to_symlink_to:
                     dest = _get_destination_path(
                         other_checkpoint, cfg.checkpoint.cloud_upload_path
                     )
-                    _copy_to_azure(source, dest, azcopy_log_dir)
+                    _copy_to_azure(final_path, dest, azcopy_log_dir)
 
         elif cfg.checkpoint.cloud_upload_path.startswith("nfs:"):
             basename = os.path.basename(filename)

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -421,7 +421,7 @@ class Trainer(object):
         return state_dicts
 
     def save_checkpoint(
-        self, filename, extra_state, training_finished=False, async_callback_fn=None
+        self, filename, extra_state, training_finished=False, async_callback_fn=None, files_to_symlink_to=None
     ):
         """Save all training state in a checkpoint file."""
 
@@ -445,7 +445,7 @@ class Trainer(object):
                 def perform_save():
                     try:
                         logger.info(f"Beginning asynchronous torch.save to {filename}")
-                        async_callback_fn(filename)
+                        async_callback_fn(filename, files_to_symlink_to)
                         logger.info(f"Asynchronous torch.save to {filename} complete.")
                     except Exception as e:
                         logger.exception(f"Asynchronous save failed: {e}")

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -421,7 +421,12 @@ class Trainer(object):
         return state_dicts
 
     def save_checkpoint(
-        self, filename, extra_state, training_finished=False, async_callback_fn=None, files_to_symlink_to=None
+        self,
+        filename,
+        extra_state,
+        training_finished=False,
+        async_callback_fn=None,
+        files_to_symlink_to=None,
     ):
         """Save all training state in a checkpoint file."""
 

--- a/tests/test_cli_train.py
+++ b/tests/test_cli_train.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import array
+import random
+import os
+import tempfile
+import unittest
+
+from metaseq.cli.train import post_checkpoint_callback
+from metaseq.dataclass.configs import MetaseqConfig
+
+
+def create_local_test_file(path, length=4096):
+    value = random.randint(0, 16)
+    with open(path, "wb") as f:
+        array.array("b", [value] * length).tofile(f)
+
+
+class TestPostCheckpointCallback(unittest.TestCase):
+    def test_nfs_copy(self):
+        with (
+            tempfile.TemporaryDirectory() as local_dir,
+            tempfile.TemporaryDirectory() as nfs_dir,
+        ):
+            checkpoint_path = os.path.join(
+                local_dir, "checkpoint_100-model_part-0-shard0.pt"
+            )
+            create_local_test_file(checkpoint_path)
+
+            cfg = MetaseqConfig()
+            cfg.checkpoint.cloud_upload_path = f"nfs:{nfs_dir}"
+            # Prevent evals
+            cfg.checkpoint.nfs_eval_frequency = 0
+
+            post_checkpoint_callback(
+                cfg=cfg,
+                num_updates=10,
+                training_finished=False,
+                filename=checkpoint_path,
+                files_to_symlink_to=None,
+            )
+
+            expected_path = os.path.join(
+                nfs_dir, "checkpoint_100/checkpoint-model_part-0-shard0.pt"
+            )
+            self.assertTrue(
+                os.path.exists(expected_path), f"File should exist: {expected_path}"
+            )
+
+    def test_nfs_copy_with_symlinks(self):
+        with (
+            tempfile.TemporaryDirectory() as local_dir,
+            tempfile.TemporaryDirectory() as nfs_dir,
+        ):
+            checkpoint_path = os.path.join(local_dir, "checkpoint_10.pt")
+            create_local_test_file(checkpoint_path)
+
+            cfg = MetaseqConfig()
+            cfg.checkpoint.cloud_upload_path = f"nfs:{nfs_dir}"
+            # Prevent evals
+            cfg.checkpoint.nfs_eval_frequency = 0
+
+            post_checkpoint_callback(
+                cfg=cfg,
+                num_updates=10,
+                training_finished=False,
+                filename=checkpoint_path,
+                files_to_symlink_to=[os.path.join(local_dir, "checkpoint_last.pt")],
+            )
+
+            self.assertTrue(
+                os.path.exists(os.path.join(nfs_dir, "checkpoint_10/checkpoint.pt"))
+            )
+            self.assertTrue(
+                os.path.islink(
+                    os.path.join(nfs_dir, "checkpoint_10/checkpoint_last.pt")
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_train.py
+++ b/tests/test_cli_train.py
@@ -8,8 +8,9 @@ import random
 import os
 import tempfile
 import unittest
+from unittest.mock import patch, MagicMock
 
-from metaseq.cli.train import post_checkpoint_callback
+from metaseq.cli.train import post_checkpoint_callback, _get_destination_path
 from metaseq.dataclass.configs import MetaseqConfig
 
 
@@ -20,6 +21,24 @@ def create_local_test_file(path, length=4096):
 
 
 class TestPostCheckpointCallback(unittest.TestCase):
+    def test_destination_path(self):
+        self.assertEqual(
+            _get_destination_path("/path/ckpt.pt", "/other"),
+            "/other/ckpt.pt",
+        )
+        self.assertEqual(
+            _get_destination_path(
+                "/path/ckpt.pt", "https://acc.blob.core.windows.net/other?q=1"
+            ),
+            "https://acc.blob.core.windows.net/other/ckpt.pt?q=1",
+        )
+        self.assertEqual(
+            _get_destination_path(
+                "https://acc.blob.core.windows.net/path/ckpt.pt?q=1", "/other"
+            ),
+            "/other/ckpt.pt",
+        )
+
     def test_nfs_copy(self):
         with (
             tempfile.TemporaryDirectory() as local_dir,
@@ -79,6 +98,38 @@ class TestPostCheckpointCallback(unittest.TestCase):
                     os.path.join(nfs_dir, "checkpoint_10/checkpoint_last.pt")
                 )
             )
+
+    def assert_azcopy(self, mock, src, dst):
+        def _match(c):
+            _, args, _ = c
+            cmd = args[0]
+            return cmd[-2] == src and cmd[-1] == dst
+
+        self.assertTrue(any([_match(c) for c in mock.mock_calls]))
+
+    def test_azure_blob_with_symlinks(self):
+        mock_azcopy = MagicMock(return_value=MagicMock(returncode=0))
+        with patch("metaseq.cli.train._run_azcopy", mock_azcopy):
+            with tempfile.TemporaryDirectory() as local_dir:
+                checkpoint_path = os.path.join(local_dir, "checkpoint_10.pt")
+                create_local_test_file(checkpoint_path)
+
+                upload_path = "https://testaccount.blob.core.windows.net/dest?q=1"
+                cfg = MetaseqConfig()
+                cfg.checkpoint.cloud_upload_path = upload_path
+
+                post_checkpoint_callback(
+                    cfg=cfg,
+                    num_updates=10,
+                    training_finished=False,
+                    filename=checkpoint_path,
+                    files_to_symlink_to=[os.path.join(local_dir, "checkpoint_last.pt")],
+                )
+
+                upload_src = "https://testaccount.blob.core.windows.net/dest/checkpoint_10.pt?q=1"
+                upload_dst = "https://testaccount.blob.core.windows.net/dest/checkpoint_last.pt?q=1"
+                self.assert_azcopy(mock_azcopy, checkpoint_path, upload_path)
+                self.assert_azcopy(mock_azcopy, upload_src, upload_dst)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_train.py
+++ b/tests/test_cli_train.py
@@ -67,10 +67,7 @@ class TestPostCheckpointCallback(unittest.TestCase):
             )
 
     def test_nfs_copy_with_symlinks(self):
-        with (
-            tempfile.TemporaryDirectory() as local_dir,
-            tempfile.TemporaryDirectory() as nfs_dir,
-        ):
+        with tempfile.TemporaryDirectory() as local_dir, tempfile.TemporaryDirectory() as nfs_dir:
             checkpoint_path = os.path.join(local_dir, "checkpoint_10.pt")
             create_local_test_file(checkpoint_path)
 

--- a/tests/test_cli_train.py
+++ b/tests/test_cli_train.py
@@ -40,10 +40,7 @@ class TestPostCheckpointCallback(unittest.TestCase):
         )
 
     def test_nfs_copy(self):
-        with (
-            tempfile.TemporaryDirectory() as local_dir,
-            tempfile.TemporaryDirectory() as nfs_dir,
-        ):
+        with tempfile.TemporaryDirectory() as local_dir, tempfile.TemporaryDirectory() as nfs_dir:
             checkpoint_path = os.path.join(
                 local_dir, "checkpoint_100-model_part-0-shard0.pt"
             )


### PR DESCRIPTION
Adding back logic that was removed in refactoring (see: https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/checkpoint_utils.py#L142-L192 and https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/checkpoint_utils.py#L538-L557) for OG history.

Brought back in by @urielsinger in https://github.com/facebookresearch/metaseq/pull/668.