### PR TITLE
Implement JSONLDataset level partitioning

### DIFF
--- a/metaseq/cli/train.py
+++ b/metaseq/cli/train.py
@@ -8,32 +8,26 @@ Train a new model on one or across multiple GPUs.
 """
 
 import argparse
-from datetime import datetime
 import functools
 import logging
 import math
 import os
+import re
+import socket
 import subprocess
 import sys
 import time
-import socket
-import re
-from typing import Dict, Optional, Any, List, Tuple, Callable
-from urllib.parse import urlparse
 import warnings
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import numpy as np
 import torch
 import torch.profiler as profiler
-from omegaconf import DictConfig, OmegaConf
 
-from metaseq import (
-    checkpoint_utils,
-    options,
-    tasks,
-    utils,
-)
-from metaseq.data import iterators, data_utils
+from metaseq import checkpoint_utils, options, tasks, utils
+from metaseq.data import data_utils, iterators
 from metaseq.data.plasma_utils import PlasmaStore
 from metaseq.dataclass.utils import convert_namespace_to_omegaconf
 from metaseq.distributed import (
@@ -45,6 +39,7 @@ from metaseq.distributed import (
 from metaseq.file_io import PathManager
 from metaseq.logging import meters, metrics, progress_bar
 from metaseq.trainer import Trainer
+from omegaconf import DictConfig, OmegaConf
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
@@ -322,6 +317,14 @@ def train(
                 metrics.reset_meters("train_inner")
 
         end_of_epoch = not itr.has_next()
+        end_of_epochs_all = distributed_utils.all_gather_list(
+            [end_of_epoch],
+            max_size=cfg.common.all_gather_list_size,
+            group=distributed_utils.get_global_group(),
+        )
+        end_of_epochs_all = [x[0] for x in end_of_epochs_all]
+        end_of_epoch = any(end_of_epochs_all)
+
         if end_of_epoch:
             grank = distributed_utils.get_global_rank()
 

--- a/metaseq/data/iterators.py
+++ b/metaseq/data/iterators.py
@@ -10,15 +10,16 @@ import operator
 import os
 import queue
 import time
+from ctypes import addressof, c_int, memmove, sizeof
 from threading import Thread
 from typing import Callable, Optional
+
 import numpy as np
 import torch
-from metaseq.distributed import utils as distributed_utils
 
 from metaseq.data import data_utils
 from metaseq.data.document_to_sequence import DocumentToSequenceDataset
-from ctypes import c_int, sizeof, memmove, addressof
+from metaseq.distributed import utils as distributed_utils
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +242,9 @@ class StreamingEpochBatchIterator(EpochBatchIterating):
         self.num_workers = num_workers
         self.epoch = max(epoch, 1)  # we use 1-based indexing for epochs
         self.num_shards = num_shards
-        assert isinstance(dataset, torch.utils.data.IterableDataset)
+        assert isinstance(
+            dataset, torch.utils.data.IterableDataset
+        ), f"Expected type `torch.utils.data.IterableDataset` instead got {dataset}"
 
         self._itr: Optional[StreamingCountingIterator] = None
         self.worker_offset = 0

--- a/metaseq/data/jsonl_dataset.py
+++ b/metaseq/data/jsonl_dataset.py
@@ -13,10 +13,10 @@ import threading
 from pathlib import Path
 from typing import Callable, Optional
 
+import metaseq.distributed.utils as distributed_utils
+
 import numpy as np
 import torch
-
-import metaseq.distributed.utils as distributed_utils
 
 logger = logging.getLogger(__name__)
 

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -21,14 +21,13 @@ from typing import Any, Dict, List
 
 import torch
 import torch.distributed as dist
-from omegaconf import OmegaConf
 
 from metaseq import checkpoint_utils, models, optim, utils
 from metaseq.distributed import (
-    utils as distributed_utils,
     fsdp_enable_wrap,
     fsdp_wrap,
     FullyShardedDataParallel,
+    utils as distributed_utils,
 )
 from metaseq.file_io import PathManager
 from metaseq.logging import meters, metrics
@@ -37,6 +36,7 @@ from metaseq.modules.megatron.mpu import get_cuda_rng_tracker
 from metaseq.nan_detector import NanDetector
 from metaseq.optim import lr_scheduler
 from metaseq.utils import set_rank_seed
+from omegaconf import OmegaConf
 
 logger = logging.getLogger(__name__)
 
@@ -651,6 +651,8 @@ class Trainer(object):
             self.cfg.dataset.train_subset,
             epoch=epoch,
             combine=combine,
+            num_shards=self.data_parallel_world_size if shard_batch_itr else 1,
+            shard_id=self.data_parallel_rank if shard_batch_itr else 1, # different than what's below because sub-sharding in JSONLDataset is indexed from 0
             data_selector=data_selector,
         )
         batch_iterator = self.task.get_batch_iterator(

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -652,7 +652,7 @@ class Trainer(object):
             epoch=epoch,
             combine=combine,
             num_shards=self.data_parallel_world_size if shard_batch_itr else 1,
-            shard_id=self.data_parallel_rank if shard_batch_itr else 1, # different than what's below because sub-sharding in JSONLDataset is indexed from 0
+            shard_id=self.data_parallel_rank + 1 if shard_batch_itr else 1, # different than what's below because sub-sharding in JSONLDataset is indexed from 0
             data_selector=data_selector,
         )
         batch_iterator = self.task.get_batch_iterator(


### PR DESCRIPTION
# High Level Change
We augment where partitioning of the data happens to be earlier in the process saving a lot of compute when it comes to running tokenization. This should allow us to scale WPS past the ceiling (~3.5M) we were seeing earlier.

# How Did We Implement?
We utilize the virtual sub-sharding implemented for JSONLDataset instead as a partitioning function (this means we cannot do sub-sharding, but no one is really using this anyway, assertions have been added). We had to adapt some of the load_dataset function signatures but overall this is a very easy change.


# What We Do Now
The current way we generate documents is the following. Each GPU does the following:
- Enumerate all documents
- Tokenize all documents
- Block by sequence length
- Each GPU selects the block that corresponds to it’s ID.

![Untitled Diagram-Page-1 drawio](https://github.com/facebookresearch/metaseq/assets/4429794/8b1ab994-7a48-4d08-a9d3-2c9096fbcf78)

Pros:
- Blocks are completely randomized on all GPU’s
- Fully reproducible. Can restart a run and follow the same exact selection process.

Cons: 
- Every GPU has to tokenize EVERY sample, which might be the cause the lack of GPU saturation.

In the current change, each GPU does the following:
1. Enumerate all documents
2. Select documents that correspond to it’s ID
3. Tokenize current GPU documents
4. Block by sequence length
5. Each GPU simply enumerates blocks

![Untitled Diagram-Page-2 drawio (1)](https://github.com/facebookresearch/metaseq/assets/4429794/67f60363-2ccc-4b09-b42d-d1a7f808816a)

Pros:
- Fully reproducible. Can restart a run and follow the same exact selection process. But ONLY when world size stays the same throughout training.
- Tokenization only occurs on the documents you actually use on the current GPU

Cons:
- Are there any? 

# Questions
Q. What happens if one GPU runs out of documents before others?
A. Same thing that happens in the previous code when one GPU is out of blocks, we stop training on current shard. The amount of data we'll be leaving behind is miniscule.

Q. Well if we're leaving data behind is this not problematic for consistent validation?
A. Yes for validation we don't _really_ care about WPS so we're okay using the old implementation that will use all of the data (except maybe for the last batch).