### PR TITLE
Support FSDP wrapper in SequenceGenerator

### DIFF
--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -174,7 +174,7 @@ class SequenceGenerator(nn.Module):
         # set all the forced tokens
         tokens[:, :start_step] = src_tokens.repeat_interleave(beam_size, 0)
         # compute the model predictions
-        model_out = self.model.decoder(
+        model_out = self.model(
             tokens[:, :start_step],
             incremental_state=incremental_states,
         )


### PR DESCRIPTION
### Summary
Currently, `SequenceGenerator` performs forward pass with `self.model.decoder` instead of `self.model`. This doesn't work properly with FSDP, because when wrapped with an FSDP wrapper, `self.model` is a submodule whose sharded parameters aren't all-gathered appropriately during its forward pass, resulting in errors such as the following (see Susan's comment in #698):
```
File "/shared/home/susanz/miniconda3/envs/fairseq-20220503/lib/python3.9/site-packages/torch/nn/functional.py", line 2183, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: The tensor has a non-zero number of elements, but its data is not allocated yet. Caffe2 uses a lazy allocation, so you will need to call mutable_data() or raw_mutable_data() to actually allocate memory.
```
### Test Plan
* We make sure the updated `SequenceGenerator` works with and without FSDP:
```bash
python metaseq/cli/interactive.py  --merges-filename /checkpoint/binhtang/gpt2-merges.txt --vocab-filename /checkpoint/binhtang/gpt2-vocab.json --path /checkpoint/binhtang/opt-125m/opt-125m-dp4-mp2/checkpoint_last.pt --model-parallel-size 2 --distributed-world-size 8 --beam 3 --max-source-positions 4 --max-target-positions 128 --ddp-backend fully_sharded --use-sharded-sta
te
```
```bash
python metaseq/cli/interactive.py  --merges-filename /checkpoint/binhtang/gpt2-merges.txt --vocab-filename /checkpoint/binhtang/gpt2-vocab.json --path /checkpoint/binhtang/opt-125m/reshard-no-os/reshard.pt --model-parallel-size 2 --distributed-world-size 2 --beam 3 --max-source-positions 4 --max-target-positions 128 --ddp-backend pytorch_ddp
```