### PR TITLE
Andy/drop mseq req from reshard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,6 @@ install_dep_pt19: &install_dep_pt19
       name: Install Pytorch Dependencies
       command: |
         source activate metaseq
-        pip install --upgrade setuptools
         pip install torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
         python -c 'import torch; print("Torch version:", torch.__version__)'
 

--- a/metaseq/scripts/reshard_fsdp.py
+++ b/metaseq/scripts/reshard_fsdp.py
@@ -127,7 +127,7 @@ def reshard_fsdp_state_dicts(
         if ('extra_state' in shard_state_dicts[0] and
             'train_iterator' in shard_state_dicts[0]['extra_state'] and
             "tokenization_cache" in shard_state_dicts[0]['extra_state']['train_iterator']):
-            shard_state_dicts[0]['extra_state']['train_iterator'].pop("tokenization_cache")
+            shard_state_dicts[0]['extra_state']['train_iterator'] = None
 
     for key in shard_state_dicts[0]:
         if key not in {"model", "last_optimizer_state", "shard_metadata"}:

--- a/metaseq/scripts/reshard_fsdp.py
+++ b/metaseq/scripts/reshard_fsdp.py
@@ -124,10 +124,13 @@ def reshard_fsdp_state_dicts(
     if drop_metaseq_req:
         # mseq checkpoints are sometimes saved with their `train_iterator` state_dicts,
         # which can only be unpickled in metaseq-aware envs. We strip these out here.
-        if ('extra_state' in shard_state_dicts[0] and
-            'train_iterator' in shard_state_dicts[0]['extra_state'] and
-            "tokenization_cache" in shard_state_dicts[0]['extra_state']['train_iterator']):
-            shard_state_dicts[0]['extra_state']['train_iterator'] = None
+        if (
+            "extra_state" in shard_state_dicts[0]
+            and "train_iterator" in shard_state_dicts[0]["extra_state"]
+            and "tokenization_cache"
+            in shard_state_dicts[0]["extra_state"]["train_iterator"]
+        ):
+            shard_state_dicts[0]["extra_state"]["train_iterator"] = None
 
     for key in shard_state_dicts[0]:
         if key not in {"model", "last_optimizer_state", "shard_metadata"}:

--- a/setup.py
+++ b/setup.py
@@ -312,6 +312,7 @@ def do_setup():
                 "pyarrow",
                 "boto3",
                 "pandas",
+                "bitsandbytes",
             ],
             # install via: pip install -e ".[multimodal]"
             "multimodal": [


### PR DESCRIPTION
The tokenization_cache in the train_iterator state_dict needs to be unpickled in a metaseq-aware env. 

Adding a flag to remove this so consolidated checkpoints load elsewhere.

Also fixes bug in named argument
