### PR TITLE
Add a script to reshard FSDP-consolidated checkpoints

### DIFF
--- a/metaseq/scripts/reshard_consolidated.py
+++ b/metaseq/scripts/reshard_consolidated.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3 -u
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+from copy import deepcopy
+from typing import Any, Dict, List, Tuple
+
+import fire
+import torch
+import torch.nn.functional as F
+
+
+logging.basicConfig(format="%(asctime)s | %(name)s | %(message)s", level=logging.INFO)
+logger: logging.Logger = logging.getLogger("metaseq.scripts.reshard_consolidated")
+
+
+def reshard_consolidated_checkpoint(
+    input: str, output: str, num_output_shards: int = 1
+) -> None:
+    """
+    Reshard an FSDP-consolidated checkpoint and write outputs to files. The model weights
+    are flattened before the resharding logic applies. The input checkpoint is expected to
+    contain unflattened, FSDP-consolidated model weights.
+
+    Args:
+        :param input: A path to the input checkpoint (e.g. "opt-2.7b-dp1-mp2/reshard-model_part-0.pt").
+        :param output: A string pattern specifying the path names of the output shards.
+            Shard indices can be included in the path names if the pattern includes `{i}`.
+            (e.g. "opt-2.7b-dp4-mp2/checkpoint_last-model_part-0-shard{i}.pt").
+        :param num_output_shards: The number of output shards.
+    """
+    state_dict = torch.load(input)
+    resharded_weights, resharded_metadata = reshard_unflattened_model_weights(
+        state_dict["model"], state_dict["shard_metadata"], num_output_shards
+    )
+    for shard_idx in range(num_output_shards):
+        output_file = output.format(i=shard_idx)
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        shard_state_dict = {
+            "model": resharded_weights[shard_idx],
+            "shard_metadata": resharded_metadata[shard_idx],
+        }
+        for key in state_dict.keys():
+            if key not in set(shard_state_dict.keys()) + {"optimizer_state"}:
+                shard_state_dict[key] = state_dict[key]
+        logger.info(f"Writing a resharded state dict to {output_file}")
+        torch.save(shard_state_dict, output_file)
+
+
+def reshard_unflattened_model_weights(
+    unsharded_weights: Dict[str, torch.Tensor],
+    shard_metadata: List[Dict[str, Any]],
+    num_output_shards: int = 1,
+) -> List[Dict[str, torch.Tensor]]:
+    logger.info(f"Reshard unflattened model weights into {num_output_shards} shard(s)")
+    resharded_weights = [{} for _ in range(num_output_shards)]
+
+    # We copy the buffer values from the first shard as they are not sharded by FSDP
+    for buffer_name in shard_metadata["buffer_names"]:
+        if buffer_name not in unsharded_weights:
+            raise ValueError(f"No buffer found for buffer name {buffer_name}.")
+        for shard_idx in range(num_output_shards):
+            resharded_weights[shard_idx][buffer_name] = unsharded_weights[buffer_name]
+        unsharded_weights.pop(buffer_name)
+
+    resharded_metadata = [deepcopy(shard_metadata) for _ in range(num_output_shards)]
+    for idx, param_metadata in enumerate(shard_metadata["param_metadata"]):
+        fsdp_path = param_metadata["fsdp_path"]
+        for flat_name, params in param_metadata["params"].items():
+            full_key = ".".join([fsdp_path, flat_name]) if fsdp_path else flat_name
+            names = [f"{fsdp_path}.{n}" if fsdp_path else n for n in params["names"]]
+            flattened = _flatten_tensors([unsharded_weights[k] for k in names])
+            # Reshard weights by chunking the unsharded tensor
+            weights, paddings = _shard_and_pad_tensor(flattened, num_output_shards)
+            for shard_idx, (weight, pad) in enumerate(zip(weights, paddings)):
+                resharded_weights[shard_idx][full_key] = weight
+                resharded_metadata[shard_idx]["param_metadata"][idx]["params"][
+                    flat_name
+                ]["padding"] = pad
+
+    return resharded_weights, resharded_metadata
+
+
+def _flatten_tensors(tensors: List[torch.Tensor]) -> torch.Tensor:
+    output = torch.empty(sum(t.numel() for t in tensors), dtype=tensors[0].dtype)
+    offset = 0
+    for tensor in tensors:
+        output[offset : offset + tensor.numel()].copy_(tensor.view(-1))
+        offset += tensor.numel()
+    return output
+
+
+def _shard_and_pad_tensor(
+    tensor: torch.Tensor, num_shards: int, dim: int = 0
+) -> Tuple[List[torch.Tensor], List[int]]:
+    if num_shards == 1:
+        return [tensor], [0]
+    #  Cloning is needed as torch.save always writes unsliced tensors
+    chunks = [chunk.clone() for chunk in tensor.chunk(num_shards, dim=dim)]
+    assert len(chunks) == num_shards, len(chunks)
+    paddings = [chunks[0].numel() - chunk.numel() for chunk in chunks]
+    for idx, (chunk, padding) in enumerate(zip(chunks, paddings)):
+        if padding > 0:
+            chunks[idx] = F.pad(chunk, [0, padding])
+    return chunks, paddings
+
+
+if __name__ == "__main__":
+    """
+    Example usage:
+        python -m metaseq.scripts.reshard_consolidated \
+        --input "opt-2.7b-dp1-mp2/reshard-model_part-0.pt" \
+        --output "opt-2.7b-dp4-mp2/checkpoint_last-model_part-0-shard{i}.pt" \
+        --num-output-shards 4
+    """
+    fire.Fire(reshard_consolidated_checkpoint)

--- a/metaseq/scripts/reshard_consolidated.py
+++ b/metaseq/scripts/reshard_consolidated.py
@@ -44,9 +44,8 @@ def reshard_consolidated_checkpoint(
             "model": resharded_weights[shard_idx],
             "shard_metadata": resharded_metadata[shard_idx],
         }
-        for key in state_dict.keys():
-            if key not in set(shard_state_dict.keys()) + {"optimizer_state"}:
-                shard_state_dict[key] = state_dict[key]
+        for key in state_dict.keys() - shard_state_dict.keys() - {"optimizer_state"}:
+            shard_state_dict[key] = state_dict[key]
         logger.info(f"Writing a resharded state dict to {output_file}")
         torch.save(shard_state_dict, output_file)
 

--- a/metaseq/scripts/reshard_fsdp.py
+++ b/metaseq/scripts/reshard_fsdp.py
@@ -163,7 +163,6 @@ def reshard_fsdp_model_weights(
                 for n, t, s in zip(names, unsharded_weights.split(numels), shapes):
                     param_name = ".".join([fsdp_path, n]) if fsdp_path else n
                     resharded_weights[0][param_name] = t.view(s)
-                resharded_metadata = [{}] * num_output_shards
                 continue
 
             # Otherwise, reshard weights by chunking the unsharded tensor
@@ -252,10 +251,10 @@ def _shard_and_pad_tensor(
     return chunks, paddings
 
 
-def _unpad_tensor(shard: torch.Tensor, pad: int) -> torch.Tensor:
+def _unpad_tensor(tensor: torch.Tensor, pad: int) -> torch.Tensor:
     if pad > 0:
-        shard = shard[:-pad]
-    return shard
+        tensor = tensor[:-pad]
+    return tensor
 
 
 def _maybe_type(input: torch.Tensor, dtype: Optional[torch.dtype] = None):

--- a/metaseq/scripts/reshard_mp.py
+++ b/metaseq/scripts/reshard_mp.py
@@ -102,7 +102,13 @@ def reshard_model_parallel_parts(
 
         state_dict = {"model": sharded_dict}
         # Copy other values from rank 0
-        for key in ["cfg", "extra_state", "optimizer_history", "args"]:
+        for key in [
+            "cfg",
+            "extra_state",
+            "optimizer_history",
+            "args",
+            "shard_metadata",
+        ]:
             state_dict[key] = rank0_state_dict.get(key, None)
         state_dict["cfg"]["model"].model_parallel_size = M
 


### PR DESCRIPTION
### Summary
Since the `reshard_mp` script requires FSDP-consolidated checkpoints, we add a new script to support changing FSDP afterwards. By using`reshard_fsdp`, `reshard_mp`, and `reshard_consolidated` together, we are now able to switch from one combination of data parallel and model parallel to another.

### Test Plan
* We convert OPT 2.7B checkpoints using the following commands:
```bash
# Consolidate FSDP checkpoints (DP64, MP4 -> DP1, MP4)
for j in 0 1 2 3; do
    python -m metaseq.scripts.reshard_fsdp --input "/checkpoint/binhtang/opt-2.7b/opt-2.7b-raw/checkpoint_last-model_part-$j-shard*.pt" --output "/checkpoint/binhtang/opt-2.7b/opt-2.7b-dp1-mp4/checkpoint_last-model_part-$j-shard{i}.pt" --num-output-shards 1 --unflatten-weights True;
done

# Update MP (DP1, MP4 -> DP1, MP2)
python -m metaseq.scripts.reshard_mp --input "/checkpoint/binhtang/opt-2.7b/opt-2.7b-dp1-mp4/checkpoint_last-model_part-*-shard0.pt" --output "/checkpoint/binhtang/opt-2.7b/opt-2.7b-dp1-mp2/checkpoint_last-model_part-{i}-shard0.pt" --num-output-parts 2

# Update DP (DP1, MP2 -> DP4, MP2)
for j in 0 1; do
    python -m metaseq.scripts.reshard_consolidated --input "/checkpoint/binhtang/opt-2.7b/opt-2.7b-dp1-mp2/checkpoint_last-model_part-$j-shard0.pt" --output "/checkpoint/binhtang/opt-2.7b/opt-2.7b-dp4-mp2/checkpoint_last-model_part-$j-shard{i}.pt" --num-output-shards 4
done
```
* The converted checkpoints can be examined using the following interactive script:
```python
import logging
import random
import torch
import sys

from metaseq import options
from metaseq.dataclass.configs import MetaseqConfig
from metaseq.dataclass.utils import convert_namespace_to_omegaconf
from metaseq.distributed import utils as distributed_utils
from metaseq.hub_utils import GeneratorInterface
from metaseq.service.utils import build_logger


logger = build_logger()
logging.getLogger("metaseq.hub_utils").setLevel(logging.WARNING)


def main(cfg: MetaseqConfig):
    torch.manual_seed(random.randint(1, 20000))
    generator = GeneratorInterface(cfg)
    generator.load_model()

    output_length = cfg.task.max_target_positions
    prompt = "What is the meaning of life?"
    inputs = [generator.encode_fn(p.strip()) for p in prompt.split("|")]
    request = [{"inputs": inputs, "max_tokens": [output_length, output_length]}]
    output = generator.generate(**request[0])
    if torch.distributed.get_rank() == 0:
        print(f"\033[0mOutput: {output[0][0]['text']}")

if __name__ == "__main__":
    parser = options.get_generation_parser()
    parser.set_defaults(lr_scheduler=None, criterion=None)
    LAUNCH_ARGS = ["--task language_modeling", "--bpe hf_byte_bpe", "/tmp"]
    launch_args = sys.argv[1:] + [item for arg in LAUNCH_ARGS for item in arg.split()]
    args = options.parse_args_and_arch(parser, input_args=launch_args)
    
    args.bpe_merges = args.merges_filename
    args.bpe_vocab = args.vocab_filename
    cfg = convert_namespace_to_omegaconf(args)
    model_overrides = {
        "memory_efficient_fp16": True,
        "fp16": True,
        "bf16": True,
        "sequence_parallel": False,
        "inference": True,
        "truncate_init": False
    }
    cfg.common_eval.model_overrides = str(model_overrides)
    distributed_utils.call_main(cfg, main)
```
```
python metaseq/cli/interactive.py --merges-filename /checkpoint/binhtang/gpt2-merges.txt --vocab-filename /checkpoint/binhtang/gpt2-vocab.json --path /checkpoint/binhtang/opt-2.7b/opt-2.7b-dp4-mp2/checkpoint_last.pt --model-parallel-size 2 --distributed-world-size 8 --beam 3 --max-source-positions 4 --max-target-positions 128 --ddp-backend fully_sharded --use-sharded-state
> To be happy.