### PR TITLE
fix and add marmot support for cm3v2

### DIFF
--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -317,7 +317,10 @@ class StreamingLanguageModelingTask(LegacyTask):
                 raise ValueError(f"dataset not valid: {json['dataset_name']}")
 
     def _tokenize_text_json(self, json):
-        text = json["text"]
+        if type(json) is dict:
+            text = json["text"]
+        else:
+            text = str(json)
         return torch.LongTensor(
             # append an end-of-document symbol after each document
             self.tokenizer.encode(text.rstrip()).ids


### PR DESCRIPTION
**Patch Description**
Add support for training with marmot data

**Testing steps**
Conduct ablation study for marmot on RSC. log: /checkpoint/vllm/cm3leon/experiments/ablations/DATA_ABLATION_marmot2_760m/DATA_ABLATION_marmot2_760m.bm_none.fp16.bf16.trunc.fmis0.0.sig0.006.pos0.0002.nobias.noaffln.relu.transformer_lm_megatron.nlay24.emb1536.lrnpos.0emb_scale.tps8192.adam.b2_0.95.cl1.0.lr0.00025.wu1500.dr0.1.atdr0.0.0emb_dr.wd0.1.ms8.mu119209.s1.ngpu256.

<!--

Considerations before submitting:

- [x] Was this discussed/approved via a Github issue?
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?
-->
