### PR TITLE
[fix] Set upper limit for aim version

### DIFF
--- a/metaseq/logging/progress_bar/aim_progress_bar.py
+++ b/metaseq/logging/progress_bar/aim_progress_bar.py
@@ -33,7 +33,7 @@ class AimProgressBarWrapper(BaseProgressBar):
 
         if get_aim_run is None:
             self.run = None
-            logger.warning("Aim not found, please install with: pip install aim")
+            logger.warning("Aim not found, please install with: pip install \"aim<4.0.0\"")
         else:
             logger.info(f"Storing logs at Aim repo: {aim_repo}")
             assert AimRepo is not None

--- a/metaseq/logging/progress_bar/aim_progress_bar.py
+++ b/metaseq/logging/progress_bar/aim_progress_bar.py
@@ -12,7 +12,7 @@ from metaseq.logging.progress_bar.base_progress_bar import (
 try:
     import functools
 
-    from aim import Repo as AimRepo
+    from aim.sdk import Repo as AimRepo
 
     @functools.lru_cache()
     def get_aim_run(repo, run_hash):

--- a/setup.py
+++ b/setup.py
@@ -301,7 +301,7 @@ def do_setup():
             "dev": [
                 "flake8",
                 "black==22.3.0",
-                "aim>=3.9.4",
+                "aim>=3.9.4,<4.0.0",
                 "azure-storage-blob",
                 "mypy",
             ],


### PR DESCRIPTION
With the upcoming major release of Aim (https://github.com/aimhubio/aim) Aim SDK will not be backwards compatible.
To prevent any failures on metaseq side, setting upper limit for the install Aim version