### PR TITLE
Adding ability to specify either the unified tokenizer, or the bpe and vocab tokenizer

### DIFF
--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -62,13 +62,13 @@ def create_generation_config_with_defaults(model_path, ddp_backend="pytorch_ddp"
     HF_TOKENIZER = model_path + "/gpt2-unified.json"
 
     if os.path.exists(HF_TOKENIZER):
-        print(f'Using unified tokenizer file {HF_TOKENIZER}')
+        print(f"Using unified tokenizer file {HF_TOKENIZER}")
         TOKENIZER_ARGS = [
             "--hf-tokenizer",
             HF_TOKENIZER,
         ]
     else:
-        print(f'Using vocab and merges files {BPE_VOCAB} {BPE_MERGES}')
+        print(f"Using vocab and merges files {BPE_VOCAB} {BPE_MERGES}")
         TOKENIZER_ARGS = [
             "--bpe-merges",
             BPE_MERGES,
@@ -81,25 +81,29 @@ def create_generation_config_with_defaults(model_path, ddp_backend="pytorch_ddp"
         ]
 
     # Skeleton out all the annoying command line args we can infer
-    ARGS = [
-        "--model-parallel-size",
-        str(MP),
-        "--distributed-world-size",
-        str(MP),
-        "--ddp-backend",
-        ddp_backend,
-        "--task",
-        "language_modeling",
-    ] + TOKENIZER_ARGS + [
-        "--bpe",
-        "hf_byte_bpe",
-        "--path",
-        model_path + "/reshard.pt",
-        "--checkpoint-shard-count",
-        "1",
-        "--use-sharded-state",
-        model_path,
-    ]
+    ARGS = (
+        [
+            "--model-parallel-size",
+            str(MP),
+            "--distributed-world-size",
+            str(MP),
+            "--ddp-backend",
+            ddp_backend,
+            "--task",
+            "language_modeling",
+        ]
+        + TOKENIZER_ARGS
+        + [
+            "--bpe",
+            "hf_byte_bpe",
+            "--path",
+            model_path + "/reshard.pt",
+            "--checkpoint-shard-count",
+            "1",
+            "--use-sharded-state",
+            model_path,
+        ]
+    )
     print(ARGS)
 
     # build up the config file

--- a/metaseq/scripts/convert_to_singleton.py
+++ b/metaseq/scripts/convert_to_singleton.py
@@ -59,6 +59,26 @@ def create_generation_config_with_defaults(model_path, ddp_backend="pytorch_ddp"
     MP = len(files)
     BPE_MERGES = model_path + "/gpt2-merges.txt"
     BPE_VOCAB = model_path + "/gpt2-vocab.json"
+    HF_TOKENIZER = model_path + "/gpt2-unified.json"
+
+    if os.path.exists(HF_TOKENIZER):
+        print(f'Using unified tokenizer file {HF_TOKENIZER}')
+        TOKENIZER_ARGS = [
+            "--hf-tokenizer",
+            HF_TOKENIZER,
+        ]
+    else:
+        print(f'Using vocab and merges files {BPE_VOCAB} {BPE_MERGES}')
+        TOKENIZER_ARGS = [
+            "--bpe-merges",
+            BPE_MERGES,
+            "--merges-filename",
+            BPE_MERGES,
+            "--bpe-vocab",
+            BPE_VOCAB,
+            "--vocab-filename",
+            BPE_VOCAB,
+        ]
 
     # Skeleton out all the annoying command line args we can infer
     ARGS = [
@@ -70,14 +90,7 @@ def create_generation_config_with_defaults(model_path, ddp_backend="pytorch_ddp"
         ddp_backend,
         "--task",
         "language_modeling",
-        "--bpe-merges",
-        BPE_MERGES,
-        "--merges-filename",
-        BPE_MERGES,
-        "--bpe-vocab",
-        BPE_VOCAB,
-        "--vocab-filename",
-        BPE_VOCAB,
+    ] + TOKENIZER_ARGS + [
         "--bpe",
         "hf_byte_bpe",
         "--path",


### PR DESCRIPTION
**Patch Description**
Adds ability to specify a unified tokenizer file instead of the vocab and merges files.

**Testing steps**
```
$ wget https://dl.fbaipublicfiles.com/opt/test_artifacts/125m_with_hf_dependencies.tar.gz
$ tar -xvzf 125m_with_hf_dependencies.tar.gz
$ python -m metaseq.scripts.convert_to_singleton 125m

Using unified tokenizer file 125m/gpt2-unified.json                                                                                                                                                   
['--model-parallel-size', '2', '--distributed-world-size', '2', '--ddp-backend', 'pytorch_ddp', '--task', 'language_modeling', '--hf-tokenizer', '125m/gpt2-unified.json', '--bpe', 'hf_byte_bpe', '--
path', '125m/reshard.pt', '--checkpoint-shard-count', '1', '--use-sharded-state', '125m']                                                                                                             
2023-03-17 17:35:23 | INFO | metaseq.distributed.utils | initialized host devfair0311 as rank 0                                                                                                       
2023-03-17 17:35:23 | INFO | metaseq.distributed.utils | initialized host devfair0311 as rank 1                                                                                                       
> initializing tensor model parallel with size 2                                                                                                                                                      
> initializing pipeline model parallel with size 1                                                                                                                                                    
> initializing model parallel cuda seeds on global rank 0, model parallel rank 0, and data parallel rank 0 with model parallel seed: 2719 and data parallel seed: 1                                   
2023-03-17 17:35:25 | INFO | metaseq.checkpoint_utils | Done reading from disk                                                                                                                        
2023-03-17 17:35:25 | INFO | metaseq.checkpoint_utils | Done loading state dict                                                                                                                       
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.7.fc2.bias: 0.0009765625                                                                           
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.7.final_layer_norm.weight: 0.000457763671875                                                       
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.7.final_layer_norm.bias: 0.00128173828125                                                          
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.8.self_attn.out_proj.bias: 0.00079345703125                                                        
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.8.self_attn_layer_norm.bias: 0.000946044921875                                                     
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.9.fc2.bias: 0.000762939453125                                                                      
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.9.final_layer_norm.weight: 0.001373291015625                                                       
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.9.final_layer_norm.bias: 0.001678466796875                                                         
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.10.self_attn.out_proj.bias: 0.0011138916015625                                                     
2023-03-17 17:35:26 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.10.self_attn_layer_norm.bias: 0.00146484375                                                        
2023-03-17 17:35:26 | INFO | metaseq.checkpoint_utils | Done reading from disk  

$ mv 125m/restored.pt 125m/restored.pt.unified 
$ rm 125m/gpt2-unified.json

python -m metaseq.scripts.convert_to_singleton 125m                                                                                                                                                
Using vocab and merges files 125m/gpt2-vocab.json 125m/gpt2-merges.txt                                                                                                                                
['--model-parallel-size', '2', '--distributed-world-size', '2', '--ddp-backend', 'pytorch_ddp', '--task', 'language_modeling', '--bpe-merges', '125m/gpt2-merges.txt', '--merges-filename', '125m/gpt2
-merges.txt', '--bpe-vocab', '125m/gpt2-vocab.json', '--vocab-filename', '125m/gpt2-vocab.json', '--bpe', 'hf_byte_bpe', '--path', '125m/reshard.pt', '--checkpoint-shard-count', '1', '--use-sharded-
state', '125m']
2023-03-17 17:36:15 | INFO | metaseq.distributed.utils | initialized host devfair0311 as rank 0
2023-03-17 17:36:15 | INFO | metaseq.distributed.utils | initialized host devfair0311 as rank 1
> initializing tensor model parallel with size 2
> initializing pipeline model parallel with size 1
> initializing model parallel cuda seeds on global rank 0, model parallel rank 0, and data parallel rank 0 with model parallel seed: 2719 and data parallel seed: 1
2023-03-17 17:36:17 | INFO | metaseq.checkpoint_utils | Done reading from disk
2023-03-17 17:36:17 | INFO | metaseq.checkpoint_utils | Done loading state dict
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.7.fc2.bias: 0.0009765625
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.7.final_layer_norm.weight: 0.000457763671875
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.7.final_layer_norm.bias: 0.00128173828125
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.8.self_attn.out_proj.bias: 0.00079345703125
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.8.self_attn_layer_norm.bias: 0.000946044921875
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.9.fc2.bias: 0.000762939453125
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.9.final_layer_norm.weight: 0.001373291015625
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.9.final_layer_norm.bias: 0.001678466796875
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.10.self_attn.out_proj.bias: 0.0011138916015625
2023-03-17 17:36:18 | INFO | metaseq.distributed.stitch_fsdp_ckpt | max discrepancy decoder.layers.10.self_attn_layer_norm.bias: 0.00146484375
2023-03-17 17:36:18 | INFO | metaseq.checkpoint_utils | Done reading from disk


$ md5sum 125m/restored.pt

357cd02690a03b5a5101bff69e69ac2a  125m/restored.pt

$ md5sum 125m/restored.pt.unified 

357cd02690a03b5a5101bff69e69ac2a  125m/restored.pt.unified

```

We can see that the md5sum of the two unified checkpoints are the same.
<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
