### PR TITLE
Add support for top-k

### DIFF
--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -639,7 +639,7 @@ class GenerationConfig(MetaseqDataclass):
     sampling_topk: int = field(
         default=-1,
         metadata={
-            "help": "sample from the top k next words"
+            "help": "sample from among the top k next tokens"
         },
     )
     temperature: float = field(

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -636,6 +636,12 @@ class GenerationConfig(MetaseqDataclass):
             "help": "sample from the smallest set whose cumulative probability mass exceeds p for next words"
         },
     )
+    sampling_topk: int = field(
+        default=-1,
+        metadata={
+            "help": "sample from the top k next words"
+        },
+    )
     temperature: float = field(
         default=1.0,
         metadata={"help": "temperature for generation"},

--- a/metaseq/dataclass/configs.py
+++ b/metaseq/dataclass/configs.py
@@ -639,7 +639,7 @@ class GenerationConfig(MetaseqDataclass):
     sampling_topk: int = field(
         default=-1,
         metadata={
-            "help": "sample from among the top k next tokens"
+            "help": "sample from among the top k tokens"
         },
     )
     temperature: float = field(

--- a/metaseq/hub_utils.py
+++ b/metaseq/hub_utils.py
@@ -200,6 +200,7 @@ class GeneratorInterface:
         max_tokens: List[int] = None,
         temperature: float = 1.0,
         top_p: float = -1.0,
+        top_k: int = -1,
         logprobs: int = 0,
         n: int = 1,
         best_of: Optional[int] = None,
@@ -232,6 +233,7 @@ class GeneratorInterface:
         max_tokens: forces EOS after this many tokens
         temperature: softmax temperature
         top_p: nucleus probability
+        top_k: top-k probability
         log_probs: return this cutoff of the probability distribution
         best_of: beam size
         n: number of beams to return. must be <= best_of
@@ -264,8 +266,10 @@ class GeneratorInterface:
         if not best_of:
             best_of = n
         assert best_of >= n
+        assert not (top_p > 0 and top_k > 0)
         self.cfg.generation.sampling_topp = top_p if top_p > 0 else -1
-        self.cfg.generation.sampling = top_p > 0.0
+        self.cfg.generation.sampling_topk = top_k if top_k > 0 else -1
+        self.cfg.generation.sampling = top_p > 0.0 or top_k > 0
         self.cfg.generation.beam = best_of
         if temperature > 0:
             self.cfg.generation.temperature = temperature
@@ -273,6 +277,7 @@ class GeneratorInterface:
             self.cfg.generation.sampling = False
             self.cfg.generation.temperature = 1.0
             self.cfg.generation.sampling_topp = -1
+            self.cfg.generation.sampling_topk = -1
         elif temperature < 0:
             raise ValueError("temperature must be >= 0 and <= 1")
 

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -665,7 +665,6 @@ class SequenceGenerator(nn.Module):
             truncated_indices: (bsz x input_beam_size x ?)
                 the indices of the chosen elements.
         """
-        # TODO: update docstring given topk implementation, once it's tested on BS > 1
         if self.temperature == 0.0 or (self.sampling_topp == 0.0 and self.sampling_topk == 0):
             # greedy search
             return tuple(lprobs.max(dim=-1))  # (output, index)

--- a/metaseq/sequence_generator.py
+++ b/metaseq/sequence_generator.py
@@ -696,9 +696,6 @@ class SequenceGenerator(nn.Module):
             if self.lambda_decay > 0:
                 self._update_sampling_topp(tok_ids)
         elif self.sampling_topk > 0:
-            if probs.dim() != 2 or probs.size(0) != 1:
-                raise NotImplementedError('The top-k implementation must be checked in the case where batch size is greater than 1!')
-                # TODO: test this out
             topk_value, _ = torch.topk(probs, self.sampling_topk, dim=-1)
             min_value_top_k = topk_value[:, [-1]]
             trunc_probs = probs.detach().clone()

--- a/metaseq/tasks/base_task.py
+++ b/metaseq/tasks/base_task.py
@@ -344,11 +344,9 @@ class BaseTask(object):
         sampling = getattr(args, "sampling", False)
         sampling_topp = getattr(args, "sampling_topp", -1.0)
         assert sampling_topp < 0 or sampling, "--sampling-topp requires --sampling"
-
-        if getattr(args, "sampling_topk", False):
-            logger.warning(
-                "sampling with topk is not supported, ignoring the sampling_topk argument"
-            )
+        sampling_topk = getattr(args, "sampling_topk", -1.0)
+        assert sampling_topk < 0 or sampling, "--sampling-topk requires --sampling"
+        assert not (sampling_topp > 0 and sampling_topk > 0)
 
         extra_gen_cls_kwargs = extra_gen_cls_kwargs or {}
         if seq_gen_cls is None:
@@ -363,6 +361,7 @@ class BaseTask(object):
             min_len=getattr(args, "min_len", 1),
             temperature=getattr(args, "temperature", 1.0),
             topp=sampling_topp,
+            topk=sampling_topk,
             **extra_gen_cls_kwargs,
         )
 


### PR DESCRIPTION
- Add support for top-k to metaseq, to support the decoding settings we use for GPT2 and BLOOM evaluations in the ROBBIE paper

**Note:** trying LLaMa on batch size >1 gives very incoherent generations currently, but LLaMa with BS 1 gives results that are coherent and match the ROBBIE eval numbers of LLaMa run with the llm_evaluations repo