### PR TITLE
fix: ensure last checkpoint is always saved, refactor training stop conditions to be computed in single location

### DIFF
--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -79,7 +79,9 @@ def save_checkpoint(
     extra_state = {"train_iterator": epoch_itr.state_dict()}
 
     checkpoint_file_paths = [
-        os.path.join(cfg.save_dir, checkpoint_file_name) for checkpoint_file_name, cond in checkpoint_conds.items() if cond
+        os.path.join(cfg.save_dir, checkpoint_file_name)
+        for checkpoint_file_name, cond in checkpoint_conds.items()
+        if cond
     ]
 
     def _save_checkpoint(checkpoint_file_path: str):
@@ -108,7 +110,9 @@ def save_checkpoint(
         _save_checkpoint(checkpoint_file_paths[0])
 
     if training_finished and cfg.save_last_checkpoint:
-        checkpoint_last_file_path = os.path.join(cfg.save_dir, checkpoint_last_file_name)
+        checkpoint_last_file_path = os.path.join(
+            cfg.save_dir, checkpoint_last_file_name
+        )
         _save_checkpoint(checkpoint_last_file_path)
 
 

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -11,7 +11,6 @@ import re
 import socket
 from typing import Any, Dict, List, Optional, Tuple
 import math
-from concurrent.futures import ThreadPoolExecutor
 import torch
 from omegaconf import OmegaConf
 
@@ -73,7 +72,7 @@ def save_checkpoint(
 
     save_for_updates = not end_of_epoch and (save_to_NFS or save_locally)
 
-    checkpoint_conds[f"checkpoint{epoch}_{updates}{suffix}.pt"] = save_for_epoch
+    checkpoint_conds[f"checkpoint{epoch}{suffix}.pt"] = save_for_epoch
     checkpoint_conds[f"checkpoint_{updates}{suffix}.pt"] = save_for_updates
     checkpoint_last_file_name = f"checkpoint_last{suffix}.pt"
 
@@ -101,9 +100,8 @@ def save_checkpoint(
         )
 
         # See if there's any older checkpoints to delete after saving a new one.
-        # Only deletes if keep_last_updates > 0 or keep_last_epochs > 0.
-        async_executer = ThreadPoolExecutor(max_workers=1)
-        async_executer.submit(delete_old_checkpoint_files, cfg, end_of_epoch, suffix)
+        # Only deletes if keep_last_updates > 0 or keep_last_epochs > 0 (default -1 for both).
+        delete_old_checkpoint_files(cfg, end_of_epoch, suffix)
 
     # If there are checkpoints to save, save the first in the list
     if len(checkpoint_file_paths) > 0:
@@ -115,36 +113,28 @@ def save_checkpoint(
 
 
 def delete_old_checkpoint_files(cfg: CheckpointConfig, end_of_epoch: bool, suffix: str):
-    removed_checkpoint = False
     if not end_of_epoch and cfg.keep_last_updates > 0:
         # remove old checkpoints; checkpoints are sorted in descending order
         checkpoints = checkpoint_paths(
-            cfg.save_dir, pattern=r"checkpoint_(\d+){}\.pt".format(suffix)
+            cfg.save_dir, pattern=r"checkpoint_\d+_(\d+){}\.pt".format(suffix)
         )
-        for old_checkpoint in checkpoints[cfg.keep_last_updates:]:
-            if os.path.lexists(old_checkpoint):
-                logger.warning(f"Removing checkpoint {old_checkpoint} because it's older than {cfg.keep_last_updates} updates")
-                os.remove(old_checkpoint)
-                removed_checkpoint = True
+        for old_chk in checkpoints[cfg.keep_last_updates :]:
+            if os.path.lexists(old_chk):
+                os.remove(old_chk)
 
     if cfg.keep_last_epochs > 0:
         # remove old epoch checkpoints; checkpoints are sorted in descending order
         checkpoints = checkpoint_paths(
-            cfg.save_dir, pattern=r"checkpoint\d+_(\d+){}\.pt".format(suffix)
+            cfg.save_dir, pattern=r"checkpoint(\d+){}\.pt".format(suffix)
         )
-        for old_checkpoint in checkpoints[cfg.keep_last_epochs:]:
-            if os.path.lexists(old_checkpoint):
-                logger.warning(f"Removing checkpoint {old_checkpoint} because it's older than {cfg.keep_last_epochs} epochs")
-                os.remove(old_checkpoint)
-                removed_checkpoint = True
-
-    if removed_checkpoint:
-        logger.info("Done removing old checkpoints on worker {}".format(distributed_utils.get_global_rank()))
+        for old_chk in checkpoints[cfg.keep_last_epochs :]:
+            if os.path.lexists(old_chk):
+                os.remove(old_chk)
 
 
 # Reference:
 # https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/checkpoint_utils.py#L538
-def checkpoint_paths(path, pattern=None):
+def checkpoint_paths(path, pattern=r"checkpoint(\d+)\.pt"):
     """Retrieves all checkpoints found in `path` directory.
     Checkpoints are identified by matching filename to the specified pattern. If
     the pattern contains groups, the result will be sorted by the first group in
@@ -220,37 +210,11 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
     else:
         checkpoint_path_to_load = cfg.restore_file
 
-    last_checkpoint = None
-    default_restore_file = "checkpoint_last.pt"
-    if PathManager.exists(cfg.save_dir):
-        if PathManager.exists(os.path.join(cfg.save_dir, default_restore_file.replace(".pt", suffix + ".pt"))):
-            last_checkpoint = os.path.join(cfg.save_dir, default_restore_file.replace(".pt", suffix + ".pt"))
-        elif PathManager.exists(os.path.join(cfg.save_dir, default_restore_file)):
-            last_checkpoint = os.path.join(cfg.save_dir, default_restore_file)
-        else:
-            checkpoints = checkpoint_paths(cfg.save_dir, pattern=r"checkpoint\d*_(\d+){}\.pt".format(suffix))
-            if len(checkpoints) > 0 and PathManager.exists(checkpoints[0]):
-                last_checkpoint = checkpoints[0]
-
-            if last_checkpoint is None:
-                checkpoints = checkpoint_paths(cfg.save_dir, pattern=r"checkpoint\d*_(\d+)\.pt")
-                if len(checkpoints) > 0 and PathManager.exists(checkpoints[0]):
-                    last_checkpoint = checkpoints[0]
-
-    if last_checkpoint is not None and last_checkpoint != checkpoint_path_to_load:
-        if PathManager.exists(last_checkpoint):
-            logger.warning(f"Overriding restore-file-path to load with {last_checkpoint}")
-            checkpoint_path_to_load = last_checkpoint
-            logger.info(
-                f"Disregarding --reset-dataloader, --reset-lr-scheduler, --reset-optimizer, --reset-meters\
-                         flags since we are resuming from a intermediate output checkpoint"
-            )
-            reset_optimizer = False
-            reset_lr_scheduler = False
-            reset_meters = False
-            reset_dataloader = False
-        else:
-            raise ValueError(f"Checkpoint {last_checkpoint} does not exist. Incorrect value found in save_checkpoint_log.txt")
+    if cfg.restore_file != default_restore_file and cfg.finetune_from_model:
+        raise ValueError(
+            "--finetune-from-model and --restore-file (non-default value) "
+            "can not be specified together: " + str(cfg)
+        )
 
     # Azure logic
     try:

--- a/metaseq/checkpoint_utils.py
+++ b/metaseq/checkpoint_utils.py
@@ -105,6 +105,7 @@ def save_checkpoint(
         async_executer = ThreadPoolExecutor(max_workers=1)
         async_executer.submit(delete_old_checkpoint_files, cfg, end_of_epoch, suffix)
 
+    # If there are checkpoints to save, save the first in the list
     if len(checkpoint_file_paths) > 0:
         _save_checkpoint(checkpoint_file_paths[0])
 
@@ -143,7 +144,7 @@ def delete_old_checkpoint_files(cfg: CheckpointConfig, end_of_epoch: bool, suffi
 
 # Reference:
 # https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq/checkpoint_utils.py#L538
-def checkpoint_paths(path, pattern=r"checkpoint(\d+)\.pt"):
+def checkpoint_paths(path, pattern=None):
     """Retrieves all checkpoints found in `path` directory.
     Checkpoints are identified by matching filename to the specified pattern. If
     the pattern contains groups, the result will be sorted by the first group in

--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -452,12 +452,16 @@ def validate_and_save(
 
     if num_epoch > max_epoch:
         should_stop = True
-        logger.info(f"Stopping training due to "
-                    f"num_epoch: {num_epoch} > max_epoch: {max_epoch}")
+        logger.info(
+            f"Stopping training due to "
+            f"num_epoch: {num_epoch} > max_epoch: {max_epoch}"
+        )
     elif num_updates > max_update:
         should_stop = True
-        logger.info(f"Stopping training due to "
-                    f"num_updates: {num_updates} > max_update: {max_update}")
+        logger.info(
+            f"Stopping training due to "
+            f"num_updates: {num_updates} > max_update: {max_update}"
+        )
 
     is_epoch_save_interval = (
         end_of_epoch
@@ -467,22 +471,28 @@ def validate_and_save(
     is_successful_update_local_save_interval = (
         cfg.checkpoint.local_save_interval_updates > 0
         and num_updates > 0
-        and num_updates % cfg.checkpoint.local_save_interval_updates == 0 and was_successful_step
+        and num_updates % cfg.checkpoint.local_save_interval_updates == 0
+        and was_successful_step
     )
     is_successful_update_save_interval = (
         cfg.checkpoint.save_interval_updates > 0
         and num_updates > 0
-        and num_updates % cfg.checkpoint.save_interval_updates == 0 and was_successful_step
+        and num_updates % cfg.checkpoint.save_interval_updates == 0
+        and was_successful_step
     )
     is_successful_update_validate_interval = (
         cfg.checkpoint.validate_interval_updates > 0
         and num_updates > 0
-        and num_updates % cfg.checkpoint.validate_interval_updates == 0 and was_successful_step
+        and num_updates % cfg.checkpoint.validate_interval_updates == 0
+        and was_successful_step
     )
 
     do_save = (
         is_epoch_save_interval
-        or (is_successful_update_local_save_interval or is_successful_update_save_interval)
+        or (
+            is_successful_update_local_save_interval
+            or is_successful_update_save_interval
+        )
         or should_stop
     )
     do_validate = (
@@ -502,7 +512,7 @@ def validate_and_save(
             training_finished=should_stop,
             async_callback_fn=functools.partial(
                 post_checkpoint_callback, cfg, num_updates, should_stop
-            )
+            ),
         )
 
     valid_losses = [None]


### PR DESCRIPTION
# Issues

## 1 Inconsistent checkpoint filenames saved by trainer

In our pipeline we often have sequence of steps such as (train, reshard/unflatten, evaluate). The output files of the training become inputs to the resharding scripts. In order for the execution to work reliably the output files need to have consistent filenames, such as `checkpoint_last-model_part-0-shard0.pt`

When running metaseq.cli.train with tasks such as streaming_finetune_language_modeling there are two different stopping conditions set by --max-epochs and --max-updates. Whichever limit is hit first will cause the model stop training.

The issue is that checkpoint_last-* file is ONLY written the epoch stop condition or update stop conditions were false.
This couples the checkpoint filename with the stopping conditions

Notice `checkpoints[0]` only uses the FIRST true filename/condition

https://github.com/facebookresearch/metaseq/blob/c16d21047d975b7a925648f38cba3190a8ef27d6/metaseq/checkpoint_utils.py#L89-L99

## Goal

We want to be able to run the jobs/pipeline and change the stopping conditions without implicitly changing the output file that will be given to the subsequent commands / scripts

## 2 Training Stop was Handled in Multiple Locations

Loop condition:
https://github.com/facebookresearch/metaseq/blob/c16d21047d975b7a925648f38cba3190a8ef27d6/metaseq/cli/train.py#L209
Loop break:
https://github.com/facebookresearch/metaseq/blob/c16d21047d975b7a925648f38cba3190a8ef27d6/metaseq/cli/train.py#L212-L213

This makes it harder to reason about which condition will cause training to stop. 

# Solution

- Consolidate all training stop conditions in to `validate_and_save` and `should_stop`
    - Use `>` instead of `>=` conditions
- Change to always save `checkpoint_last*` file
    - This means there are cases it will save multiple checkpoints
        - Epoch AND last checkpoint
        - Updates AND last checkpoint
        
# Testing

I wasn't able to test since this is merging with metaseq main instead of our fork's main.
I wanted to at least share the ideas. Although changing training stop conditions can be serious, so maybe someone else can submit a small jobs to test. One with max-epochs, other with max-updates, and in both cases it saves checkpoint_last files

Related to #726 

<!--

Considerations before submitting:

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
-->
