### PR TITLE
Generation should stop after two new lines if that is the stop criteria

### DIFF
--- a/metaseq/tasks/base_task.py
+++ b/metaseq/tasks/base_task.py
@@ -420,9 +420,16 @@ class BaseTask(object):
     ) -> torch.utils.data.Dataset:
         raise NotImplementedError
 
-    def inference_step(self, generator, models, sample, prefix_tokens=None):
+    def inference_step(
+        self, generator, models, sample, prefix_tokens=None, recurring_punctuation=None
+    ):
         with torch.no_grad():
-            return generator.generate(models, sample, prefix_tokens=prefix_tokens)
+            return generator.generate(
+                models,
+                sample,
+                prefix_tokens=prefix_tokens,
+                recurring_punctuation=recurring_punctuation,
+            )
 
     def begin_epoch(self, epoch, model):
         """Hook function called before the start of each epoch."""


### PR DESCRIPTION
This addresses Issue 642. When the stop token is \n\n the generation should stop after generation two new lines.

Check the previous token that is generated and if it is repeated, and if the stop token contains this as the criteria, stop generating further tokens


