### PR TITLE
fix: add support for wide characters when building index of dataset files

### DIFF
--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -133,14 +133,14 @@ class JsonlDataset(torch.utils.data.Dataset):
         # and then wraps around if the epoch id goes beyond the data_subshard_count
         return (self.epoch - 1) % self.data_subshard_count
 
-    def _build_index(self, path: str):
+    def _build_index(self, file_path: str):
         """Build index of start positions of each line."""
-        logger.info(f"Building index for file: {path}")
-        f: TextIOWrapper = self._get_mmap()
+        logger.info(f"Building index for file: {file_path}")
+        file: TextIOWrapper = self._get_mmap()
 
         offsets = [0]
-        for _ in iter(f.readline, b""):
-            offsets.append(f.tell())
+        for _ in iter(file.readline, b""):
+            offsets.append(file.tell())
 
         # return all offsets except the last one, which is the end of the file
         return offsets[:-1]

--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+from io import TextIOWrapper
 import json
 import logging
 import mmap
@@ -135,19 +136,14 @@ class JsonlDataset(torch.utils.data.Dataset):
     def _build_index(self, path: str):
         """Build index of start positions of each line."""
         logger.info(f"Building index for file: {path}")
-        f = self._get_mmap()
-        f.seek(0)
-        offsets = []
-        cur = 0
-        line_num = 0
-        while True:
-            line = f.readline()
-            if line == b"":
-                break
-            offsets.append(cur)
-            cur += len(line)
-            line_num += 1
-        return offsets
+        f: TextIOWrapper = self._get_mmap()
+
+        offsets = [0]
+        for _ in iter(f.readline, b""):
+            offsets.append(f.tell())
+
+        # return all offsets except the last one, which is the end of the file
+        return offsets[:-1]
 
     def __setstate__(self, state):
         self.__dict__ = state


### PR DESCRIPTION
## Context

When reading a dataset for the first time metaseq will create an "index" file that will store the byte offset in the .jsonl file where item N begins

## Issue

This calculation `cur += len(line)` was previously assuming the "length" of the read line was the offset of "next" item.
In the case that the line contains wide Unicode characters, this calculation is incorrect. `len(line)` will return 1 instead of the total bytes of the character.

### Example

An example where len gives us the wrong number with a normal string that contains wide-unicode char
The correct length is given if we use a byte-string

```bash
>>> "\u2205"
'∅'
>>> len("\u2205")
1
>>> len(b"\u2205")
6
```

## Solution

Instead of keeping a running counter this PR simplifies the implementation by querying the current position of the file reader after every line is read. This approach properly accounts for the bytes and not the characters.

Credit goes to @tupini07 for diagnosing and fixing.

One of the important bug fixes from #726 

## Testing steps

We noticed this bug in our repo when testing datasets containing these wide characters and have been using it in our pipeline for few weeks now.